### PR TITLE
ci: eliminate depot.dev builds, reduce redundant Maven compilation

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -26,8 +26,6 @@ jobs:
           java-version: '21'
       - name: Compile and install modules
         run: mvn install -DskipTests -B
-      - name: Resolve all dependencies for offline use
-        run: mvn dependency:go-offline -B
       - name: Upload local Maven artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -26,6 +26,8 @@ jobs:
           java-version: '21'
       - name: Compile and install modules
         run: mvn install -DskipTests -B
+      - name: Resolve all dependencies for offline use
+        run: mvn dependency:go-offline -B
       - name: Upload local Maven artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -32,3 +32,9 @@ jobs:
           name: maven-local-modules
           path: ~/.m2/repository/app/mcorg
           retention-days: 1
+      - name: Upload application JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-jar
+          path: webapp/mc-web/target/*-with-dependencies.jar
+          retention-days: 1

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,34 @@
+name: Compile
+
+on:
+  workflow_call:
+
+jobs:
+  compile:
+    name: Compile
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./webapp
+    steps:
+      - uses: actions/checkout@v6
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-${{ runner.os }}-
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'adopt'
+          java-version: '21'
+      - name: Compile and install modules
+        run: mvn install -DskipTests -B
+      - name: Upload local Maven artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-local-modules
+          path: ~/.m2/repository/app/mcorg
+          retention-days: 1

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -20,8 +20,13 @@ on:
       - webapp/*/pom.xml
       - webapp/Dockerfile
 jobs:
+  compile:
+    if: github.actor != 'dependabot[bot]'
+    uses: ./.github/workflows/compile.yml
+
   deploy-dev:
     if: github.actor != 'dependabot[bot]'
+    needs: compile
     environment: dev
     runs-on: ubuntu-latest
     permissions:
@@ -42,6 +47,11 @@ jobs:
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
+      - name: Restore local Maven artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-local-modules
+          path: ~/.m2/repository/app/mcorg
 
       - name: Create Neon branch
         uses: neondatabase/create-branch-action@v6.4.0
@@ -57,10 +67,8 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '21'
-      - name: Install modules
-        run: mvn install -DskipTests -B
       - name: Run flyway migrations
-        run: mvn flyway:migrate
+        run: mvn flyway:migrate -o
         working-directory: ./webapp/mc-web
         env:
           DB_URL: "jdbc:postgresql://${{ steps.create-neon-branch.outputs.db_host }}/mcorg?sslmode=require"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -3,8 +3,8 @@
 name: Deploy to dev and test E2E
 env:
   NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
-  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }} # You can generate a Fly API token in your account settings
-  GH_TOKEN: ${{ secrets.GH_TOKEN }} # Required for commenting on pull requests for private repos
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+  GH_TOKEN: ${{ secrets.GH_TOKEN }}
   DB_USERNAME: mcorg_owner
 on:
   pull_request:
@@ -27,6 +27,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      packages: write
     concurrency:
       group: pr-${{ github.event.number }}
     defaults:
@@ -65,19 +66,54 @@ jobs:
           DB_URL: "jdbc:postgresql://${{ steps.create-neon-branch.outputs.db_host }}/mcorg?sslmode=require"
           DB_USER: ${{ env.DB_USERNAME }}
           DB_PASSWORD: ${{ steps.create-neon-branch.outputs.password }}
-      - name: Deploy dev app to Fly
-        uses: superfly/fly-pr-review-apps@1.6.0
-        id: deploy
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
         with:
-          name: mcorg-dev-${{ github.event.number }}
-          path: ./webapp
-          config: ./dev.fly.toml
-          org: mc-org
-          secrets: APP_HOST=mcorg-dev-${{ github.event.number }}.fly.dev DB_PASSWORD=${{ steps.create-neon-branch.outputs.password }} DB_URL=jdbc:postgresql://${{ steps.create-neon-branch.outputs.db_host_pooled }}/mcorg?sslmode=require DB_USER=${{ env.DB_USERNAME }} RSA_PUBLIC_KEY=${{ secrets.RSA_PUBLIC_KEY }} RSA_PRIVATE_KEY=${{ secrets.RSA_PRIVATE_KEY }}
-          build_args: |
-            BUILDKIT_INLINE_CACHE=1
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./webapp
+          file: ./webapp/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}:pr-${{ github.event.number }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
+
+      - name: Setup flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Create Fly preview app
+        run: flyctl apps create mcorg-dev-${{ github.event.number }} --org mc-org || true
         env:
-          DOCKER_BUILDKIT: 1
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Set Fly app secrets
+        run: |
+          flyctl secrets set \
+            APP_HOST=mcorg-dev-${{ github.event.number }}.fly.dev \
+            DB_PASSWORD=${{ steps.create-neon-branch.outputs.password }} \
+            "DB_URL=jdbc:postgresql://${{ steps.create-neon-branch.outputs.db_host_pooled }}/mcorg?sslmode=require" \
+            DB_USER=${{ env.DB_USERNAME }} \
+            RSA_PUBLIC_KEY="${{ secrets.RSA_PUBLIC_KEY }}" \
+            RSA_PRIVATE_KEY="${{ secrets.RSA_PRIVATE_KEY }}" \
+            --app mcorg-dev-${{ github.event.number }} --stage
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Deploy to Fly
+        run: |
+          flyctl deploy \
+            --image ghcr.io/${{ github.repository }}:pr-${{ github.event.number }} \
+            --app mcorg-dev-${{ github.event.number }} \
+            --config ./dev.fly.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
       - uses: actions/github-script@v8
         with:
           github-token: ${{secrets.GH_TOKEN_PR_COMMENTS}}
@@ -86,10 +122,10 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Fly Preview URL :balloon: : ${{ steps.deploy.outputs.url }}\n Neon branch :elephant: : https://console.neon.tech/app/projects/${{ env.NEON_PROJECT_ID }}/branches/${{ steps.create-branch.outputs.branch_id }}'
+              body: 'Fly Preview URL :balloon: : https://mcorg-dev-${{ github.event.number }}.fly.dev\n Neon branch :elephant: : https://console.neon.tech/app/projects/${{ env.NEON_PROJECT_ID }}/branches/${{ steps.create-neon-branch.outputs.branch_id }}'
             })
     outputs:
-      dev_url: ${{ steps.deploy.outputs.url }}
+      dev_url: https://mcorg-dev-${{ github.event.number }}.fly.dev
 #  playwright-tests:
 #    name: "E2E Playwright Tests"
 #    timeout-minutes: 60

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -75,6 +75,12 @@ jobs:
           DB_USER: ${{ env.DB_USERNAME }}
           DB_PASSWORD: ${{ steps.create-neon-branch.outputs.password }}
 
+      - name: Download application JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: app-jar
+          path: ./jar
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -88,8 +94,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: ./webapp
-          file: ./webapp/Dockerfile
+          context: ./jar
+          file: ./webapp/Dockerfile.ci
           push: true
           tags: ghcr.io/${{ github.repository }}:pr-${{ github.event.number }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -75,6 +75,9 @@ jobs:
           DB_USER: ${{ env.DB_USERNAME }}
           DB_PASSWORD: ${{ steps.create-neon-branch.outputs.password }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -68,7 +68,7 @@ jobs:
           distribution: 'adopt'
           java-version: '21'
       - name: Run flyway migrations
-        run: mvn flyway:migrate -o
+        run: mvn flyway:migrate
         working-directory: ./webapp/mc-web
         env:
           DB_URL: "jdbc:postgresql://${{ steps.create-neon-branch.outputs.db_host }}/mcorg?sslmode=require"

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -60,6 +60,12 @@ jobs:
           DB_USER: ${{ vars.DB_USER }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
 
+      - name: Download application JAR
+        uses: actions/download-artifact@v4
+        with:
+          name: app-jar
+          path: ./jar
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -73,8 +79,8 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: ./webapp
-          file: ./webapp/Dockerfile
+          context: ./jar
+          file: ./webapp/Dockerfile.ci
           push: true
           tags: |
             ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -60,6 +60,9 @@ jobs:
           DB_USER: ${{ vars.DB_USER }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -53,7 +53,7 @@ jobs:
           java-version: '21'
 
       - name: Run Flyway migrations
-        run: mvn flyway:migrate -o
+        run: mvn flyway:migrate
         working-directory: ./webapp/mc-web
         env:
           DB_URL: ${{ vars.DB_URL }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -25,6 +25,9 @@ jobs:
       run:
         working-directory: ./webapp
     environment: production
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
       - name: Cache Maven packages
@@ -49,8 +52,27 @@ jobs:
           DB_URL: ${{ vars.DB_URL }}
           DB_USER: ${{ vars.DB_USER }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./webapp
+          file: ./webapp/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
+
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only --build-arg BUILDKIT_INLINE_CACHE=1
+      - run: flyctl deploy --image ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-          DOCKER_BUILDKIT: 1

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -17,8 +17,12 @@ permissions:
   contents: read
 
 jobs:
+  compile:
+    uses: ./.github/workflows/compile.yml
+
   deploy:
     name: Deploy app
+    needs: compile
     runs-on: ubuntu-latest
     concurrency: deploy-group
     defaults:
@@ -37,16 +41,19 @@ jobs:
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
+      - name: Restore local Maven artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-local-modules
+          path: ~/.m2/repository/app/mcorg
       - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'adopt'
           java-version: '21'
 
-      - name: Install modules
-        run: mvn install -DskipTests -B
       - name: Run Flyway migrations
-        run: mvn flyway:migrate
+        run: mvn flyway:migrate -o
         working-directory: ./webapp/mc-web
         env:
           DB_URL: ${{ vars.DB_URL }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         working-directory: ./webapp/mc-web
         run: bash create-keys.sh
       - name: Run unit tests
-        run: mvn test -B -o -Dmaven.main.skip=true
+        run: mvn test -B -Dmaven.main.skip=true
 
   integration-tests:
     name: Integration Tests
@@ -84,4 +84,4 @@ jobs:
         working-directory: ./webapp/mc-web
         run: bash create-keys.sh
       - name: Run database tests
-        run: mvn test -pl mc-web -Dsurefire.excludedGroups= -Dgroups=database -B -o -Dmaven.main.skip=true
+        run: mvn test -pl mc-web -Dsurefire.excludedGroups= -Dgroups=database -B -Dmaven.main.skip=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  unit-tests:
-    name: Unit Tests
+  compile:
+    name: Compile
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -32,6 +32,41 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '21'
+      - name: Compile and install modules
+        run: mvn install -DskipTests -B
+      - name: Upload local Maven artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-local-modules
+          path: ~/.m2/repository/app/mcorg
+          retention-days: 1
+
+  unit-tests:
+    name: Unit Tests
+    needs: compile
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./webapp
+    steps:
+      - uses: actions/checkout@v6
+      - name: Cache Maven packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-${{ runner.os }}-
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'adopt'
+          java-version: '21'
+      - name: Restore local Maven artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-local-modules
+          path: ~/.m2/repository/app/mcorg
       - name: Cache Minecraft server data
         uses: actions/cache@v5
         with:
@@ -43,10 +78,11 @@ jobs:
         working-directory: ./webapp/mc-web
         run: bash create-keys.sh
       - name: Run unit tests
-        run: mvn test -B
+        run: mvn test -B -o -Dmaven.main.skip=true
 
   integration-tests:
     name: Integration Tests
+    needs: compile
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -65,10 +101,13 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: '21'
+      - name: Restore local Maven artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-local-modules
+          path: ~/.m2/repository/app/mcorg
       - name: Generate JWT signing keys
         working-directory: ./webapp/mc-web
         run: bash create-keys.sh
-      - name: Build modules
-        run: mvn install -DskipTests -B
       - name: Run database tests
-        run: mvn test -pl mc-web -Dsurefire.excludedGroups= -Dgroups=database -B
+        run: mvn test -pl mc-web -Dsurefire.excludedGroups= -Dgroups=database -B -o -Dmaven.main.skip=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,33 +13,7 @@ permissions:
 
 jobs:
   compile:
-    name: Compile
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./webapp
-    steps:
-      - uses: actions/checkout@v6
-      - name: Cache Maven packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.m2/repository
-          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            maven-${{ runner.os }}-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'adopt'
-          java-version: '21'
-      - name: Compile and install modules
-        run: mvn install -DskipTests -B
-      - name: Upload local Maven artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: maven-local-modules
-          path: ~/.m2/repository/app/mcorg
-          retention-days: 1
+    uses: ./.github/workflows/compile.yml
 
   unit-tests:
     name: Unit Tests

--- a/webapp/Dockerfile.ci
+++ b/webapp/Dockerfile.ci
@@ -1,0 +1,12 @@
+FROM eclipse-temurin:21-jre-alpine
+
+EXPOSE "8080:8080"
+
+RUN mkdir /app
+
+COPY *-with-dependencies.jar /app/mcorg.jar
+
+ENTRYPOINT ["java", "-Xms256m", "-Xmx768m", "-jar", "/app/mcorg.jar"]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/test/ping || exit 1

--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/minecraft/MinecraftVersion.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/minecraft/MinecraftVersion.kt
@@ -126,7 +126,8 @@ sealed interface MinecraftVersion {
             return Release(minor = minor, patch = patch)
         }
 
-        val supportedVersions = listOf(
+        // Fallback used when the Modrinth API is unavailable
+        val supportedVersions_backup = listOf(
             release(20, 0),
             release(21, 0)
         )

--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/minecraft/MinecraftVersion.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/minecraft/MinecraftVersion.kt
@@ -126,7 +126,7 @@ sealed interface MinecraftVersion {
             return Release(minor = minor, patch = patch)
         }
 
-        val supportedVersions_backup = listOf<Release>(
+        val supportedVersions = listOf(
             release(20, 0),
             release(21, 0)
         )


### PR DESCRIPTION
## Summary
- **Remove depot.dev costs (~$20/month)**: Both `dev.yml` and `prod.yml` now build Docker images in GitHub Actions using `docker/build-push-action`, push to GHCR (free), and deploy with `flyctl deploy --image` instead of remote/depot builds.
- **GHCR layer caching**: `buildcache` tag used as registry cache — prod builds warm from PR preview builds, making subsequent builds significantly faster.
- **dev.yml**: Replaces `superfly/fly-pr-review-apps` with explicit flyctl steps (`apps create || true` → `secrets set --stage` → `deploy --image`) to support pre-built image deployment.
- **test.yml**: New `compile` job installs all modules once, uploads `~/.m2/repository/app/mcorg` as a 1-day artifact. Both test jobs restore it and skip main source recompilation (`-o -Dmaven.main.skip=true`), removing one full Maven compile from the critical path.

## Test plan
- [ ] Open a PR to master → verify `dev.yml` runs: creates Neon branch, runs Flyway, builds and pushes Docker image to GHCR, deploys preview app via `flyctl deploy --image`, posts PR comment with URL
- [ ] Verify `test.yml` runs: `compile` job completes first, then `unit-tests` and `integration-tests` run in parallel using the uploaded artifact
- [ ] Merge to master → verify `prod.yml` runs: builds and pushes to GHCR, runs Flyway, deploys with `flyctl deploy --image`
- [ ] Confirm no depot.dev charges appear in billing after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)