### PR TITLE
fix: correct logback logger for moved ExtractRelevantMinecraftFilesStep

### DIFF
--- a/webapp/mc-web/src/main/resources/logback.xml
+++ b/webapp/mc-web/src/main/resources/logback.xml
@@ -17,5 +17,5 @@
     <logger name="com.github.dockerjava" level="WARN" />
     <logger name="org.testcontainers" level="WARN" />
     <logger name="io.mockk" level="ERROR" />
-    <logger name="app.mcorg.pipeline.minecraftfiles.ExtractRelevantMinecraftFilesStep" level="INFO" />
+    <logger name="app.mcorg.data.minecraft.extract.ExtractRelevantMinecraftFilesStep" level="INFO" />
 </configuration>


### PR DESCRIPTION
## Summary
- The `ExtractRelevantMinecraftFilesStep` class now lives at `app.mcorg.data.minecraft.extract`, but `logback.xml` still referenced the old `app.mcorg.pipeline.minecraftfiles` path, so its `INFO` level was silently never applied.
- Updates the logger name to match the current package.

## Test plan
- [ ] App starts and `ExtractRelevantMinecraftFilesStep` logs at INFO

🤖 Generated with [Claude Code](https://claude.com/claude-code)