### PR TITLE
chore(db): HikariCP minimumIdle 0 in prod to stop Neon keepalive (MCO-164)

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/config/Database.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/config/Database.kt
@@ -18,7 +18,7 @@ class HikariDatabaseProvider(private val isProduction: Boolean) : DatabaseConnec
     private val poolConfig = if (isProduction) {
         PoolConfig(
             maximumPoolSize = 10,
-            minimumIdle = 2,
+            minimumIdle = 0,
             connectionTimeout = 30000,
             idleTimeout = 600000,
             maxLifetime = 1800000


### PR DESCRIPTION
## Summary

- Production `HikariDatabaseProvider` now uses `minimumIdle = 0` (was `2`).
- Stops the 30-minute Neon compute wake/suspend churn we were paying for at zero traffic.

## Why

`neonctl operations list` shows the compute waking and suspending every 30 min — perfectly regular, 14 cycles over the last 6 hours, ~6 min of active compute per cycle. The cause is Hikari's default `maxLifetime = 30 min`: each idle connection gets recycled at the half-hour mark, the replacement TCP connection wakes Neon, the `SELECT 1` validation query runs, the connection idles, Neon's auto-suspend fires ~5 min later. Repeat.

At today's traffic level (effectively zero authenticated requests in 6 hours of fly logs), this heartbeat is the dominant DB cost. Estimated ~144 compute hours/month spent on it — most of Neon's free tier.

Setting `minimumIdle = 0` makes the pool lazy: no pre-warmed connections, Neon stays suspended until a real user request needs the DB.

## Trade-off

The first DB-using request after a long idle period now waits ~1–3s for Neon to wake. Fine while we have no users; not fine at scale. [MCO-164](https://linear.app/evegul/issue/MCO-164/restore-hikaricp-minimumidle-to-1-2-once-we-have-real-users) tracks the revert to `1` or `2` once we have real users or care about cold-start p95.

## Test plan

- [ ] Deploy and confirm `neonctl operations list --project-id morning-fog-11467472` no longer shows regular 30-min start/suspend cycles.
- [ ] Hit `/` once, confirm sign-in page still loads (cold path wakes compute on demand).
- [ ] CI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)