### PR TITLE
feat(db): add minecraft_version_ingestion ledger table (MCO-166)

### DIFF
--- a/webapp/mc-web/src/main/resources/db/migration/V2_34_0__add_minecraft_version_ingestion_ledger.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_34_0__add_minecraft_version_ingestion_ledger.sql
@@ -1,0 +1,25 @@
+-- Single source of truth for "has this Minecraft version been ingested, and from which server.jar".
+-- Replaces the 4-table EXISTS proxy in AllFileMigrationsCompletedStep (GetServerFilesPipeline.kt).
+CREATE TABLE minecraft_version_ingestion (
+    version        VARCHAR(50) PRIMARY KEY REFERENCES minecraft_version(version),
+    server_jar_sha TEXT,           -- SHA1 from Mojang's version meta; NULL when unknown
+    server_jar_url TEXT,
+    status         TEXT NOT NULL CHECK (status IN ('pending', 'in_progress', 'completed', 'failed')),
+    started_at     TIMESTAMPTZ,
+    completed_at   TIMESTAMPTZ,
+    last_error     TEXT,
+    attempt_count  INT NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_minecraft_version_ingestion_status ON minecraft_version_ingestion(status);
+
+-- Backfill one 'completed' row per version where the legacy EXISTS check currently passes.
+-- server_jar_sha stays NULL: we don't know the SHA retroactively. The freshness check (MCO-168)
+-- treats NULL as "data exists, SHA unknown" rather than "needs re-ingestion".
+INSERT INTO minecraft_version_ingestion (version, status, completed_at, attempt_count)
+SELECT mv.version, 'completed', now(), 1
+FROM minecraft_version mv
+WHERE EXISTS(SELECT 1 FROM minecraft_items mi WHERE mi.version = mv.version)
+  AND EXISTS(SELECT 1 FROM minecraft_tag tags WHERE tags.version = mv.version)
+  AND EXISTS(SELECT 1 FROM minecraft_tag_item tag_items WHERE tag_items.version = mv.version)
+  AND EXISTS(SELECT 1 FROM resource_source rs WHERE rs.version = mv.version);


### PR DESCRIPTION
## What

Adds the `minecraft_version_ingestion` ledger table — the single source of truth for "has this Minecraft version been ingested, and from which server.jar". This is step 1 of the [MCO-165](https://linear.app/evegul/issue/MCO-165) migration to move server-files ingestion off the web process.

It replaces the 4-table `EXISTS` proxy (`AllFileMigrationsCompletedStep` in `GetServerFilesPipeline.kt`) as the basis for ingestion decisions. This PR only adds the table + backfill; reading/writing it from the pipeline is [MCO-167](https://linear.app/evegul/issue/MCO-167).

## Schema

`V2_34_0__add_minecraft_version_ingestion_ledger.sql`:
- `version` PK → FK to `minecraft_version(version)`
- `server_jar_sha`, `server_jar_url` — Mojang metadata (NULL until known)
- `status` with a CHECK constraint (`pending` | `in_progress` | `completed` | `failed`)
- `started_at`, `completed_at`, `last_error`, `attempt_count`
- index on `status`

## Backfill

One `completed` row per version where the legacy EXISTS check currently passes; `server_jar_sha` left NULL (unknown retroactively — the freshness check in MCO-168 treats NULL as "data exists, SHA unknown").

## Verification

- `migrate-locally.sh` applies cleanly (v2.33.0 → v2.34.0).
- 30 versions total, 30 ledger rows, 0 excluded — backfill exactly mirrors the EXISTS check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)