### PR TITLE
feat(ingestion): drive ingestion decisions from the ledger (MCO-167)

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/minecraftfiles/GetServerFilesPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/minecraftfiles/GetServerFilesPipeline.kt
@@ -65,75 +65,28 @@ data object GetServerUrlsStep : Step<List<MinecraftVersion.Release>, AppFailure,
     }
 }
 
-private data object FilterAlreadyStoredVersionsStep : Step<List<Pair<MinecraftVersion.Release, URI>>, AppFailure, List<Pair<MinecraftVersion.Release, URI>>> {
+internal data object FilterAlreadyStoredVersionsStep : Step<List<Pair<MinecraftVersion.Release, URI>>, AppFailure, List<Pair<MinecraftVersion.Release, URI>>> {
     override suspend fun process(input: List<Pair<MinecraftVersion.Release, URI>>): Result<AppFailure, List<Pair<MinecraftVersion.Release, URI>>> {
         val logger = LoggerFactory.getLogger(this.javaClass)
-        val storedVersions = GetSupportedVersionsStep.process(Unit)
 
-        if (storedVersions is Result.Failure) {
-            return storedVersions
+        val statuses = LoadIngestionStatusStep.process(Unit)
+        if (statuses is Result.Failure) {
+            logger.error("Failed to load ingestion status from the ledger.")
+            return statuses
         }
-
-        val shouldMigrate = AllFileMigrationsCompletedStep.process(input.map { it.first })
-
-        if (shouldMigrate is Result.Failure) {
-            logger.error("Failed to check migrations for some versions.")
-            return shouldMigrate
-        }
+        val completed = statuses.getOrNull().orEmpty()
 
         return Result.success(
-            input.filter {
-                val allMigrationsComplete = shouldMigrate.getOrNull()?.get(it.first) ?: false
-
-                if (allMigrationsComplete) {
-                    logger.info("All migrations complete for version ${it.first}, skipping download.")
+            input.filter { (version, _) ->
+                val alreadyIngested = completed[version] == IngestionStatus.COMPLETED
+                if (alreadyIngested) {
+                    logger.info("Version $version already ingested (ledger status=completed), skipping download.")
                 } else {
-                    logger.info("Migrations not complete for version ${it.first}, will download and process.")
+                    logger.info("Version $version not yet ingested, will download and process.")
                 }
-
-                !allMigrationsComplete
+                !alreadyIngested
             }
         )
-    }
-}
-
-private data object AllFileMigrationsCompletedStep : Step<List<MinecraftVersion.Release>, AppFailure, Map<MinecraftVersion.Release, Boolean>> {
-    override suspend fun process(input: List<MinecraftVersion.Release>): Result<AppFailure, Map<MinecraftVersion.Release, Boolean>> {
-        val logger = LoggerFactory.getLogger(this.javaClass)
-        val result = DatabaseSteps.query<Unit, Map<MinecraftVersion.Release, Boolean>>(
-            sql = SafeSQL.select("""
-                SELECT mv.version,
-                       EXISTS(SELECT 1 FROM minecraft_items mi WHERE mi.version = mv.version) AS items_migrated,
-                       EXISTS(SELECT 1 FROM minecraft_tag tags WHERE tags.version = mv.version) AS tags_migrated,
-                       EXISTS(SELECT 1 FROM minecraft_tag_item tag_items WHERE tag_items.version = mv.version) AS tag_items_migrated,
-                       EXISTS(SELECT 1 FROM resource_source rs WHERE rs.version = mv.version) AS sources_migrated
-                FROM minecraft_version mv
-            """.trimIndent()),
-            resultMapper = { resultSet ->
-                val migrationStatus = mutableMapOf<MinecraftVersion.Release, Boolean>()
-                while (resultSet.next()) {
-                    val versionString = resultSet.getString("version")
-                    val itemsMigrated = resultSet.getBoolean("items_migrated")
-                    val tagsMigrated = resultSet.getBoolean("tags_migrated")
-                    val tagItemsMigrated = resultSet.getBoolean("tag_items_migrated")
-                    val sourcesMigrated = resultSet.getBoolean("sources_migrated")
-                    try {
-                        val version = MinecraftVersion.Release.fromString(versionString)
-                        migrationStatus[version] = itemsMigrated && sourcesMigrated && tagsMigrated && tagItemsMigrated
-                    } catch (e: IllegalArgumentException) {
-                        logger.error("Invalid version format in database: $versionString", e)
-                    }
-                }
-                migrationStatus
-            }
-        ).process(Unit)
-
-        return result as? Result.Failure
-            ?: Result.success(
-                input.associateWith { version ->
-                    result.getOrNull()?.get(version) ?: false
-                }
-            )
     }
 }
 
@@ -165,15 +118,35 @@ private data object ProcessServerFilesStep : Step<List<Pair<MinecraftVersion.Rel
         return Result.success()
     }
 
-    private suspend fun processServerFile(input: Pair<MinecraftVersion.Release, URI>): Result<AppFailure, Unit> = pipelineResult {
-        val file = GetServerFileStep.run(input)
-        val extracted = ExtractRelevantMinecraftFilesStep().process(file)
-            .mapError { AppFailure.FileError(ProcessServerFilesStep.javaClass) }
-            .bind()
-        val data = ExtractMinecraftDataStep.process(extracted)
-            .mapError { AppFailure.FileError(ProcessServerFilesStep.javaClass) }
-            .bind()
-        StoreMinecraftDataStep.run(data)
+    private suspend fun processServerFile(input: Pair<MinecraftVersion.Release, URI>): Result<AppFailure, Unit> {
+        val version = input.first
+
+        val marked = MarkIngestionInProgressStep.process(version)
+        if (marked is Result.Failure) {
+            logger.error("Could not mark ingestion in progress for version $version, skipping.")
+            return marked
+        }
+
+        val result: Result<AppFailure, Unit> = pipelineResult {
+            val file = GetServerFileStep.run(input)
+            val extracted = ExtractRelevantMinecraftFilesStep().process(file)
+                .mapError { AppFailure.FileError(ProcessServerFilesStep.javaClass) }
+                .bind()
+            val data = ExtractMinecraftDataStep.process(extracted)
+                .mapError { AppFailure.FileError(ProcessServerFilesStep.javaClass) }
+                .bind()
+            StoreMinecraftDataStep.run(data)
+        }
+
+        return when (result) {
+            is Result.Success -> MarkIngestionCompletedStep.process(version)
+            is Result.Failure -> {
+                // Best-effort: record the failure so a rerun retries this version only. If the ledger
+                // write itself fails we still surface the original, more informative error.
+                MarkIngestionFailedStep.process(version to result.error.toString())
+                result
+            }
+        }
     }
 }
 
@@ -189,4 +162,87 @@ data object GetServerFileStep : Step<Pair<MinecraftVersion.Release, URI>, AppFai
             Result.failure(AppFailure.ApiError.UnknownError)
         }
     }
+}
+
+/** Ledger status values, mirrored from the `minecraft_version_ingestion.status` CHECK constraint. */
+object IngestionStatus {
+    const val IN_PROGRESS = "in_progress"
+    const val COMPLETED = "completed"
+    const val FAILED = "failed"
+}
+
+/**
+ * Reads the ingestion ledger into a `version -> status` map. A version absent from the map has no
+ * ledger row and is treated as "never ingested" by the caller. Replaces the legacy 4-table EXISTS
+ * proxy as the source of truth for ingestion decisions (MCO-167).
+ */
+internal data object LoadIngestionStatusStep : Step<Unit, AppFailure.DatabaseError, Map<MinecraftVersion.Release, String>> {
+    private val logger = LoggerFactory.getLogger(this.javaClass)
+
+    override suspend fun process(input: Unit): Result<AppFailure.DatabaseError, Map<MinecraftVersion.Release, String>> =
+        DatabaseSteps.query<Unit, Map<MinecraftVersion.Release, String>>(
+            sql = SafeSQL.select("SELECT version, status FROM minecraft_version_ingestion"),
+            resultMapper = { resultSet ->
+                buildMap {
+                    while (resultSet.next()) {
+                        val versionString = resultSet.getString("version")
+                        try {
+                            put(MinecraftVersion.Release.fromString(versionString), resultSet.getString("status"))
+                        } catch (e: IllegalArgumentException) {
+                            logger.error("Invalid version format in ingestion ledger: $versionString", e)
+                        }
+                    }
+                }
+            }
+        ).process(Unit)
+}
+
+/**
+ * Marks a version's ingestion as started: upserts an `in_progress` row, stamps `started_at`,
+ * bumps `attempt_count`, and clears any stale `last_error`. No FK to minecraft_version, so this is
+ * safe for brand-new versions whose data does not exist yet (MCO-167).
+ */
+internal data object MarkIngestionInProgressStep : Step<MinecraftVersion.Release, AppFailure.DatabaseError, Unit> {
+    override suspend fun process(input: MinecraftVersion.Release): Result<AppFailure.DatabaseError, Unit> =
+        DatabaseSteps.update<MinecraftVersion.Release>(
+            sql = SafeSQL.insert("""
+                INSERT INTO minecraft_version_ingestion (version, status, started_at, attempt_count)
+                VALUES (?, 'in_progress', now(), 1)
+                ON CONFLICT (version) DO UPDATE SET
+                    status = 'in_progress',
+                    started_at = now(),
+                    attempt_count = minecraft_version_ingestion.attempt_count + 1,
+                    last_error = NULL
+            """.trimIndent()),
+            parameterSetter = { statement, version -> statement.setString(1, version.toString()) }
+        ).process(input).map { }
+}
+
+/** Marks a version's ingestion as completed and clears any prior error (MCO-167). */
+internal data object MarkIngestionCompletedStep : Step<MinecraftVersion.Release, AppFailure.DatabaseError, Unit> {
+    override suspend fun process(input: MinecraftVersion.Release): Result<AppFailure.DatabaseError, Unit> =
+        DatabaseSteps.update<MinecraftVersion.Release>(
+            sql = SafeSQL.update("""
+                UPDATE minecraft_version_ingestion
+                SET status = 'completed', completed_at = now(), last_error = NULL
+                WHERE version = ?
+            """.trimIndent()),
+            parameterSetter = { statement, version -> statement.setString(1, version.toString()) }
+        ).process(input).map { }
+}
+
+/** Records an ingestion failure with its error message, leaving completed_at untouched (MCO-167). */
+internal data object MarkIngestionFailedStep : Step<Pair<MinecraftVersion.Release, String>, AppFailure.DatabaseError, Unit> {
+    override suspend fun process(input: Pair<MinecraftVersion.Release, String>): Result<AppFailure.DatabaseError, Unit> =
+        DatabaseSteps.update<Pair<MinecraftVersion.Release, String>>(
+            sql = SafeSQL.update("""
+                UPDATE minecraft_version_ingestion
+                SET status = 'failed', last_error = ?
+                WHERE version = ?
+            """.trimIndent()),
+            parameterSetter = { statement, (version, error) ->
+                statement.setString(1, error)
+                statement.setString(2, version.toString())
+            }
+        ).process(input).map { }
 }

--- a/webapp/mc-web/src/main/resources/db/migration/V2_35_0__drop_ingestion_version_fk.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_35_0__drop_ingestion_version_fk.sql
@@ -1,0 +1,7 @@
+-- Drop the FK from the ingestion ledger to minecraft_version.
+-- The ledger tracks ingestion *attempts* — including 'in_progress' and 'failed' rows for versions
+-- that do not yet (or may never) exist in minecraft_version, since ingestion is what creates that
+-- row. The FK forced the parent to exist before we could mark a run in progress, which is backwards.
+-- version stays PRIMARY KEY (one ledger row per version). See MCO-167.
+ALTER TABLE minecraft_version_ingestion
+    DROP CONSTRAINT IF EXISTS minecraft_version_ingestion_version_fkey;

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/minecraftfiles/IngestionLedgerStepsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/minecraftfiles/IngestionLedgerStepsTest.kt
@@ -1,0 +1,189 @@
+package app.mcorg.pipeline.minecraftfiles
+
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.test.postgres.DatabaseTestExtension
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import java.net.URI
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class IngestionLedgerStepsTest {
+
+    private val v1 = MinecraftVersion.Release(1, 21, 4)
+    private val v2 = MinecraftVersion.Release(1, 20, 6)
+    private val v3 = MinecraftVersion.Release(1, 19, 2)
+
+    @BeforeEach
+    fun clearLedger() {
+        DatabaseTestExtension.executeSQL("TRUNCATE TABLE minecraft_version_ingestion")
+    }
+
+    // --- LoadIngestionStatusStep ---------------------------------------------------------------
+
+    @Test
+    fun `LoadIngestionStatusStep returns a status per ledger row and omits absent versions`() {
+        seed(v1, IngestionStatus.COMPLETED)
+        seed(v2, IngestionStatus.FAILED)
+
+        val statuses = runBlocking { LoadIngestionStatusStep.process(Unit) }
+        val map = assertIs<Result.Success<Map<MinecraftVersion.Release, String>>>(statuses).value
+
+        assertEquals(IngestionStatus.COMPLETED, map[v1])
+        assertEquals(IngestionStatus.FAILED, map[v2])
+        assertNull(map[v3]) // no row → absent from map
+    }
+
+    // --- MarkIngestionInProgressStep -----------------------------------------------------------
+
+    @Test
+    fun `MarkIngestionInProgress inserts a fresh in_progress row for a version with no data`() {
+        val result = runBlocking { MarkIngestionInProgressStep.process(v1) }
+        assertIs<Result.Success<*>>(result)
+
+        val row = assertNotNull(readRow(v1))
+        assertEquals(IngestionStatus.IN_PROGRESS, row.status)
+        assertEquals(1, row.attemptCount)
+        assertTrue(row.hasStarted)
+        assertNull(row.lastError)
+    }
+
+    @Test
+    fun `MarkIngestionInProgress on an existing row bumps attempt_count and clears last_error`() {
+        seed(v1, IngestionStatus.FAILED, attemptCount = 2, lastError = "boom")
+
+        val result = runBlocking { MarkIngestionInProgressStep.process(v1) }
+        assertIs<Result.Success<*>>(result)
+
+        val row = assertNotNull(readRow(v1))
+        assertEquals(IngestionStatus.IN_PROGRESS, row.status)
+        assertEquals(3, row.attemptCount)
+        assertNull(row.lastError)
+    }
+
+    // --- MarkIngestionCompletedStep ------------------------------------------------------------
+
+    @Test
+    fun `MarkIngestionCompleted sets completed, stamps completed_at and clears last_error`() {
+        seed(v1, IngestionStatus.IN_PROGRESS, attemptCount = 1, lastError = "stale")
+
+        val result = runBlocking { MarkIngestionCompletedStep.process(v1) }
+        assertIs<Result.Success<*>>(result)
+
+        val row = assertNotNull(readRow(v1))
+        assertEquals(IngestionStatus.COMPLETED, row.status)
+        assertTrue(row.hasCompleted)
+        assertNull(row.lastError)
+    }
+
+    // --- MarkIngestionFailedStep ---------------------------------------------------------------
+
+    @Test
+    fun `MarkIngestionFailed records the error and leaves completed_at null`() {
+        seed(v1, IngestionStatus.IN_PROGRESS)
+
+        val result = runBlocking { MarkIngestionFailedStep.process(v1 to "download timed out") }
+        assertIs<Result.Success<*>>(result)
+
+        val row = assertNotNull(readRow(v1))
+        assertEquals(IngestionStatus.FAILED, row.status)
+        assertEquals("download timed out", row.lastError)
+        assertEquals(false, row.hasCompleted)
+    }
+
+    // --- FilterAlreadyStoredVersionsStep -------------------------------------------------------
+
+    @Test
+    fun `Filter keeps versions that are missing, failed or in_progress and drops completed`() {
+        seed(v1, IngestionStatus.COMPLETED)
+        seed(v2, IngestionStatus.FAILED)
+        // v3 intentionally has no ledger row (the truncate-to-recreate path)
+
+        val input = listOf(
+            v1 to URI.create("https://example.test/v1/server.jar"),
+            v2 to URI.create("https://example.test/v2/server.jar"),
+            v3 to URI.create("https://example.test/v3/server.jar"),
+        )
+
+        val result = runBlocking { FilterAlreadyStoredVersionsStep.process(input) }
+        val kept = assertIs<Result.Success<List<Pair<MinecraftVersion.Release, URI>>>>(result).value
+
+        assertEquals(setOf(v2, v3), kept.map { it.first }.toSet())
+    }
+
+    @Test
+    fun `Filter keeps everything when the ledger is empty`() {
+        val input = listOf(
+            v1 to URI.create("https://example.test/v1/server.jar"),
+            v2 to URI.create("https://example.test/v2/server.jar"),
+        )
+
+        val result = runBlocking { FilterAlreadyStoredVersionsStep.process(input) }
+        val kept = assertIs<Result.Success<List<Pair<MinecraftVersion.Release, URI>>>>(result).value
+
+        assertEquals(setOf(v1, v2), kept.map { it.first }.toSet())
+    }
+
+    // --- helpers --------------------------------------------------------------------------------
+
+    private data class LedgerRow(
+        val status: String,
+        val attemptCount: Int,
+        val lastError: String?,
+        val hasStarted: Boolean,
+        val hasCompleted: Boolean,
+    )
+
+    private fun seed(
+        version: MinecraftVersion.Release,
+        status: String,
+        attemptCount: Int = 0,
+        lastError: String? = null,
+    ) = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO minecraft_version_ingestion (version, status, attempt_count, last_error) VALUES (?, ?, ?, ?)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, version.toString())
+                stmt.setString(2, status)
+                stmt.setInt(3, attemptCount)
+                stmt.setString(4, lastError)
+            }
+        ).process(Unit)
+        assertIs<Result.Success<*>>(result)
+    }
+
+    private fun readRow(version: MinecraftVersion.Release): LedgerRow? = runBlocking {
+        DatabaseSteps.query<Unit, LedgerRow?>(
+            sql = SafeSQL.select(
+                "SELECT status, attempt_count, last_error, started_at, completed_at FROM minecraft_version_ingestion WHERE version = ?"
+            ),
+            parameterSetter = { stmt, _ -> stmt.setString(1, version.toString()) },
+            resultMapper = { rs ->
+                if (rs.next()) {
+                    LedgerRow(
+                        status = rs.getString("status"),
+                        attemptCount = rs.getInt("attempt_count"),
+                        lastError = rs.getString("last_error"),
+                        hasStarted = rs.getTimestamp("started_at") != null,
+                        hasCompleted = rs.getTimestamp("completed_at") != null,
+                    )
+                } else null
+            }
+        ).process(Unit).getOrThrow()
+    }
+}

--- a/webapp/scripts/test.sh
+++ b/webapp/scripts/test.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(dirname "$0")"
 WEBAPP_DIR="$SCRIPT_DIR/.."
 
 usage() {
-    echo "Usage: $0 [--database] [--integration] [--exclude-unit-tests]"
+    echo "Usage: $0 [--database] [--integration] [--exclude-unit-tests] [-- <maven-args>...]"
     echo ""
     echo "Runs unit tests by default (no Docker required)."
     echo ""
@@ -13,12 +13,16 @@ usage() {
     echo "  --database            Include database tests (requires Docker)"
     echo "  --integration         Include integration tests (requires Docker and the app running)"
     echo "  --exclude-unit-tests  Skip unit tests"
+    echo ""
+    echo "Anything after a literal '--' is forwarded verbatim to the underlying 'mvn test' runs,"
+    echo "e.g. narrow to one class:  $0 --database -- -Dtest=IngestionLedgerStepsTest"
     exit 1
 }
 
 DATABASE=false
 INTEGRATION=false
 UNIT=true
+PASSTHROUGH=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -36,6 +40,11 @@ while [[ $# -gt 0 ]]; do
             ;;
         -h|--help)
             usage
+            ;;
+        --)
+            shift
+            PASSTHROUGH=("$@")
+            break
             ;;
         *)
             echo "Unknown option: $1"
@@ -56,15 +65,15 @@ mvn test-compile -B
 
 if [[ "$UNIT" == true ]]; then
     echo "Running unit tests..."
-    mvn test -B
+    mvn test -B ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}
 fi
 
 if [[ "$DATABASE" == true ]]; then
     echo "Running database tests..."
-    mvn test -pl mc-web -Dsurefire.excludedGroups= -Dgroups=database -B
+    mvn test -pl mc-web -Dsurefire.excludedGroups= -Dgroups=database -B ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}
 fi
 
 if [[ "$INTEGRATION" == true ]]; then
     echo "Running integration tests..."
-    mvn failsafe:integration-test failsafe:verify -pl mc-web -B
+    mvn failsafe:integration-test failsafe:verify -pl mc-web -B ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}
 fi


### PR DESCRIPTION
## What

Step 2 of [MCO-165](https://linear.app/evegul/issue/MCO-165). Switches the server-files pipeline from the 4-table `EXISTS` proxy to the `minecraft_version_ingestion` ledger as the source of truth for "do we ingest this version?". Behaviour stays equivalent on the current DB (the MCO-166 backfill already marked every existing version `completed`); this is plumbing, not policy.

## Changes

`GetServerFilesPipeline.kt`:
- **`AllFileMigrationsCompletedStep` → `LoadIngestionStatusStep`** — reads `version -> status` from the ledger. A version with no row is absent from the map.
- **`FilterAlreadyStoredVersionsStep`** drops only versions whose ledger `status = 'completed'`. A missing row → re-ingest (this is what makes "truncate the ledger to rebuild" work).
- **`processServerFile()`** now wraps each version: `MarkIngestionInProgressStep` before the run (upsert → `in_progress`, stamp `started_at`, bump `attempt_count`, clear `last_error`), `MarkIngestionCompletedStep` on success, `MarkIngestionFailedStep` (with `last_error`) on failure. A rerun therefore retries only the failed versions.

`server_jar_sha` is intentionally **not** written yet — that's MCO-168, which threads the SHA through `GetServerUrlsStep`.

## Schema: drop the ledger FK (`V2_35_0`)

The MCO-166 ledger had `version REFERENCES minecraft_version(version)`. But ingestion is *what creates* the `minecraft_version` row, so marking a brand-new version `in_progress` before its data exists violated the FK. The ledger tracks ingestion *attempts* — including `in_progress`/`failed` rows for versions not (yet) in `minecraft_version` — so it must precede the data it produces. Dropping the FK (keeping `version` as PK) also removes the RESTRICT concern when wiping `minecraft_version`. Per discussion on MCO-165, this matches the "ledger is a disposable cache" framing.

## Tests

DB-tagged `IngestionLedgerStepsTest` (7 cases): `LoadIngestionStatusStep` mapping + absent versions; the three mark steps (fresh insert, upsert/bump/clear, completed stamps, failed records error and leaves `completed_at` null); and the filter — drops `completed`, keeps `failed`/`in_progress`/**missing** (the recreate path), and keeps everything on an empty ledger.

- `mvn clean compile` clean.
- Full suite green: **503 unit + 60 database** tests, incl. `DatabaseMigrationTest`.

## Tooling

`scripts/test.sh` now forwards anything after a literal `--` to the underlying `mvn test` runs, so you can scope a run: `./webapp/scripts/test.sh --database -- -Dtest=IngestionLedgerStepsTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)