### PR TITLE
fix(api): reuse a single shared HttpClient across providers (MCO-173)

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/config/ApiProvider.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/config/ApiProvider.kt
@@ -136,19 +136,27 @@ sealed class ApiProvider(
 class DefaultApiProvider(
     config: ApiConfig
 ) : ApiProvider(config) {
-    // Rate limiting state
-    private val rateLimitState = ConcurrentHashMap<String, RateLimitInfo>()
-    private val rateLimitMutex = Mutex()
+    companion object {
+        // A single HttpClient shared across all providers: one connection pool + TLS-session
+        // cache reused app-wide, instead of constructing (and leaking) a new client per call.
+        private val httpClient = HttpClient(CIO) {
+            install(ContentNegotiation) {
+                json(Json {
+                    ignoreUnknownKeys = true
+                    isLenient = true
+                })
+            }
+            install(HttpTimeout) {
+                requestTimeoutMillis = 30000
+                connectTimeoutMillis = 10000
+                socketTimeoutMillis = 30000
+            }
+        }
 
-    private val httpClient = HttpClient(CIO) {
-        install(ContentNegotiation) {
-            json(json)
-        }
-        install(HttpTimeout) {
-            requestTimeoutMillis = 30000
-            connectTimeoutMillis = 10000
-            socketTimeoutMillis = 30000
-        }
+        // Rate limiting state, keyed by baseUrl and shared so the window persists across
+        // calls (each getProvider() previously returned a fresh instance with empty state).
+        private val rateLimitState = ConcurrentHashMap<String, RateLimitInfo>()
+        private val rateLimitMutex = Mutex()
     }
 
     override fun <I, S> request(


### PR DESCRIPTION
## Summary

`ApiConfig.getProvider()` returns a **new** `DefaultApiProvider` on every call, and each one constructed its **own** `HttpClient(CIO)` that was **never closed**.

- **Resource leak:** every external API call created an HttpClient (connection pool + engine threads) that was never `.close()`d — a single Microsoft sign-in (Microsoft token → Xbox → XSTS → Minecraft token → profile) leaked all 5.
- **Latency:** no connection/TLS-session reuse — each hop paid full client construction + a fresh TLS handshake.

## Fix

Move the `HttpClient` and the rate-limit state into a `companion object` on `DefaultApiProvider`, so a single client (one connection pool + TLS-session cache) is reused across all providers app-wide. The per-request differences (content type, accept, user-agent, URL, body) are already applied per call in `request()`, so one client config serves every `ApiConfig`.

Rate-limit state is now shared too: it's keyed by `baseUrl`, but previously reset to an empty map on every call (each provider instance was fresh), so it was effectively dead. Sharing it makes the window actually persist across calls. `FakeApiProvider` is unaffected — it never touches the client.

## Testing

- `mvn compile` clean
- All 27 `config` tests pass (`ApiProviderTest`, `ApiProviderRateLimitingTest`, `ApiProviderEdgeCasesTest`, `DefaultApiProviderTest`)

Closes MCO-173

🤖 Generated with [Claude Code](https://claude.com/claude-code)