### PR TITLE
chore(worktree): isolate each worktree's database via Neon branches

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -51,6 +51,23 @@
             "type": "command",
             "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/worktree-create-keys.sh",
             "statusMessage": "Generating JWT signing keys..."
+          },
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/webapp/scripts/worktree-db.sh\"",
+            "statusMessage": "Provisioning isolated Neon branch for worktree...",
+            "timeout": 180
+          }
+        ]
+      },
+      {
+        "matcher": "ExitWorktree",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/webapp/scripts/worktree-db-cleanup.sh\" --prune",
+            "statusMessage": "Pruning orphaned Neon worktree branches...",
+            "timeout": 60
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules/
 .sessions
 .playwright-cli
 .claude/screenshots/
+.claude/worktrees/
 
 # mc-data symlink to mc-web test data
 webapp/mc-data/src/test/resources/servers/extracted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,56 @@ cd webapp && mvn test -pl mc-web         # Single module tests
 - **Database access:** Verify the postgres MCP server is available (`/mcp`) before any database read or query. Always
   use MCP tools for database access — never `psql` or other CLI tools.
 
+## Worktree Database Isolation
+
+**Start new work in a git worktree, not the main checkout.** The main checkout
+(`master`) shares the production-backed dev database; worktrees each get their own
+isolated copy (below). Working in a worktree keeps `master` clean, lets features
+run in parallel without database or migration collisions, and matches how CI builds
+each PR. Use an agent's `isolation: "worktree"` or `git worktree add` to start.
+
+Each git worktree gets its **own** database so migrations and data never collide
+with the main checkout or sibling worktrees. This mirrors what CI already does
+per pull request (`.github/workflows/dev.yml` forks `dev/pr-<N>` Neon branches) —
+only locally, per worktree, using the same Neon project (`morning-fog-11467472`).
+
+**Workflow:**
+
+1. Start a worktree (an agent's `isolation: "worktree"`, or `git worktree add`).
+2. On `EnterWorktree`, a PostToolUse hook runs `webapp/scripts/worktree-db.sh`. It:
+   - Forks a copy-on-write Neon branch `wt/<git-branch>` from production (`master`)
+   - Writes the worktree's `webapp/local.env` (main checkout's non-DB config + the
+     branch's `DB_*` credentials)
+   - Runs `flyway:migrate` against the isolated branch
+3. The worktree's app and tests now target the worktree's own branch — never the
+   shared dev DB — and any migrations you run land on the isolated branch.
+4. On `ExitWorktree`, `webapp/scripts/worktree-db-cleanup.sh --prune` reconciles
+   live `wt/*` Neon branches against `git worktree list` and deletes orphans.
+5. **Manual worktrees** (e.g. `claude -w`, where the EnterWorktree hook may not fire):
+   run `bash webapp/scripts/worktree-db.sh` yourself from the worktree root.
+
+**Why fork production?** Same as the CI previews — a copy-on-write branch inherits
+the real ingested Minecraft data instantly (no re-ingestion) and matches CI exactly.
+
+**Caveats:**
+
+- `webapp/local.env` is **gitignored**. The main checkout's copy is the single
+  source for non-DB local config (Microsoft, Modrinth, `ENV`, …); the setup script
+  writes each worktree's `local.env` fresh from it, swapping in the branch's Neon
+  `DB_*` values. Keep the main checkout's `local.env` current — a fresh clone has
+  none, and the script errors until you create it.
+- **Migration number collisions are orthogonal to DB isolation.** If two branches
+  each add `V{n}__*.sql` with the same `{n}`, Flyway errors on merge (out-of-order
+  / checksum). Fix: renumber the later-merged migration to the next free number and
+  re-run `migrate-locally.sh`. No DB-branching scheme prevents this — it's a git
+  conflict, not a data one.
+
+**Scripts:**
+
+- `webapp/scripts/worktree-db.sh` — fork Neon branch + point `local.env` at it + migrate
+- `webapp/scripts/worktree-db-cleanup.sh` — delete the current worktree's branch
+- `webapp/scripts/worktree-db-cleanup.sh --prune` — delete all orphaned `wt/*` branches
+
 ## Issue Tracking
 
 Linear — workspace: evegul, team: Mcorg. Do NOT create GitHub issues.

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -38,5 +38,6 @@ out/
 target
 
 src/main/resources/keys
+local.env
 local_microsoft.env
 truststore.jks

--- a/webapp/local.env
+++ b/webapp/local.env
@@ -1,9 +1,0 @@
-DB_URL=jdbc:postgresql://localhost:5432/postgres
-DB_USER=postgres
-DB_PASSWORD=supersecret
-MICROSOFT_CLIENT_ID=
-MICROSOFT_CLIENT_SECRET=
-ENV=LOCAL
-SKIP_MICROSOFT_SIGN_IN=true
-
-MODRINTH_URL=https://staging-api.modrinth.com

--- a/webapp/scripts/worktree-db-cleanup.sh
+++ b/webapp/scripts/worktree-db-cleanup.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Delete Neon worktree branches (wt/*).
+#
+#   bash webapp/scripts/worktree-db-cleanup.sh            # delete the branch for the current worktree
+#   bash webapp/scripts/worktree-db-cleanup.sh wt/foo     # delete a named branch
+#   bash webapp/scripts/worktree-db-cleanup.sh --prune    # delete every wt/* with no matching git worktree
+#
+# Runs automatically (--prune) via the ExitWorktree PostToolUse hook, which
+# reconciles live Neon wt/* branches against `git worktree list` and removes
+# the orphans.
+
+set -euo pipefail
+
+NEON_PROJECT_ID="morning-fog-11467472"
+
+# Run git commands from the directory the script physically lives in (the main
+# checkout), so prune works even when the just-removed worktree was the cwd.
+cd "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+list_wt_branches() {
+  neonctl branches list --project-id "$NEON_PROJECT_ID" --output json \
+    | python3 -c 'import sys,json
+d=json.load(sys.stdin)
+for b in (d if isinstance(d,list) else d.get("branches",[])):
+    if b.get("name","").startswith("wt/"): print(b["name"])'
+}
+
+delete_branch() {
+  echo "worktree-db-cleanup: deleting Neon branch $1..."
+  neonctl branches delete "$1" --project-id "$NEON_PROJECT_ID" --force >/dev/null
+}
+
+prune() {
+  local active nb wt orphans=0
+  active="$(git worktree list | sed -n 's/.*\[\(.*\)\]/\1/p')"
+  while IFS= read -r nb; do
+    [ -z "$nb" ] && continue
+    wt="${nb#wt/}"
+    if ! grep -qxF "$wt" <<<"$active"; then
+      delete_branch "$nb"; orphans=$((orphans + 1))
+    fi
+  done < <(list_wt_branches)
+  echo "worktree-db-cleanup: pruned ${orphans} orphaned branch(es)."
+}
+
+case "${1:-}" in
+  --prune) prune ;;
+  "")
+    branch="wt/$(git branch --show-current)"
+    delete_branch "$branch"
+    ;;
+  *) delete_branch "$1" ;;
+esac

--- a/webapp/scripts/worktree-db.sh
+++ b/webapp/scripts/worktree-db.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Provision an isolated Neon database branch for the current git worktree.
+#
+# Forks a copy-on-write branch (wt/<git-branch>) from the production Neon
+# branch (master), points this worktree's webapp/local.env at it, and runs
+# Flyway migrations. Each worktree gets its own database, so migrations and
+# data never collide with the main checkout or with sibling worktrees.
+#
+# This mirrors what CI already does per pull request (.github/workflows/dev.yml
+# creates dev/pr-<N> branches) — only here it runs locally, per worktree.
+#
+# Runs automatically via the EnterWorktree PostToolUse hook. For worktrees
+# created outside an agent run (e.g. `claude -w` or `git worktree add`), run it
+# manually from the worktree root:
+#   bash webapp/scripts/worktree-db.sh
+#
+# Teardown happens via the ExitWorktree hook, or manually:
+#   bash webapp/scripts/worktree-db-cleanup.sh
+
+set -euo pipefail
+
+NEON_PROJECT_ID="morning-fog-11467472"
+NEON_PARENT="master"        # the production / default Neon branch
+DB_NAME="mcorg"
+DB_ROLE="mcorg_owner"
+
+# --- Resolve the worktree root ---------------------------------------------
+# Prefer an explicit path arg, then the hook's stdin `cwd`, then $PWD.
+# Normalise to the git worktree top-level either way.
+TARGET_DIR="${1:-}"
+if [ -z "$TARGET_DIR" ] && [ ! -t 0 ]; then
+  STDIN_JSON="$(cat || true)"
+  if [ -n "$STDIN_JSON" ]; then
+    TARGET_DIR="$(printf '%s' "$STDIN_JSON" | python3 -c 'import sys,json
+try: print(json.load(sys.stdin).get("cwd",""))
+except Exception: print("")' 2>/dev/null || true)"
+  fi
+fi
+TARGET_DIR="${TARGET_DIR:-$PWD}"
+
+WORKTREE_ROOT="$(git -C "$TARGET_DIR" rev-parse --show-toplevel)"
+MAIN_REPO="$(git -C "$TARGET_DIR" rev-parse --path-format=absolute --git-common-dir | sed 's|/\.git$||')"
+GIT_BRANCH="$(git -C "$WORKTREE_ROOT" branch --show-current)"
+
+if [ -z "$GIT_BRANCH" ]; then
+  echo "worktree-db: not on a named branch — skipping." >&2
+  exit 0
+fi
+if [ "$WORKTREE_ROOT" = "$MAIN_REPO" ]; then
+  echo "worktree-db: refusing to isolate the main checkout ($MAIN_REPO)." >&2
+  echo "worktree-db: run this from a git worktree, not the primary working tree." >&2
+  exit 0
+fi
+
+NEON_BRANCH="wt/${GIT_BRANCH}"
+ENV_FILE="$WORKTREE_ROOT/webapp/local.env"
+
+# --- Create (or reuse) the Neon branch -------------------------------------
+echo "worktree-db: creating Neon branch '${NEON_BRANCH}' forked from '${NEON_PARENT}'..."
+if ! neonctl branches create \
+      --project-id "$NEON_PROJECT_ID" \
+      --name "$NEON_BRANCH" \
+      --parent "$NEON_PARENT" \
+      --output json >/dev/null 2>&1; then
+  echo "worktree-db: branch may already exist; reusing it." >&2
+fi
+
+CONN="$(neonctl connection-string \
+  --project-id "$NEON_PROJECT_ID" \
+  --branch "$NEON_BRANCH" \
+  --role-name "$DB_ROLE" \
+  --database-name "$DB_NAME" \
+  --pooled)"
+
+# Parse host + password out of postgresql://user:pass@host/db?params
+read -r DB_HOST DB_PASSWORD < <(printf '%s' "$CONN" | python3 -c 'import sys,urllib.parse as u
+p=u.urlparse(sys.stdin.read().strip())
+print(p.hostname, p.password)')
+
+# Match the JDBC shape used in fly.toml (no channel_binding param).
+JDBC_URL="jdbc:postgresql://${DB_HOST}/${DB_NAME}?sslmode=require"
+
+# --- Build this worktree's local.env ---------------------------------------
+# local.env is gitignored, so a fresh worktree starts without one. Derive it
+# from the main checkout (every line except the DB_ ones), then append the
+# branch's Neon credentials. The script fully owns the worktree's local.env.
+MAIN_ENV="$MAIN_REPO/webapp/local.env"
+if [ ! -f "$MAIN_ENV" ]; then
+  echo "worktree-db: $MAIN_ENV not found — create it in the main checkout first." >&2
+  echo "worktree-db: (it holds the non-DB local config that worktrees inherit.)" >&2
+  exit 1
+fi
+{
+  grep -vE '^(DB_URL|DB_USER|DB_PASSWORD)=' "$MAIN_ENV" || true
+  printf 'DB_URL=%s\nDB_USER=%s\nDB_PASSWORD=%s\n' "$JDBC_URL" "$DB_ROLE" "$DB_PASSWORD"
+} > "$ENV_FILE"
+
+echo "worktree-db: wrote local.env (inherited from main checkout) pointing at ${DB_HOST}"
+
+# --- Migrate ----------------------------------------------------------------
+echo "worktree-db: running Flyway migrations against the worktree branch..."
+(
+  cd "$WORKTREE_ROOT/webapp"
+  DB_URL="$JDBC_URL" DB_USER="$DB_ROLE" DB_PASSWORD="$DB_PASSWORD" \
+    mvn -q flyway:migrate -pl mc-web
+)
+
+echo "worktree-db: ready. Neon branch '${NEON_BRANCH}' is isolated to this worktree."


### PR DESCRIPTION
## What

Per-worktree database isolation for local development. Each git worktree gets
its own copy-on-write Neon branch, so migrations and data never collide with the
main checkout or sibling worktrees. This mirrors what CI already does per pull
request (`.github/workflows/dev.yml` forks `dev/pr-<N>` branches) — only locally,
per worktree, reusing the same Neon project.

Adapted from the equivalent setup in the skyteruta repo, minus the parts that
don't apply here (no Clerk-ID fixup; no schema-command guards — see below).

## How

- **`webapp/scripts/worktree-db.sh`** — forks a Neon branch `wt/<git-branch>`
  from production (`master`), writes the worktree's `local.env` fresh (inheriting
  the main checkout's non-DB config + the branch's Neon credentials), and runs
  `flyway:migrate` against the isolated branch.
- **`webapp/scripts/worktree-db-cleanup.sh`** — deletes the current worktree's
  branch, or with `--prune` reconciles `wt/*` branches against `git worktree list`
  and removes orphans.
- **Hooks** — `worktree-db.sh` runs on `EnterWorktree` alongside the existing
  `worktree-create-keys.sh`; an `ExitWorktree` hook runs `--prune`.
- **`local.env` is now gitignored** — the main checkout's copy is the single
  source of non-DB local config; `.claude/worktrees/` is ignored too.
- **CLAUDE.md** documents the workflow, the work-in-a-worktree directive, the
  manual-run fallback, and the migration-number-collision caveat.

## Why no guards

skyteruta ships a `guard-drizzle.sh` PreToolUse hook that blocks schema commands
against the shared DB. It's unnecessary here: nothing auto-mutates the shared dev
DB (the auto-apply migration hook was removed in #272), and with each worktree on
its own Neon branch, any migrations you run land on that branch.

## Testing

Verified end-to-end against the real Neon project (`morning-fog-11467472`):
- branch fork lands on a distinct endpoint (genuine isolation)
- `local.env` written with non-DB lines preserved + `DB_*` swapped to the branch
- `flyway:migrate` connects and runs
- `--prune` reconciles against `git worktree list` and deletes orphans

No application source or migrations changed, so `compile`/`test` are unaffected.

## Note

The `EnterWorktree`/`ExitWorktree` hooks only fire in sessions started *after*
the hook config is present (Claude Code loads hooks at session start). The hook
*command* is verified working; auto-firing requires a fresh session. For CLI
`claude -w` worktrees the hook may not fire at all — the documented fallback is
`bash webapp/scripts/worktree-db.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)