### PR TITLE
feat(ingestion): guard the pipeline with a Postgres advisory lock (MCO-169)

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/minecraftfiles/GetServerFilesPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/minecraftfiles/GetServerFilesPipeline.kt
@@ -1,5 +1,6 @@
 package app.mcorg.pipeline.minecraftfiles
 
+import app.mcorg.config.Database
 import app.mcorg.config.MojangLauncherMetaApiConfig
 import app.mcorg.data.minecraft.ExtractMinecraftDataStep
 import app.mcorg.data.minecraft.extract.ExtractRelevantMinecraftFilesStep
@@ -9,10 +10,12 @@ import app.mcorg.domain.pipeline.Step
 import app.mcorg.domain.pipeline.pipelineResult
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.TransactionConnection
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.minecraft.GetAvailableVersionsStep
 import app.mcorg.pipeline.minecraft.StoreMinecraftDataStep
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
@@ -20,11 +23,81 @@ import org.slf4j.MDC
 import java.io.InputStream
 import java.net.URI
 
-suspend fun executeServerFilesPipeline(): Result<AppFailure, Unit> = pipelineResult {
-    val versions = GetAvailableVersionsStep.run(Unit)
-    val urls = GetServerUrlsStep.run(versions)
-    val filtered = FilterAlreadyStoredVersionsStep.run(urls)
-    ProcessServerFilesStep.run(filtered)
+/**
+ * Fixed advisory-lock key guarding a whole ingestion run. Any stable bigint works; this value is
+ * arbitrary and shared by every invocation path (app boot, manual run, the future cron machine) so
+ * they serialise against each other.
+ */
+private const val INGESTION_ADVISORY_LOCK_KEY = 7331L
+
+private val ingestionLogger = LoggerFactory.getLogger("app.mcorg.pipeline.minecraftfiles.ServerFilesIngestion")
+
+/**
+ * Runs server-files ingestion under a Postgres advisory lock so overlapping triggers become silent
+ * no-ops instead of duplicate work. The lock is held on a dedicated connection for the whole run and
+ * released on every exit path, including failure and cancellation (MCO-169).
+ */
+suspend fun executeServerFilesPipeline(): Result<AppFailure, Unit> = withIngestionLock {
+    pipelineResult {
+        val versions = GetAvailableVersionsStep.run(Unit)
+        val urls = GetServerUrlsStep.run(versions)
+        val filtered = FilterAlreadyStoredVersionsStep.run(urls)
+        ProcessServerFilesStep.run(filtered)
+    }
+}
+
+/**
+ * Acquires the ingestion advisory lock on a dedicated connection and runs [block]. If another run
+ * already holds the lock, logs and returns success without running [block] — overlapping triggers
+ * become no-ops. The lock is released and the connection returned on every path; release runs under
+ * [NonCancellable] so a cancelled run still frees the lock rather than leaking it on the pooled
+ * session (a pg advisory lock is session-scoped and Hikari keeps sessions alive across checkouts).
+ */
+internal suspend fun withIngestionLock(block: suspend () -> Result<AppFailure, Unit>): Result<AppFailure, Unit> {
+    val connection = try {
+        TransactionConnection(withContext(Dispatchers.IO) { Database.getConnection() })
+    } catch (e: Exception) {
+        ingestionLogger.error("Could not open a connection for the ingestion advisory lock", e)
+        return Result.failure(AppFailure.DatabaseError.ConnectionError)
+    }
+
+    return connection.connection.use {
+        when (val acquired = tryAdvisoryLock(connection)) {
+            is Result.Failure -> acquired
+            is Result.Success -> if (!acquired.value) {
+                ingestionLogger.info("Another ingestion run is in progress, skipping.")
+                Result.success()
+            } else {
+                try {
+                    block()
+                } finally {
+                    withContext(NonCancellable) { releaseAdvisoryLock(connection) }
+                }
+            }
+        }
+    }
+}
+
+private suspend fun tryAdvisoryLock(connection: TransactionConnection): Result<AppFailure.DatabaseError, Boolean> =
+    DatabaseSteps.query<Long, Boolean>(
+        sql = SafeSQL.select("SELECT pg_try_advisory_lock(?)"),
+        parameterSetter = { statement, key -> statement.setLong(1, key) },
+        resultMapper = { rs -> rs.next() && rs.getBoolean(1) },
+        transactionConnection = connection,
+    ).process(INGESTION_ADVISORY_LOCK_KEY)
+
+private suspend fun releaseAdvisoryLock(connection: TransactionConnection) {
+    DatabaseSteps.query<Long, Boolean>(
+        sql = SafeSQL.select("SELECT pg_advisory_unlock(?)"),
+        parameterSetter = { statement, key -> statement.setLong(1, key) },
+        resultMapper = { rs -> rs.next() && rs.getBoolean(1) },
+        transactionConnection = connection,
+    ).process(INGESTION_ADVISORY_LOCK_KEY).fold(
+        onSuccess = { released ->
+            if (!released) ingestionLogger.warn("Ingestion advisory lock $INGESTION_ADVISORY_LOCK_KEY was not held at release time.")
+        },
+        onFailure = { ingestionLogger.error("Failed to release ingestion advisory lock: $it") },
+    )
 }
 
 

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/minecraftfiles/IngestionAdvisoryLockTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/minecraftfiles/IngestionAdvisoryLockTest.kt
@@ -1,0 +1,105 @@
+package app.mcorg.pipeline.minecraftfiles
+
+import app.mcorg.config.Database
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.test.postgres.DatabaseTestExtension
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Proves the ingestion advisory lock serialises overlapping runs (MCO-169). Each call opens its own
+ * session, so the lock genuinely contends across connections.
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class IngestionAdvisoryLockTest {
+
+    /** Must match INGESTION_ADVISORY_LOCK_KEY in GetServerFilesPipeline.kt. */
+    private val key = 7331L
+
+    @Test
+    fun `runs the block and releases the lock when it is free`() {
+        var count = 0
+        val first = runBlocking { withIngestionLock { count++; Result.success() } }
+        assertIs<Result.Success<*>>(first)
+        assertEquals(1, count)
+
+        // The lock was released, so a second run executes too.
+        val second = runBlocking { withIngestionLock { count++; Result.success() } }
+        assertIs<Result.Success<*>>(second)
+        assertEquals(2, count)
+    }
+
+    @Test
+    fun `skips the block and returns success when another session holds the lock`() {
+        holdingLock {
+            var ran = false
+            val result = runBlocking { withIngestionLock { ran = true; Result.success() } }
+            assertIs<Result.Success<*>>(result)
+            assertFalse(ran, "block must not run while the lock is held by another session")
+        }
+    }
+
+    @Test
+    fun `releases the lock even when the block fails`() {
+        val failed = runBlocking { withIngestionLock { Result.failure(AppFailure.ApiError.UnknownError) } }
+        assertIs<Result.Failure<*>>(failed)
+
+        // If the lock had leaked, this would be skipped; instead it must run.
+        var ran = false
+        val next = runBlocking { withIngestionLock { ran = true; Result.success() } }
+        assertIs<Result.Success<*>>(next)
+        assertTrue(ran, "lock must be freed on the failure path")
+    }
+
+    @Test
+    fun `holds the lock for the duration of the block`() {
+        var unavailableToOthersDuringBlock: Boolean? = null
+        val result = runBlocking {
+            withIngestionLock {
+                unavailableToOthersDuringBlock = !tryLockOnNewSession()
+                Result.success()
+            }
+        }
+        assertIs<Result.Success<*>>(result)
+        assertEquals(true, unavailableToOthersDuringBlock, "other sessions must not acquire the lock during the block")
+        // And it is available again afterwards.
+        assertTrue(tryLockOnNewSession(), "lock should be free once the block has finished")
+    }
+
+    /** Opens a fresh session, tries the lock, and closes (releasing it if acquired). */
+    private fun tryLockOnNewSession(): Boolean =
+        Database.getConnection().use { conn ->
+            conn.prepareStatement("SELECT pg_try_advisory_lock(?)").use { stmt ->
+                stmt.setLong(1, key)
+                stmt.executeQuery().use { rs -> rs.next() && rs.getBoolean(1) }
+            }
+        }
+
+    /** Holds the lock on a dedicated session for the duration of [block], then releases it. */
+    private fun holdingLock(block: () -> Unit) {
+        val conn = Database.getConnection()
+        try {
+            conn.prepareStatement("SELECT pg_try_advisory_lock(?)").use { stmt ->
+                stmt.setLong(1, key)
+                stmt.executeQuery().use { rs -> assertTrue(rs.next() && rs.getBoolean(1), "precondition: should acquire the lock") }
+            }
+            block()
+        } finally {
+            conn.prepareStatement("SELECT pg_advisory_unlock(?)").use { stmt ->
+                stmt.setLong(1, key)
+                stmt.execute()
+            }
+            conn.close()
+        }
+    }
+}


### PR DESCRIPTION
## What

Step 4 of [MCO-165](https://linear.app/evegul/issue/MCO-165). Makes `executeServerFilesPipeline()` safe to invoke concurrently — overlapping triggers become silent no-ops instead of duplicate work. This is the guard that must be in place before MCO-170 adds a second invocation path (the CLI).

## How

`executeServerFilesPipeline()` is wrapped in `withIngestionLock { … }`:
- Opens a **dedicated** connection and runs `SELECT pg_try_advisory_lock(7331)` (any stable bigint; documented as `INGESTION_ADVISORY_LOCK_KEY`).
- **Lock busy** → logs "another ingestion run is in progress, skipping" and returns `Result.success()` without running the pipeline.
- **Lock acquired** → runs the pipeline, then releases with `pg_advisory_unlock` in a `finally`.

A dedicated connection is required because advisory locks are session-scoped and Hikari returns pooled connections between steps. Release runs under `NonCancellable`, so a cancelled run still frees the lock rather than leaking it on the pooled session. Failure to open the lock connection surfaces as `DatabaseError.ConnectionError`.

## Tests

`IngestionAdvisoryLockTest` (Testcontainers via `DatabaseTestExtension`), each call on its own session so the lock genuinely contends:
- runs the block + releases the lock when free (a second run also executes);
- skips the block and returns success when another session holds the lock;
- frees the lock on the block's **failure** path;
- lock is genuinely unavailable to other sessions for the block's duration, and free again after.

Full suite: **509 unit + 66 database**, green. `mvn clean compile` clean.

## Notes

- `7331` is arbitrary; the test references the same literal with a comment to keep them in sync.
- Built in an isolated worktree.

## Depends on

MCO-167 (merged) — the ledger writes are what the lock protects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)