### PR TITLE
chore(worktree): add local.env.example template with fallbacks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,8 +95,10 @@ the real ingested Minecraft data instantly (no re-ingestion) and matches CI exac
 - `webapp/local.env` is **gitignored**. The main checkout's copy is the single
   source for non-DB local config (Microsoft, Modrinth, `ENV`, …); the setup script
   writes each worktree's `local.env` fresh from it, swapping in the branch's Neon
-  `DB_*` values. Keep the main checkout's `local.env` current — a fresh clone has
-  none, and the script errors until you create it.
+  `DB_*` values. A fresh clone has no `local.env` — copy `webapp/local.env.example`
+  (the committed template) to create it; `run.sh` seeds it for you on first run, and
+  `worktree-db.sh` falls back to the template so worktrees provision even before the
+  main checkout's `local.env` exists.
 - **Migration number collisions are orthogonal to DB isolation.** If two branches
   each add `V{n}__*.sql` with the same `{n}`, Flyway errors on merge (out-of-order
   / checksum). Fix: renumber the later-merged migration to the next free number and

--- a/webapp/local.env.example
+++ b/webapp/local.env.example
@@ -1,0 +1,22 @@
+# Template for webapp/local.env (which is gitignored). Copy it:
+#   cp webapp/local.env.example webapp/local.env
+# then fill in the blanks below.
+#
+# Worktrees derive their own local.env from this template (or, preferably, from
+# the main checkout's local.env) and swap in per-branch Neon DB_* values
+# automatically — see webapp/scripts/worktree-db.sh.
+
+# Local Postgres. Password matches POSTGRES_PASSWORD in
+# webapp/docker-compose-local.yaml. (Worktrees override all three DB_* values.)
+DB_URL=jdbc:postgresql://localhost:5432/postgres
+DB_USER=postgres
+DB_PASSWORD=
+
+# Microsoft OAuth. Leave blank for local dev (SKIP_MICROSOFT_SIGN_IN=true).
+MICROSOFT_CLIENT_ID=
+MICROSOFT_CLIENT_SECRET=
+
+ENV=LOCAL
+SKIP_MICROSOFT_SIGN_IN=true
+
+MODRINTH_URL=https://staging-api.modrinth.com

--- a/webapp/scripts/run.sh
+++ b/webapp/scripts/run.sh
@@ -68,6 +68,12 @@ case "$ENV_NAME" in
 esac
 
 if [[ ! -f "$ENV_FILE" ]]; then
+    if [[ "$ENV_NAME" == "local" && -f "$WEBAPP_DIR/local.env.example" ]]; then
+        cp "$WEBAPP_DIR/local.env.example" "$ENV_FILE"
+        echo "Seeded $ENV_FILE from local.env.example."
+        echo "Set DB_PASSWORD (see docker-compose-local.yaml) and any other blanks, then re-run."
+        exit 1
+    fi
     echo "Environment file not found: $ENV_FILE"
     exit 1
 fi

--- a/webapp/scripts/worktree-db.sh
+++ b/webapp/scripts/worktree-db.sh
@@ -86,8 +86,12 @@ JDBC_URL="jdbc:postgresql://${DB_HOST}/${DB_NAME}?sslmode=require"
 # branch's Neon credentials. The script fully owns the worktree's local.env.
 MAIN_ENV="$MAIN_REPO/webapp/local.env"
 if [ ! -f "$MAIN_ENV" ]; then
-  echo "worktree-db: $MAIN_ENV not found — create it in the main checkout first." >&2
-  echo "worktree-db: (it holds the non-DB local config that worktrees inherit.)" >&2
+  # Fresh clone with no local.env yet — fall back to the committed template so
+  # worktrees still get the non-DB config (DB_* lines are stripped below anyway).
+  MAIN_ENV="$MAIN_REPO/webapp/local.env.example"
+fi
+if [ ! -f "$MAIN_ENV" ]; then
+  echo "worktree-db: no local.env or local.env.example in $MAIN_REPO/webapp." >&2
   exit 1
 fi
 {


### PR DESCRIPTION
Hardens the worktree-DB setup against the missing-`local.env` trap.

## Why

Gitignoring `local.env` (#276) had an edge: once `master` advanced past the
deletion, git removed the main checkout's working copy, and a fresh clone never
had one — so `worktree-db.sh` errored with no base file to derive from.

## Changes

- **`webapp/local.env.example`** — committed template (non-DB config + blank
  Microsoft fields; `DB_PASSWORD` blank, matches `docker-compose-local.yaml`).
  Placeholders only, no real credentials.
- **`worktree-db.sh`** — falls back to `local.env.example` when the main checkout
  has no `local.env` yet, so worktrees provision on a fresh clone. (DB_* lines are
  stripped and replaced with the branch's Neon values regardless.)
- **`run.sh`** — seeds `local.env` from the template on first run (local env),
  prompting to set `DB_PASSWORD`.
- **CLAUDE.md** — documents the template + fallbacks.

## Testing

- Both scripts pass `bash -n`.
- Verified the strip logic against the template (non-DB lines pass through; DB_*
  excluded).
- Auto-firing confirmed end-to-end: this branch's worktree was provisioned by the
  live `EnterWorktree` hooks (JWT keys + Neon branch + `local.env`).

No application source changed — `compile`/`test` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)