### PR TITLE
feat(ingestion): add a CLI entry point that runs ingestion outside Ktor (MCO-170)

### DIFF
--- a/webapp/mc-web/pom.xml
+++ b/webapp/mc-web/pom.xml
@@ -104,6 +104,25 @@
                 <configuration>
                     <mainClass>${main.class}</mainClass>
                 </configuration>
+                <executions>
+                    <!--
+                      Standalone ingestion entry point (MCO-170): runs the server-files pipeline
+                      once and exits, no Ktor server. Invoke with:
+                        mvn -pl mc-web exec:java@ingest-server-files
+                      The jar-with-dependencies artifact also bundles this class, so the Fly machine
+                      (MCO-171) can run it directly:
+                        java -cp mc-web-*-jar-with-dependencies.jar app.mcorg.cli.IngestServerFilesKt
+                    -->
+                    <execution>
+                        <id>ingest-server-files</id>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                        <configuration>
+                            <mainClass>app.mcorg.cli.IngestServerFilesKt</mainClass>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/cli/IngestServerFiles.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/cli/IngestServerFiles.kt
@@ -1,0 +1,63 @@
+package app.mcorg.cli
+
+import app.mcorg.config.Database
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.minecraftfiles.executeServerFilesPipeline
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import kotlin.system.exitProcess
+
+private val logger = LoggerFactory.getLogger("app.mcorg.cli.IngestServerFiles")
+
+/**
+ * Standalone entry point that runs server-files ingestion once and exits — no Ktor server, no
+ * routing, no listeners (MCO-170). This is the process the scheduled Fly machine in MCO-171 will
+ * invoke. It shares the `mc-web` classpath, so it reuses the same [Database] pool,
+ * [app.mcorg.config.AppConfig] env loading, the Mojang HTTP provider, and the
+ * advisory-lock-guarded [executeServerFilesPipeline].
+ */
+fun main() {
+    val exitCode = runBlocking {
+        runIngestion(
+            pipeline = { executeServerFilesPipeline() },
+            shutdown = { Database.shutdown() },
+        )
+    }
+    exitProcess(exitCode)
+}
+
+/**
+ * Runs [pipeline] and maps its outcome to a process exit code, always calling [shutdown] afterwards
+ * (so the Hikari pool is released and the JVM can exit promptly instead of lingering on idle pool
+ * threads). Extracted from [main] so the exit-code mapping is unit-testable without terminating the
+ * JVM via `exitProcess`.
+ *
+ * Exit codes:
+ * - `0` — success, including the no-op case where another run already holds the advisory lock.
+ * - `1` — the pipeline returned a [Result.Failure].
+ * - `2` — an unexpected throwable escaped the pipeline.
+ */
+internal suspend fun runIngestion(
+    pipeline: suspend () -> Result<AppFailure, Unit>,
+    shutdown: () -> Unit,
+): Int {
+    return try {
+        logger.info("Starting standalone server-files ingestion")
+        when (val result = pipeline()) {
+            is Result.Success -> {
+                logger.info("Server-files ingestion completed successfully")
+                0
+            }
+            is Result.Failure -> {
+                logger.error("Server-files ingestion failed: ${result.error}")
+                1
+            }
+        }
+    } catch (e: Throwable) {
+        logger.error("Unexpected error during server-files ingestion", e)
+        2
+    } finally {
+        shutdown()
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/cli/IngestServerFilesTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/cli/IngestServerFilesTest.kt
@@ -1,0 +1,55 @@
+package app.mcorg.cli
+
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.failure.AppFailure
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for the standalone ingestion entry point's exit-code mapping (MCO-170). The real
+ * pipeline (DB + HTTP) is covered elsewhere; here we only assert how outcomes become exit codes and
+ * that the pool is always shut down.
+ */
+class IngestServerFilesTest {
+
+    @Test
+    fun `success maps to exit code 0`() {
+        var shutdownCalled = false
+        val code = runBlocking {
+            runIngestion(
+                pipeline = { Result.Success(Unit) },
+                shutdown = { shutdownCalled = true },
+            )
+        }
+        assertEquals(0, code)
+        assertTrue(shutdownCalled, "shutdown must run after a successful pipeline")
+    }
+
+    @Test
+    fun `pipeline failure maps to exit code 1`() {
+        var shutdownCalled = false
+        val code = runBlocking {
+            runIngestion(
+                pipeline = { Result.Failure(AppFailure.DatabaseError.ConnectionError) },
+                shutdown = { shutdownCalled = true },
+            )
+        }
+        assertEquals(1, code)
+        assertTrue(shutdownCalled, "shutdown must run after a failed pipeline")
+    }
+
+    @Test
+    fun `unexpected throwable maps to exit code 2`() {
+        var shutdownCalled = false
+        val code = runBlocking {
+            runIngestion(
+                pipeline = { throw IllegalStateException("boom") },
+                shutdown = { shutdownCalled = true },
+            )
+        }
+        assertEquals(2, code)
+        assertTrue(shutdownCalled, "shutdown must run even when the pipeline throws")
+    }
+}


### PR DESCRIPTION
## What

Adds `app.mcorg.cli.IngestServerFilesKt.main()` — a standalone entry point that runs the advisory-lock-guarded `executeServerFilesPipeline()` once and exits. **No Ktor server, no routing, no Netty listener.** This is the process the scheduled Fly machine (MCO-171) will execute.

## How

- **`IngestServerFiles.kt`** — `main()` runs the pipeline under `runBlocking`, maps the outcome to an exit code, and always shuts down the Hikari pool so the JVM exits promptly. It reuses the existing `mc-web` classpath: same `Database` pool, `AppConfig` env loading, and the Mojang HTTP provider (Ktor **client** / CIO — not the server engine).
  - Exit codes: `0` success (including the no-op when another run already holds the advisory lock), `1` pipeline `Result.Failure`, `2` unexpected throwable.
  - The exit-code mapping is extracted into `internal suspend fun runIngestion(pipeline, shutdown)` so it's unit-testable without terminating the JVM via `exitProcess`.
- **`pom.xml`** — a named `exec-maven-plugin` execution so it runs via Maven:
  ```
  mvn -pl mc-web exec:java@ingest-server-files
  ```
  The existing `jar-with-dependencies` artifact already bundles this class, so MCO-171's Fly machine can launch it directly with `java -cp mc-web-*-jar-with-dependencies.jar app.mcorg.cli.IngestServerFilesKt`. The web default (`ApplicationKt`) is untouched.
- **`IngestServerFilesTest.kt`** — unit tests for all three exit codes and that `shutdown` always runs (including when the pipeline throws).

## Verification

- `mvn -pl mc-web test` — **512 tests pass**, including the 3 new ones.
- **Local smoke test** against an isolated Neon branch: fetched the Mojang manifest, resolved per-version metadata, filtered against the ledger (everything up-to-date → no re-ingestion), exited `0`.
- **No Netty in the logs** — the run loads `io.ktor.client` (CIO, required for the Mojang fetch) but never the embedded server. Note: the acceptance criterion's "no Ktor classes" is interpreted as its parenthetical intent — *absence of Netty / no HTTP listener*; the Ktor HTTP **client** is unavoidable since the pipeline fetches from Mojang.

## Scope

This only adds the invocation path. Removing `SchedulingPlugin` and wiring the Fly scheduled machine is **MCO-171**.

## Depends on

MCO-169 (advisory lock) — merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)