### PR TITLE
fix(ingestion): resolve the deploy image correctly in ingest-machine.sh

### DIFF
--- a/webapp/scripts/ingest-machine.sh
+++ b/webapp/scripts/ingest-machine.sh
@@ -59,16 +59,23 @@ case "${1:-}" in
 esac
 
 # Resolve the exact image the app is currently running so the CLI runs identical
-# code to the deployed web process. Falls back to a manual hint if jq/parsing
-# fails — copy the Ref from `fly image show -a mcorg`.
-echo "Resolving current image for app '$APP'..."
-IMAGE="$(fly image show -a "$APP" --json 2>/dev/null | jq -r '.Ref // empty')"
-if [[ -z "$IMAGE" ]]; then
-  echo "Could not auto-resolve the image. Run 'fly image show -a $APP', then re-run with:"
-  echo "  IMAGE=<ref> $0 ${1:-}"
-  IMAGE="${IMAGE:?IMAGE not set}"
+# code to the deployed web process. Honors a manual `IMAGE=<ref>` override; else
+# pins the deployed image by digest from `fly image show --json`, which returns
+# an ARRAY of {Registry, Repository, Tag, Digest} (e.g. the image lives on GHCR:
+# ghcr.io/evengul/mc-org@sha256:...). Pinning by digest is immutable, unlike Tag.
+if [[ -n "${IMAGE:-}" ]]; then
+  echo "Using image from \$IMAGE override: $IMAGE"
+else
+  echo "Resolving current image for app '$APP'..."
+  IMAGE="$(fly image show -a "$APP" --json 2>/dev/null \
+    | jq -r 'first | .Registry + "/" + .Repository + "@" + .Digest')"
+  if [[ -z "$IMAGE" || "$IMAGE" == *null* ]]; then
+    echo "Could not auto-resolve the image. Run 'fly image show -a $APP', then re-run with:"
+    echo "  IMAGE=<registry>/<repository>@<digest> $0 ${1:-}"
+    exit 1
+  fi
+  echo "Using image: $IMAGE"
 fi
-echo "Using image: $IMAGE"
 
 if [[ "$MODE" == "once" ]]; then
   echo "Running a one-off ingestion (immediate, then destroyed)..."


### PR DESCRIPTION
## Problem

`./webapp/scripts/ingest-machine.sh` (added in #282) failed on first real use:

```
Resolving current image for app 'mcorg'...
jq: error (at <stdin>:11): Cannot index array with string "Ref"
```

Two wrong assumptions in the original image resolver:
- `fly image show --json` returns a **JSON array** of `{Registry, Repository, Tag, Digest}`, not an object — so `jq -r '.Ref'` errored.
- The deployed image lives on **GHCR** (`ghcr.io/evengul/mc-org@sha256:…`), not Fly's registry.

The error also hard-blocked the script (`${IMAGE:?}`), even overriding a manually-set `IMAGE`.

## Fix

- Resolve via `first | .Registry + "/" + .Repository + "@" + .Digest` — pins the **exact deployed image by digest** (immutable, unlike the tag).
- Honor a manual `IMAGE=<ref> ./ingest-machine.sh` override so it never hard-blocks again; clean `exit 1` with a usage hint if auto-resolution genuinely fails.

## Verification

Ran the new `jq` against the real `fly image show -a mcorg --json` output → resolves to:
```
ghcr.io/evengul/mc-org@sha256:ed8b06676d64ec73a625d4a9f6bb928d6608f3464c307d3bedd767439d29a064
```
`bash -n` syntax-checked.

Follow-up to #282 (MCO-171).

🤖 Generated with [Claude Code](https://claude.com/claude-code)