### PR TITLE
ci(ingestion): auto-(re)create the scheduled ingestion machine on every prod deploy (MCO-175)

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -92,3 +92,25 @@ jobs:
       - run: flyctl deploy --image ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      # Ingestion runs as its own Fly scheduled machine (MCO-171), not in the
+      # web process. A scheduled machine is pinned to the image it was created
+      # with and is NOT reconciled by `flyctl deploy`, so we recreate it here on
+      # every deploy to keep it tracking the just-deployed image. Destroy is by a
+      # stable name and idempotent, so re-runs replace rather than duplicate.
+      # DB_PASSWORD is an app-level Fly secret and is injected automatically.
+      - name: (Re)create scheduled ingestion machine
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: |
+          flyctl machine list -a mcorg --json \
+            | jq -r '.[] | select(.name=="ingest-scheduler") | .id' \
+            | xargs -r -n1 flyctl machine destroy -a mcorg --force
+          flyctl machine run ghcr.io/${{ github.repository }}:sha-${{ github.sha }} \
+            --app mcorg --name ingest-scheduler \
+            --region arn --schedule daily --restart no --vm-memory 1024 \
+            --entrypoint "java -Xmx768m -cp /app/mcorg.jar app.mcorg.cli.IngestServerFilesKt" \
+            --env DB_URL="${{ vars.DB_URL }}" \
+            --env DB_USER="${{ vars.DB_USER }}" \
+            --env ENV=PRODUCTION \
+            --env SKIP_MICROSOFT_SIGN_IN=true

--- a/webapp/scripts/ingest-machine.sh
+++ b/webapp/scripts/ingest-machine.sh
@@ -60,18 +60,20 @@ esac
 
 # Resolve the exact image the app is currently running so the CLI runs identical
 # code to the deployed web process. Honors a manual `IMAGE=<ref>` override; else
-# pins the deployed image by digest from `fly image show --json`, which returns
-# an ARRAY of {Registry, Repository, Tag, Digest} (e.g. the image lives on GHCR:
-# ghcr.io/evengul/mc-org@sha256:...). Pinning by digest is immutable, unlike Tag.
+# pins the deployed image by TAG from `fly image show --json`, which returns an
+# ARRAY of {Registry, Repository, Tag, Digest} (the image lives on GHCR, e.g.
+# ghcr.io/evengul/mc-org:sha-<commit>). We use the tag rather than the digest:
+# `fly machine run` fails to launch from a cross-registry `@sha256:...` digest
+# ref ("could not launch machine") but launches fine from the tag.
 if [[ -n "${IMAGE:-}" ]]; then
   echo "Using image from \$IMAGE override: $IMAGE"
 else
   echo "Resolving current image for app '$APP'..."
   IMAGE="$(fly image show -a "$APP" --json 2>/dev/null \
-    | jq -r 'first | .Registry + "/" + .Repository + "@" + .Digest')"
+    | jq -r 'first | .Registry + "/" + .Repository + ":" + .Tag')"
   if [[ -z "$IMAGE" || "$IMAGE" == *null* ]]; then
     echo "Could not auto-resolve the image. Run 'fly image show -a $APP', then re-run with:"
-    echo "  IMAGE=<registry>/<repository>@<digest> $0 ${1:-}"
+    echo "  IMAGE=<registry>/<repository>:<tag> $0 ${1:-}"
     exit 1
   fi
   echo "Using image: $IMAGE"


### PR DESCRIPTION
## Problem

The ingestion scheduled machine (MCO-171) was created by hand via `fly machine run --schedule`. It's **pinned to the image it was created with** and is **not** part of the `app` process group that `flyctl deploy` reconciles — so after any prod deploy it keeps running the **old** image, **silently**, until someone recreates it by hand.

## Changes

**`.github/workflows/prod.yml`** — after `flyctl deploy`, a new step destroys the previous ingest machine (found by the stable name `ingest-scheduler`; idempotent) and recreates it pinned to the just-built `sha-${{ github.sha }}` image:

```yaml
flyctl machine list -a mcorg --json \
  | jq -r '.[] | select(.name=="ingest-scheduler") | .id' \
  | xargs -r -n1 flyctl machine destroy -a mcorg --force
flyctl machine run ghcr.io/${{ github.repository }}:sha-${{ github.sha }} \
  --app mcorg --name ingest-scheduler --region arn --schedule daily --restart no ...
```

Result: the scheduler **always tracks the latest deploy**, zero manual steps. Uses the existing `vars.DB_URL`/`vars.DB_USER` (same as the Flyway step); `DB_PASSWORD` is an app-level Fly secret, injected automatically.

**`webapp/scripts/ingest-machine.sh`** — resolve the image by **tag**, not digest. In practice a cross-registry `@sha256:…` digest ref fails to launch (*"could not launch machine"*) while the tag ref launches fine (confirmed live). The script remains the manual / one-off (`--once`) escape hatch.

## Verification

- `bash -n` on the script; `jq` resolver checked against real `fly image show` output → `ghcr.io/evengul/mc-org:sha-<commit>`.
- `prod.yml` parses as valid YAML.
- A live one-off run already succeeded against prod (correctly hit the MCO-168 skip path), so the CLI + image + env combination is proven; this PR only changes *which ref* and *who creates the machine*.

## Note on rollout

`prod.yml`'s `paths:` filter only triggers on `src/**` / pom / Dockerfile changes — so **merging this PR does not itself trigger a prod deploy**, and the `ingest-scheduler` machine won't be created until the next deploy caused by an app-code change. To activate it immediately, trigger a prod deploy (any qualifying change, or a manual `flyctl deploy`). Until then, there's no scheduled machine running — which is fine, since we deliberately didn't hand-create one knowing it'd go stale.

Relates to MCO-171. Parent epic MCO-165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)