### PR TITLE
feat(ui): rework palette to "Daylight Field Notebook" (Overworld)

### DIFF
--- a/.claude/skills/docs-frontend/SKILL.md
+++ b/.claude/skills/docs-frontend/SKILL.md
@@ -7,7 +7,7 @@ user-invocable: false
 # Frontend Implementation Reference
 
 How to build UI in MC-ORG's "technical field notebook" design system. Server-side rendered Kotlin HTML
-DSL + HTMX, dark-only.
+DSL + HTMX. Light "paper" theme — the "Daylight Field Notebook" Overworld palette (warm paper + sepia ink).
 
 **This skill = how to write it** (DSL function names, CSS class names, tokens that actually exist in code).
 For the *why* — visual spec, motion, mobile rules, design rationale — load `docs-product`.
@@ -55,9 +55,11 @@ GET handlers return a full `pageShell { }`. Mutating handlers (POST/PUT/PATCH/DE
 
 Defined in `design-tokens.css`. Never hardcode hex, px, or font names — always `var(--token)`.
 
-**Color:** `--bg-base` `--bg-surface` `--bg-raised` `--border` · `--text-primary` `--text-muted`
-`--text-disabled` · `--accent` `--accent-muted` · `--green` `--amber` `--red` · `--progress`
-`--green-bg` `--red-bg`
+**Color:** `--bg-base` `--bg-surface` `--bg-raised` `--border` `--border-strong` · `--text-primary`
+`--text-muted` `--text-disabled` · `--accent` (lapis — act/links) `--accent-hover` `--accent-muted` (info
+wash + badges + focus ring) `--on-accent` (cream text on an accent fill) · `--green` (done) `--amber` (warn)
+`--red` (danger) · `--progress` `--green-bg` `--red-bg`. **One hue, one role** — see `docs-product` for the
+full palette map and the load-bearing colour-blind constraint (never signal state by colour alone).
 
 **Fonts:** `--font-ui` (IBM Plex Mono — chrome, headings, badges, labels, buttons) ·
 `--font-body` (Inter — body text, table cells, prose)
@@ -290,8 +292,10 @@ table(classes = "data-table") {
 }
 ```
 
-For a callout, emit the `.callout` structure directly (left-border notice; `.callout--info` for the accent
-variant). If a reusable DSL helper is worth adding, build it against these classes.
+For a callout, emit the `.callout` structure directly (left-border notice). Variants: default = warning
+(amber + ⚠), `.callout--error` (redstone + ✕), `.callout--success` (grass + ✓), `.callout--info` (the
+"quiet lapis" — lapis rule + ⓘ, our info treatment). If a reusable DSL helper is worth adding, build it
+against these classes.
 
 ---
 

--- a/.claude/skills/docs-product/SKILL.md
+++ b/.claude/skills/docs-product/SKILL.md
@@ -24,25 +24,62 @@ The system must scale between "tap a counter on your phone while mining" and "sc
 
 All colors are CSS variables. Never use hardcoded hex values.
 
+The palette is **"Daylight Field Notebook" (Overworld)** — a warm paper + sepia-ink
+substrate drawn from the overworld's dirt/sand/wood, with accents borrowed from
+overworld materials. It is a **light** theme (there is currently no dark theme).
+
 | Role | Token | Hex |
 |------|-------|-----|
-| Page background | `--bg-base` | `#0F1117` |
-| Cards, panels | `--bg-surface` | `#181C27` |
-| Table rows hover, inputs | `--bg-raised` | `#1F2435` |
-| Dividers, table borders | `--border` | `#2A2F42` |
-| Body, headings | `--text-primary` | `#E8EAF0` |
-| Labels, metadata | `--text-muted` | `#6E748A` |
-| Done items, dimmed content | `--text-disabled` | `#3C4158` |
-| CTAs, active toggle, links | `--accent` | `#4A7CFF` |
-| Accent backgrounds, badges | `--accent-muted` | `#1E2D5C` |
-| Completed resources, done badges | `--green` | `#3DBA7A` |
-| Partial block notices, warnings | `--amber` | `#E8A225` |
-| Destructive actions | `--red` | `#E05252` |
-| Progress bar fill | `--progress` | `#4A7CFF` |
-| Done badge background | `--green-bg` | `#1C3828` |
-| Blocked badge background | `--red-bg` | `#3A1E1E` |
+| Page edge / app background (sand·dirt) | `--bg-base` | `#EBE1C8` |
+| Page surface — cards, panels (paper) | `--bg-surface` | `#F7F0DE` |
+| Raised — inputs, row hover, badges | `--bg-raised` | `#FCF7EA` |
+| Rule lines, dividers, borders | `--border` | `#D6C6A2` |
+| Emphasized rule (hover/focus border) | `--border-strong` | `#C2AE82` |
+| Body, headings (sepia ink) | `--text-primary` | `#2A2218` |
+| Labels, metadata (faded ink) | `--text-muted` | `#7A6B47` |
+| Done items, dimmed content | `--text-disabled` | `#A99B78` |
+| **CTA, active toggle, links — "act" (lapis)** | `--accent` | `#2C6E9E` |
+| CTA hover | `--accent-hover` | `#245C85` |
+| Accent wash — info callout, badges, focus ring | `--accent-muted` | `#D6E2EC` |
+| Text/icon on an accent fill (cream) | `--on-accent` | `#FCF7EA` |
+| **Success / status / progress — "done" (grass)** | `--green` | `#4F7A2B` |
+| **Warning (wheat-gold)** | `--amber` | `#B0791A` |
+| **Danger / destructive (redstone)** | `--red` | `#A6321F` |
+| Progress bar fill (grass) | `--progress` | `#4F7A2B` |
+| Done badge background | `--green-bg` | `#DEE8CB` |
+| Blocked badge background | `--red-bg` | `#F0DACF` |
 
-Dark theme only. Light theme is Phase 3.
+### Role discipline — one hue, one job
+
+Every accent hue maps to **exactly one role**. This is what keeps the UI from
+reading as generic SaaS, and it is enforced:
+
+| Overworld material | Token(s) | Job |
+|--------------------|----------|-----|
+| Sand · dirt · wood | `--bg-*`, `--border*`, `--text-*` | Substrate: surfaces, rules, ink. **Brown is structural, never an accent.** |
+| Lapis (sky·water) | `--accent`, `--accent-muted` | **Act**: primary/CTA, links, active states — and **info** (the quiet `--accent-muted` wash) |
+| Grass · emerald | `--green`, `--progress` | **Done**: success, status, progress |
+| Wheat-gold | `--amber` | Warning |
+| Redstone | `--red` | Danger |
+
+Rules that follow from this:
+
+- **Secondary actions are not a second colour** — they're ink-on-paper
+  (`.btn--secondary`: raised surface + border + ink). Resist colored secondary buttons.
+- **Info is the *quiet* lapis**, not a new hue (we are out of colour-blind-safe hues):
+  pale `--accent-muted` wash + ⓘ icon. Solid lapis = act, pale lapis = inform.
+- **Primary (lapis) vs success (grass) are separated by hue**, so a CTA never reads
+  as "done"; primary vs status badge are further separated by fill-vs-tint.
+
+### Colour-blind constraint (load-bearing — the primary user is red-green colour-blind)
+
+- The **only reliably distinguishable axis is blue↔yellow**. The act and status
+  anchors (lapis, gold) live on it deliberately. Red/orange/brown/green all collapse
+  together — which is why the CTA is **lapis, not copper/green** (copper read as red and
+  collided with danger).
+- **Never convey state by colour alone.** Success/warning/danger must *also* carry an
+  icon or text label. Status badges already do this (they are text-labelled); callouts
+  carry an icon. Honour this in any new component.
 
 ---
 
@@ -92,7 +129,7 @@ Most-used interactive element. Must look intentional, not like a form control.
 
 - Pill shape, 2 segments, **fixed width** — not content-derived (no layout shift on toggle)
 - Inactive: `--bg-raised` background, `--text-muted` text
-- Active: `--accent` background, white text
+- Active: `--accent` background, `--on-accent` text
 - Text: IBM Plex Mono, 12px, uppercase (`PLAN` / `EXEC`)
 - Position: top-right of project detail header on desktop; inline in mobile header
 - Transition: 150ms ease-in-out on background + text color
@@ -169,7 +206,8 @@ Used for partial dependency notices and inline warnings. **Not a banner. Not ful
 - Padding: `--space-3` / `--space-4`
 - IBM Plex Mono `⚠` in amber, then Inter body text
 - CSS: `.callout`, `.callout__icon`, `.callout__body`
-- Info variant: `.callout--info` (accent color instead of amber)
+- Info variant: `.callout--info` (lapis `--accent` rule + ⓘ icon — the "quiet lapis")
+- Success variant: `.callout--success` (`--green` rule + ✓ icon)
 
 ### Navigation Header
 
@@ -186,7 +224,7 @@ CSS: `.app-header`, `.breadcrumb`, `.breadcrumb__item`, `.breadcrumb__item--curr
 ### Project Card (Project List)
 
 - Background: `--bg-surface`, border: `--border`, border-radius: `--radius`
-- Hover: border-color `#3a4060`, background `--bg-raised`
+- Hover: border-color `--border-strong`, background `--bg-raised`
 - Project name: IBM Plex Mono, `--text-base`, weight 600
 - Meta: IBM Plex Mono, `--text-xs`, `--text-muted`
 - CSS: `.project-card`, `.project-card__header`, `.project-card__name`, `.project-card__meta`
@@ -281,3 +319,14 @@ These rules apply to every UI implementation without exception:
 - Status badges text-only — no icons inside badges
 - Warning callouts left-border only — never full-width banners
 - Mobile minimum tap target: 36px for counter buttons, 44px for primary actions
+- Each accent hue keeps one role: lapis = act/info, grass = done, gold = warn, redstone = danger, brown = structure
+- Never convey state by colour alone — success/warning/danger also carry an icon or text label (the primary user is red-green colour-blind)
+
+---
+
+## Living Reference
+
+A static gallery of every component on the live tokens lives at
+**`/static/styleguide.html`** (no auth). Use it to eyeball palette/token changes
+in one place before rolling them across real pages. Source:
+`static/styleguide.html` + `static/styles/pages/styleguide.css`.

--- a/webapp/mc-web/src/main/resources/static/styleguide.html
+++ b/webapp/mc-web/src/main/resources/static/styleguide.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<!--
+  STYLEGUIDE — living component gallery / design-system reference.
+  A static kitchen-sink of the real component classes on the live design
+  tokens, for judging UI and token changes in one place. Not a route —
+  served statically at /static/styleguide.html (no auth required).
+-->
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>MC-ORG — palette test</title>
+    <link rel="stylesheet" href="/static/styles/reset.css">
+    <link rel="stylesheet" href="/static/styles/design-tokens.css">
+    <link rel="stylesheet" href="/static/styles/components/btn.css">
+    <link rel="stylesheet" href="/static/styles/components/badge.css">
+    <link rel="stylesheet" href="/static/styles/components/callout.css">
+    <link rel="stylesheet" href="/static/styles/components/progress.css">
+    <link rel="stylesheet" href="/static/styles/components/project-card.css">
+    <link rel="stylesheet" href="/static/styles/components/section.css">
+    <link rel="stylesheet" href="/static/styles/components/page-heading.css">
+    <link rel="stylesheet" href="/static/styles/components/tabs.css">
+    <link rel="stylesheet" href="/static/styles/components/form.css">
+    <link rel="stylesheet" href="/static/styles/pages/styleguide.css">
+</head>
+<body>
+    <div class="container">
+        <div class="page-heading">
+            <h1 class="page-heading__title">Palette test — world-keeper's logbook</h1>
+            <p class="page-heading__subtitle">
+                Real components on the live design tokens — a reference for judging future UI changes.
+                Roles: lapis = act/links, grass = done, gold = warn, redstone = danger, dirt = structure.
+            </p>
+        </div>
+
+        <!-- ============================ TOKENS ============================ -->
+        <section class="sg-section">
+            <h2>Tokens &amp; roles</h2>
+            <p>Each colour has one job. The blue↔yellow anchors (lapis, gold) stay distinct under red-green colour vision; green/red states are reinforced with icons, never colour alone.</p>
+            <div class="sg-swatches">
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-accent"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">CTA / links — act</span><span class="sg-swatch__token">--accent</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-accent-hover"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">CTA hover</span><span class="sg-swatch__token">--accent-hover</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-accent-muted"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">Quiet lapis / info</span><span class="sg-swatch__token">--accent-muted</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-green"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">Success / status — done</span><span class="sg-swatch__token">--green</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-amber"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">Warning</span><span class="sg-swatch__token">--amber</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-red"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">Danger</span><span class="sg-swatch__token">--red</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-progress"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">Progress fill</span><span class="sg-swatch__token">--progress</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-bg-base"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">Page edge</span><span class="sg-swatch__token">--bg-base</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-bg-surface"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">Page surface</span><span class="sg-swatch__token">--bg-surface</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-bg-raised"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">Raised / input</span><span class="sg-swatch__token">--bg-raised</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-border"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">Rule line</span><span class="sg-swatch__token">--border</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-border-strong"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">Rule (hover)</span><span class="sg-swatch__token">--border-strong</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-text-primary"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">Ink</span><span class="sg-swatch__token">--text-primary</span></div></div>
+                <div class="sg-swatch"><div class="sg-swatch__chip sw-text-muted"></div><div class="sg-swatch__meta"><span class="sg-swatch__role">Faded ink</span><span class="sg-swatch__token">--text-muted</span></div></div>
+            </div>
+        </section>
+
+        <!-- ============================ BUTTONS ============================ -->
+        <section class="sg-section">
+            <h2>Buttons</h2>
+            <p>Primary = solid lapis fill. Secondary = ink-on-paper (no colour). Lapis is deliberately distinct in hue from the redstone danger button.</p>
+            <div class="sg-row">
+                <button class="btn btn--primary">Plan build</button>
+                <button class="btn btn--secondary">Cancel</button>
+                <button class="btn btn--ghost">Skip</button>
+                <button class="btn btn--danger">Delete world</button>
+                <button class="btn btn--primary" disabled>Disabled</button>
+            </div>
+            <div class="sg-row mt-4">
+                <button class="btn btn--primary btn--sm">Small primary</button>
+                <button class="btn btn--secondary btn--sm">Small secondary</button>
+                <button class="btn btn--danger btn--sm">Small danger</button>
+            </div>
+        </section>
+
+        <!-- ============================ BADGES ============================ -->
+        <section class="sg-section">
+            <h2>Badges</h2>
+            <p>Status pills. In-progress borrows the quiet lapis; done is grass; blocked is redstone.</p>
+            <div class="sg-row">
+                <span class="badge badge--neutral">Neutral</span>
+                <span class="badge badge--status">Status</span>
+                <span class="badge badge--not-started">Not started</span>
+                <span class="badge badge--in-progress">In progress</span>
+                <span class="badge badge--done">Done</span>
+                <span class="badge badge--blocked">Blocked</span>
+            </div>
+        </section>
+
+        <!-- ============================ CALLOUTS ============================ -->
+        <section class="sg-section">
+            <h2>Callouts</h2>
+            <p>Info uses the quiet lapis (pale rule + ⓘ icon). Success / warning / danger each carry an icon as well as colour, so the state survives red-green colour vision.</p>
+            <div class="sg-stack">
+                <div class="callout callout--info">
+                    <span class="callout__icon">&#9432;</span>
+                    <div class="callout__body"><p><strong>Info.</strong> Resource graph last rebuilt 3 minutes ago.</p></div>
+                </div>
+                <div class="callout callout--success">
+                    <span class="callout__icon">&#10003;</span>
+                    <div class="callout__body"><p><strong>Success.</strong> Roadmap generated for 12 projects.</p></div>
+                </div>
+                <div class="callout">
+                    <span class="callout__icon">&#9888;</span>
+                    <div class="callout__body"><p><strong>Warning.</strong> Two recipes have unresolved ingredients.</p></div>
+                </div>
+                <div class="callout callout--error">
+                    <span class="callout__icon">&#10007;</span>
+                    <div class="callout__body"><p><strong>Danger.</strong> Could not reach the data server.</p></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- ============================ PROGRESS ============================ -->
+        <section class="sg-section">
+            <h2>Progress</h2>
+            <p>Completion bars use the grass/status fill; a fully complete bar uses the brighter complete green.</p>
+            <div class="sg-stack">
+                <div class="progress sg-w-35"><div class="progress__fill"></div></div>
+                <div class="progress sg-w-70"><div class="progress__fill"></div></div>
+                <div class="progress sg-w-100"><div class="progress__fill progress__fill--complete"></div></div>
+            </div>
+        </section>
+
+        <!-- ============================ CARDS ============================ -->
+        <section class="sg-section">
+            <h2>Project cards</h2>
+            <p>A realistic composite — name, status badge, progress, next-task hint, actions.</p>
+            <div class="sg-grid">
+                <div class="project-card">
+                    <div class="project-card__header">
+                        <a class="project-card__name" href="#">Iron farm</a>
+                        <span class="badge badge--in-progress">In progress</span>
+                    </div>
+                    <div class="project-card__meta">Overworld &middot; 4 stacks iron required</div>
+                    <div>
+                        <div class="project-card__resource-header">
+                            <span class="project-card__next-task-label">Resources</span>
+                            <span class="project-card__tasks">70%</span>
+                        </div>
+                        <div class="progress sg-w-70"><div class="progress__fill"></div></div>
+                    </div>
+                    <p class="project-card__next-task"><span class="project-card__next-task-label">Next</span> Smelt 32 iron ingots</p>
+                    <div class="sg-row">
+                        <button class="btn btn--primary btn--sm">Open</button>
+                        <button class="btn btn--ghost btn--sm">Mark done</button>
+                    </div>
+                </div>
+                <div class="project-card project-card--done">
+                    <div class="project-card__header">
+                        <a class="project-card__name" href="#">Cobblestone generator</a>
+                        <span class="badge badge--done">Done</span>
+                    </div>
+                    <div class="project-card__meta">Overworld &middot; complete</div>
+                    <div>
+                        <div class="project-card__resource-header">
+                            <span class="project-card__next-task-label">Resources</span>
+                            <span class="project-card__tasks">100%</span>
+                        </div>
+                        <div class="progress sg-w-100"><div class="progress__fill progress__fill--complete"></div></div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- ============================ FORM ============================ -->
+        <section class="sg-section">
+            <h2>Form controls</h2>
+            <p>Focus rings, hover borders, and the checked/invalid states all draw from the tokens — worth checking on paper.</p>
+            <div class="wizard-fields sg-stack">
+                <div>
+                    <label>Project name</label>
+                    <input class="form-control" type="text" value="Iron farm">
+                </div>
+                <div>
+                    <label>Dimension</label>
+                    <select class="form-control">
+                        <option>Overworld</option>
+                        <option>Nether</option>
+                        <option>The End</option>
+                    </select>
+                </div>
+                <div>
+                    <label>Target rate <span class="required-indicator">*</span></label>
+                    <input class="form-control is-invalid" type="text" placeholder="items / hour">
+                    <span class="form-error">Enter a number greater than 0.</span>
+                    <span class="form-help-text">Used to size the farm in the roadmap.</span>
+                </div>
+                <label class="filter-checkbox-label"><input type="checkbox" checked> Auto-resolve dependencies</label>
+                <label class="filter-radio-label"><input type="radio" name="view" checked> Plan view</label>
+            </div>
+        </section>
+
+        <!-- ============================ TABS ============================ -->
+        <section class="sg-section">
+            <h2>Tabs</h2>
+            <ul class="tabs">
+                <li class="tabs__tab tabs__tab--active">All</li>
+                <li class="tabs__tab">Pending</li>
+                <li class="tabs__tab">Accepted</li>
+            </ul>
+        </section>
+    </div>
+</body>
+</html>

--- a/webapp/mc-web/src/main/resources/static/styles/components/btn.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/btn.css
@@ -30,12 +30,12 @@
 
 .btn--primary {
     background: var(--accent);
-    color: #fff;
+    color: var(--on-accent);
     border: 1px solid transparent;
 }
 
 .btn--primary:hover:not(:disabled) {
-    background: #3a6aee;
+    background: var(--accent-hover);
 }
 
 .btn--secondary {
@@ -46,7 +46,7 @@
 
 .btn--secondary:hover:not(:disabled) {
     background: var(--bg-surface);
-    border-color: #3a4060;
+    border-color: var(--border-strong);
 }
 
 .btn--ghost {

--- a/webapp/mc-web/src/main/resources/static/styles/components/callout.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/callout.css
@@ -15,6 +15,10 @@
     border-left-color: var(--red);
 }
 
+.callout--success {
+    border-left-color: var(--green);
+}
+
 .callout--info {
     border-left-color: var(--accent);
 }
@@ -28,6 +32,10 @@
 
 .callout--error .callout__icon {
     color: var(--red);
+}
+
+.callout--success .callout__icon {
+    color: var(--green);
 }
 
 .callout--info .callout__icon {

--- a/webapp/mc-web/src/main/resources/static/styles/components/form.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/form.css
@@ -21,7 +21,7 @@
 }
 
 .form-control:hover:not(:focus):not(:disabled) {
-    border-color: #3a4060;
+    border-color: var(--border-strong);
 }
 
 .form-control:focus {
@@ -156,7 +156,7 @@ select.form-control option {
 .filter-radio-label:hover,
 .filter-checkbox-label:hover {
     background: var(--bg-raised);
-    border-color: #3a4060;
+    border-color: var(--border-strong);
 }
 
 .filter-radio-label:has(input:checked),
@@ -215,7 +215,7 @@ select.form-control option {
     top: 1px;
     width: 4px;
     height: 8px;
-    border: solid #fff;
+    border: solid var(--on-accent);
     border-width: 0 2px 2px 0;
     transform: rotate(45deg);
 }

--- a/webapp/mc-web/src/main/resources/static/styles/components/project-card.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/project-card.css
@@ -15,7 +15,7 @@
 }
 
 .project-card:hover {
-    border-color: #3a4060;
+    border-color: var(--border-strong);
     background: var(--bg-raised);
 }
 

--- a/webapp/mc-web/src/main/resources/static/styles/components/tabs.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/tabs.css
@@ -32,18 +32,18 @@
 .tabs__tab:hover {
     background: var(--bg-surface);
     color: var(--text-primary);
-    border-color: #3a4060;
+    border-color: var(--border-strong);
 }
 
 .tabs__tab--active,
 .tabs__tab[aria-selected="true"] {
     background: var(--accent);
-    color: #fff;
+    color: var(--on-accent);
     border-color: transparent;
 }
 
 .tabs__tab--active:hover,
 .tabs__tab[aria-selected="true"]:hover {
-    background: #3a6aee;
-    color: #fff;
+    background: var(--accent-hover);
+    color: var(--on-accent);
 }

--- a/webapp/mc-web/src/main/resources/static/styles/components/world-card.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/world-card.css
@@ -59,7 +59,7 @@
 }
 
 .world-card:hover {
-    border-color: #3a4060;
+    border-color: var(--border-strong);
     background: var(--bg-raised);
 }
 

--- a/webapp/mc-web/src/main/resources/static/styles/design-tokens.css
+++ b/webapp/mc-web/src/main/resources/static/styles/design-tokens.css
@@ -47,22 +47,33 @@
     --font-ui: 'IBM Plex Mono', monospace;
     --font-body: 'Inter', sans-serif;
 
+    /* --------------------------------------------------------------------
+       PALETTE — "Daylight Field Notebook" (Overworld theme). A warm paper +
+       sepia-ink substrate; each accent hue has exactly ONE role. The act and
+       status anchors sit on the blue↔yellow axis so they stay distinct under
+       red-green colour vision; green/red states must ALSO carry an icon or
+       label, never colour alone. Full rationale in the docs-product skill.
+       -------------------------------------------------------------------- */
+
     /* Colors */
-    --bg-base: #0F1117;
-    --bg-surface: #181C27;
-    --bg-raised: #1F2435;
-    --border: #2A2F42;
-    --text-primary: #E8EAF0;
-    --text-muted: #6E748A;
-    --text-disabled: #3C4158;
-    --accent: #4A7CFF;
-    --accent-muted: #1E2D5C;
-    --green: #3DBA7A;
-    --amber: #E8A225;
-    --red: #E05252;
-    --progress: #4A7CFF;
-    --green-bg: #1C3828;
-    --red-bg: #3A1E1E;
+    --bg-base: #EBE1C8;        /* desk / page edge — aged tan */
+    --bg-surface: #F7F0DE;     /* the page */
+    --bg-raised: #FCF7EA;      /* a raised note / card */
+    --border: #D6C6A2;         /* pencil rule line */
+    --border-strong: #C2AE82;  /* emphasized rule (hover/focus) */
+    --text-primary: #2A2218;   /* dark sepia ink */
+    --text-muted: #7A6B47;     /* faded pencil */
+    --text-disabled: #A99B78;
+    --accent: #2C6E9E;         /* lapis ink — primary / CTA + links (act) */
+    --accent-hover: #245C85;
+    --accent-muted: #D6E2EC;   /* pale lapis wash */
+    --on-accent: #FCF7EA;      /* cream text/icon on a lapis fill */
+    --green: #4F7A2B;          /* grass — success / status / growth (done) */
+    --amber: #B0791A;          /* wheat-gold — warning */
+    --red: #A6321F;            /* redstone — danger */
+    --progress: #4F7A2B;       /* grass — completion is status, not brand */
+    --green-bg: #DEE8CB;
+    --red-bg: #F0DACF;
 
     /* Typography scale */
     --text-xs: 11px;

--- a/webapp/mc-web/src/main/resources/static/styles/pages/idea-hub.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/idea-hub.css
@@ -131,7 +131,7 @@
 }
 
 .idea-card:hover {
-    border-color: #3a4060;
+    border-color: var(--border-strong);
     background: var(--bg-raised);
 }
 

--- a/webapp/mc-web/src/main/resources/static/styles/pages/styleguide.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/styleguide.css
@@ -1,0 +1,106 @@
+/* ==========================================================================
+   STYLEGUIDE PAGE
+   Layout-only styles for the component gallery at /static/styleguide.html — a
+   living reference for the design system. Component appearance comes from the
+   real component CSS + design tokens; this file only arranges the gallery.
+   ========================================================================== */
+
+.sg-section {
+    margin-bottom: var(--space-8);
+}
+
+.sg-section > h2 {
+    font-family: var(--font-ui);
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 var(--space-2) 0;
+}
+
+.sg-section > p {
+    color: var(--text-muted);
+    font-size: var(--text-sm);
+    margin: 0 0 var(--space-4) 0;
+    line-height: 1.5;
+}
+
+/* A row of components shown together, wrapping */
+.sg-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-3);
+}
+
+.sg-stack {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    max-width: 520px;
+}
+
+.sg-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: var(--space-4);
+}
+
+/* --- Token swatches --- */
+.sg-swatches {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: var(--space-3);
+}
+
+.sg-swatch {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    background: var(--bg-surface);
+}
+
+.sg-swatch__chip {
+    height: 56px;
+    border-bottom: 1px solid var(--border);
+}
+
+.sg-swatch__meta {
+    padding: var(--space-2) var(--space-3);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.sg-swatch__role {
+    font-family: var(--font-ui);
+    font-size: var(--text-label);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.sg-swatch__token {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+/* Swatch fills — one per token so the page needs no inline styles */
+.sw-bg-base { background: var(--bg-base); }
+.sw-bg-surface { background: var(--bg-surface); }
+.sw-bg-raised { background: var(--bg-raised); }
+.sw-border { background: var(--border); }
+.sw-border-strong { background: var(--border-strong); }
+.sw-text-primary { background: var(--text-primary); }
+.sw-text-muted { background: var(--text-muted); }
+.sw-accent { background: var(--accent); }
+.sw-accent-hover { background: var(--accent-hover); }
+.sw-accent-muted { background: var(--accent-muted); }
+.sw-green { background: var(--green); }
+.sw-amber { background: var(--amber); }
+.sw-red { background: var(--red); }
+.sw-progress { background: var(--progress); }
+
+/* Progress-bar demo widths (no inline styles on the page) */
+.sg-w-35 .progress__fill { width: 35%; }
+.sg-w-70 .progress__fill { width: 70%; }
+.sg-w-100 .progress__fill { width: 100%; }


### PR DESCRIPTION
## Palette rework — "Daylight Field Notebook" (Overworld)

Replaces the generic dark-SaaS palette with a light paper + sepia-ink theme drawn from the overworld. Every accent hue maps to exactly **one role**:

| Material | Role |
|---|---|
| Lapis (sky / water) | **act** — CTA, links, active states; and **info** (the quiet wash) |
| Grass / emerald | success / status / progress (**done**) |
| Wheat-gold | warning |
| Redstone | danger |
| Sand / dirt / wood | structure — surfaces, rules, ink |

### Colour-blind aware
The act/status anchors sit on the **blue↔yellow axis** (the primary user is red-green colour-blind), and semantic states pair colour with an icon/label rather than relying on hue alone. This is why the CTA is **lapis** — copper and green both collided with redstone-danger.

### Changes
- `design-tokens.css`: Overworld palette; new `--accent-hover`, `--border-strong`, `--on-accent`
- Routed hardcoded colour leaks (`#3a6aee`, `#3a4060`, `#fff`) through tokens in btn / tabs / form / project-card / world-card / idea-hub
- `callout.css`: added `--success`; `--info` is now the quiet lapis
- New living component gallery at `/static/styleguide.html`
- `docs-product` / `docs-frontend`: documented the palette, role discipline, and the colour-blind constraint

Template / CSS + docs only — no logic changes. `mvn compile` clean; `LayoutTest` 17/17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
