### PR TITLE
refactor(domain): remove slf4j from mc-domain; document the kotlinx-serialization exception (MCO-176)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,11 +61,15 @@ cd webapp && mvn test -pl mc-web         # Single module tests
 
 ## Worktree Database Isolation
 
-**Start new work in a git worktree, not the main checkout.** The main checkout
-(`master`) shares the production-backed dev database; worktrees each get their own
-isolated copy (below). Working in a worktree keeps `master` clean, lets features
-run in parallel without database or migration collisions, and matches how CI builds
-each PR. Use an agent's `isolation: "worktree"` or `git worktree add` to start.
+**Start new work in a git worktree, not the main checkout — check this BEFORE the
+first edit, not at commit time.** The main checkout (`master`) shares the
+production-backed dev database; worktrees each get their own isolated copy (below).
+Working in a worktree keeps `master` clean, lets features run in parallel without
+database or migration collisions, and matches how CI builds each PR. Use an agent's
+`isolation: "worktree"` or `git worktree add` to start. If you only realise mid-task
+that you are on `master`, immediately branch off (`git checkout -b <linear-branch>`)
+so the work leaves `master` clean — a branch is the fallback floor; a worktree is the
+default. Never edit or commit on `master` directly.
 
 Each git worktree gets its **own** database so migrations and data never collide
 with the main checkout or sibling worktrees. This mirrors what CI already does
@@ -116,6 +120,14 @@ the real ingested Minecraft data instantly (no re-ingestion) and matches CI exac
 Linear — workspace: evegul, team: Mcorg. Do NOT create GitHub issues.
 
 ## Critical Rules
+
+**Worktree first:** Before making ANY code change, confirm you are NOT in the `master`
+checkout. If `git rev-parse --abbrev-ref HEAD` is `master`, STOP and start a worktree
+(`git worktree add`, or an agent's `isolation: "worktree"`) before editing — do not edit
+files on `master`. If a worktree is impractical, at minimum create a feature branch first
+(`git checkout -b <linear-branch>`); never commit work directly onto `master`. See
+[Worktree Database Isolation](#worktree-database-isolation). This is the FIRST thing to
+check when work begins, not an afterthought at commit time.
 
 **Imports:** `import kotlinx.html.stream.createHTML` — NOT `import kotlinx.html.createHTML`
 

--- a/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/extract/loot/LootTableParser.kt
+++ b/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/extract/loot/LootTableParser.kt
@@ -30,8 +30,12 @@ data class LootTableParser(
         val type = json.objectResult(filename)
             .flatMap { it.getResult("type", filename) }
             .flatMap { it.primitiveResult(filename) }
-            .flatMap { ResourceSource.SourceType.of(it.content)?.let { type -> Result.success(type) } ?: Result.failure(
-                ExtractionFailure.JsonFailure.UnknownValue(it.content, "type", json, filename))
+            .map { primitive ->
+                ResourceSource.SourceType.of(primitive.content).also { resolved ->
+                    if (resolved == ResourceSource.SourceType.UNKNOWN) {
+                        logger.warn("Unknown ResourceSource.SourceType id '${primitive.content}' in loot file: $filename")
+                    }
+                }
             }
 
         if (json is JsonObject && json.jsonObject["pools"] == null) {

--- a/webapp/mc-domain/CLAUDE.md
+++ b/webapp/mc-domain/CLAUDE.md
@@ -1,6 +1,7 @@
 # mc-domain
 
-Pure domain models and value objects. No business logic, no framework dependencies.
+Pure domain models and value objects. No business logic, no framework dependencies
+(see the serialization exception below).
 
 ## Purpose
 
@@ -8,9 +9,25 @@ This module defines the shared vocabulary of the entire application. Every other
 
 ## Tech
 
-- Kotlin stdlib only (no Ktor, no database, no serialization annotations)
+- Kotlin stdlib + `kotlinx-serialization-core` only (no Ktor, no database, no logging, no I/O)
 - Maven build, JVM 21 target
 - Package: `app.mcorg.domain.model.*`
+
+## Allowed dependencies (and the one exception)
+
+The only third-party dependency is `kotlinx-serialization-core`. Domain models **may**
+carry `@Serializable` annotations and, where a sealed/value type needs custom wire
+handling, a `KSerializer` (e.g. `ResourceSource.SourceType.SourceTypeSerializer`). This
+is a deliberate, stated exception: with a single entity layer and railway architecture,
+a separate DTO layer purely to keep annotations off the domain would duplicate every
+model plus mappers for negligible gain. `serialization-core` is pure-Kotlin, compile-time,
+and effectively a marker — categorically lighter than JPA/Jackson.
+
+Everything else stays out: **no logging, no I/O, no Ktor, no database, no other framework
+deps.** Models are pure data + lookups. Behaviour that needs runtime context (e.g. logging
+an unrecognized id) belongs at the boundary that has that context — for source-type
+resolution that is the `mc-data` extraction layer, not `SourceType.of()`, which returns
+`UNKNOWN` silently.
 
 ## Structure
 

--- a/webapp/mc-domain/pom.xml
+++ b/webapp/mc-domain/pom.xml
@@ -81,10 +81,6 @@
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-serialization-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
     </dependencies>
 
 </project>

--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ResourceSource.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ResourceSource.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
-import org.slf4j.LoggerFactory
 
 data class ResourceSource(
     val type: SourceType,
@@ -98,11 +97,15 @@ data class ResourceSource(
         }
 
         companion object {
-            private val logger = LoggerFactory.getLogger(ResourceSource::class.java)
-
             val UNKNOWN = SourceType("mcorg:unknown", "Unknown", 0)
 
-            fun of(id: String): SourceType? {
+            /**
+             * Resolves a raw source-type id to its [SourceType], returning [UNKNOWN] for
+             * unrecognized ids. This is a pure lookup — callers at an extraction boundary
+             * (where file/version context is available) are responsible for logging an
+             * [UNKNOWN] result if it warrants a diagnostic.
+             */
+            fun of(id: String): SourceType {
                 return when (id) {
                     LootTypes.ARCHAEOLOGY.id -> LootTypes.ARCHAEOLOGY
                     LootTypes.FISHING.id -> LootTypes.FISHING
@@ -141,10 +144,7 @@ data class ResourceSource(
                     TradeTypes.TOOLSMITH.id -> TradeTypes.TOOLSMITH
                     TradeTypes.WEAPONSMITH.id -> TradeTypes.WEAPONSMITH
                     TradeTypes.WANDERING_TRADER.id -> TradeTypes.WANDERING_TRADER
-                    else -> {
-                        logger.warn("Unknown ResourceSource.Type id: $id")
-                        UNKNOWN
-                    }
+                    else -> UNKNOWN
                 }
             }
 
@@ -200,7 +200,7 @@ data class ResourceSource(
                 }
 
                 override fun deserialize(decoder: Decoder): SourceType {
-                    return of(decoder.decodeString()) ?: UNKNOWN
+                    return of(decoder.decodeString())
                 }
             }
 

--- a/webapp/mc-engine/src/main/kotlin/app/mcorg/engine/model/ItemSourceGraph.kt
+++ b/webapp/mc-engine/src/main/kotlin/app/mcorg/engine/model/ItemSourceGraph.kt
@@ -72,7 +72,6 @@ data class SourceNode(
             val sourceTypeId = parts[1]
             val filename = parts.subList(2, parts.size).joinToString(":")
             val sourceType = ResourceSource.SourceType.of("$groupId:$sourceTypeId")
-                ?: ResourceSource.SourceType.UNKNOWN
             return SourceNode(sourceType, filename)
         }
     }


### PR DESCRIPTION
## What

Removes the lone framework dependency keeping `mc-domain` from being the pure model layer its CLAUDE.md describes, and turns the serialization grey area into a stated rule.

- **slf4j removed from `mc-domain`.** `ResourceSource.SourceType.of()` did `logger.warn(...)` inside a domain factory — runtime behaviour in a pure model. It now returns `UNKNOWN` silently and is non-nullable (it never actually returned null; the `SourceType?` signature was misleading). Drops `slf4j-api` from `mc-domain/pom.xml` entirely.
- **Unknown-id logging moves to the extraction boundary.** `LootTableParser` (mc-data) now logs `Unknown ResourceSource.SourceType id '<id>' in loot file: <filename>` when resolution yields `UNKNOWN` — a more useful diagnostic, since it has the filename. This replaced a `Result.failure(UnknownValue)` branch that `of()`'s never-null return had made unreachable.
- **Serialization exception documented** in `mc-domain/CLAUDE.md`: domain models *may* carry `kotlinx-serialization-core` annotations + a custom `KSerializer` as a deliberate single-entity-layer exception (a DTO layer would duplicate every model + mappers for negligible gain); no logging / I/O / other framework deps.
- Dropped the now-redundant `?: UNKNOWN` fallbacks at the two other `of()` callers (`SourceTypeSerializer.deserialize`, `ItemSourceGraph.fromKey`).
- **Hardened the root `CLAUDE.md`** to start work in a worktree (or at minimum a branch) before the first edit, not at commit time.

## Out of scope

No DTO layer; no change to the serialization approach — this explicitly *accepts* annotations on domain models and only removes the logging behaviour.

## Testing

`mvn clean compile` clean. `mc-domain` (94) + `mc-engine` (65) + `LootTableParserTest` (6, incl. `unknown loot table type maps to UNKNOWN`) all pass.

Closes MCO-176

🤖 Generated with [Claude Code](https://claude.com/claude-code)