### PR TITLE
refactor(pipeline): remove Ktor from mc-pipeline test-jar (MCO-177)

### DIFF
--- a/webapp/mc-pipeline/pom.xml
+++ b/webapp/mc-pipeline/pom.xml
@@ -88,12 +88,6 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- TestUtils.createTestParameters (published in the tests JAR) uses io.ktor.http.Parameters -->
-        <dependency>
-            <groupId>io.ktor</groupId>
-            <artifactId>ktor-http-jvm</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/webapp/mc-pipeline/src/test/kotlin/app/mcorg/pipeline/TestUtils.kt
+++ b/webapp/mc-pipeline/src/test/kotlin/app/mcorg/pipeline/TestUtils.kt
@@ -1,8 +1,6 @@
 package app.mcorg.pipeline
 
 import app.mcorg.domain.pipeline.Step
-import io.ktor.http.Parameters
-import io.ktor.http.parametersOf
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.fail
 import kotlin.test.assertIs
@@ -76,13 +74,6 @@ object TestUtils {
                 error
             }
         }
-    }
-
-    /**
-     * Create test parameters map for form data simulation
-     */
-    fun createTestParameters(vararg pairs: Pair<String, String>): Parameters {
-        return parametersOf(*pairs.map { (key, value) -> key to listOf(value) }.toTypedArray())
     }
 
     /**


### PR DESCRIPTION
## Summary

`mc-pipeline` is the generic railway framework, yet its test-jar pulled in **Ktor**: `TestUtils.createTestParameters()` built `io.ktor.http.Parameters` for form-data simulation. That was the only reason the generic module touched a web framework, and it forced a `ktor-http-jvm` test dependency into the pom.

The issue assumed mc-web tests called this helper — but a repo-wide grep found **zero callers**. It was dead code. So rather than relocating it into mc-web, this deletes it outright (same end goal, strictly cleaner):

- **`TestUtils.kt`** — remove `createTestParameters` and its `io.ktor.http.{Parameters, parametersOf}` imports. The genuinely-shared generic `Result`/`Step` assertion helpers stay.
- **`mc-pipeline/pom.xml`** — drop the now-unused `ktor-http-jvm` test dependency.

Ktor is now entirely absent from the generic framework module.

## Verification

- `mvn clean install -pl mc-pipeline -am` — passes (test-jar rebuilt)
- `mvn test -pl mc-pipeline` — passes
- `mvn test-compile` across the full reactor — passes (all consumers compile against the new test-jar)

Closes MCO-177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)