### PR TITLE
ci(dev): gate Fly preview deploy behind a `preview` label (MCO-183)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -8,6 +8,7 @@ env:
   DB_USERNAME: mcorg_owner
 on:
   pull_request:
+    types: [ opened, synchronize, reopened, labeled ]
     branches: [ master ]
     paths:
       - webapp/mc-domain/src/main/**
@@ -98,7 +99,9 @@ jobs:
         run: mvn test -pl mc-web -Dsurefire.excludedGroups= -Dgroups=database -B -Dmaven.main.skip=true
 
   deploy-dev:
-    if: github.actor != 'dependabot[bot]'
+    if: >-
+      github.actor != 'dependabot[bot]'
+      && contains(github.event.pull_request.labels.*.name, 'preview')
     needs: [unit-tests, integration-tests]
     environment: dev
     runs-on: ubuntu-latest

--- a/.github/workflows/preview-label.yml
+++ b/.github/workflows/preview-label.yml
@@ -1,0 +1,31 @@
+name: Apply preview label on !preview comment
+
+# Escape hatch for the deploy-dev gate in dev.yml: commenting `!preview` on a PR
+# applies the `preview` label, which fires dev.yml's `labeled` trigger and re-runs
+# the compile -> test -> deploy flow with the label present. The label stays the
+# single source of truth for "deploy a Fly preview for this PR".
+on:
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  apply-preview-label:
+    if: >-
+      github.event.issue.pull_request != null
+      && github.event.comment.body == '!preview'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      # Use a PAT (not GITHUB_TOKEN): labels applied by GITHUB_TOKEN do not spawn
+      # new workflow runs, so dev.yml's `labeled` trigger would never fire.
+      # GH_TOKEN_PR_COMMENTS is the repo's existing PAT for cross-workflow PR writes.
+      - name: Add preview label and acknowledge
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_PR_COMMENTS }}
+        run: |
+          gh pr edit ${{ github.event.issue.number }} --repo ${{ github.repository }} --add-label preview
+          gh api --method POST \
+            repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions \
+            -f content=rocket

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,20 @@ cd webapp && mvn compile -pl mc-engine   # Single module
 cd webapp && mvn test -pl mc-web         # Single module tests
 ```
 
+## CI / PR Previews
+
+`.github/workflows/dev.yml` runs `compile` + `unit-tests` + `integration-tests` on
+**every** PR touching source paths. The `deploy-dev` job (Neon branch + Docker image +
+ephemeral Fly app `mcorg-dev-<PR#>` + preview-URL comment) is **opt-in**: it only runs
+when the PR carries the **`preview`** label.
+
+- **No `preview` label** → tests run, no Fly preview deploy. This is the default; use it
+  for backend / data / logic changes with nothing to eyeball.
+- **Want a preview** → add the `preview` label, or comment **`!preview`** on the PR
+  (`.github/workflows/preview-label.yml` applies the label for you, via the
+  `GH_TOKEN_PR_COMMENTS` PAT so the `labeled` trigger re-fires). The label is the single
+  source of truth; adding it re-runs compile → test → deploy with the preview included.
+
 ## Environment (WSL2)
 
 - `localhost` in WSL2 ≠ Windows localhost.
@@ -73,8 +87,9 @@ default. Never edit or commit on `master` directly.
 
 Each git worktree gets its **own** database so migrations and data never collide
 with the main checkout or sibling worktrees. This mirrors what CI already does
-per pull request (`.github/workflows/dev.yml` forks `dev/pr-<N>` Neon branches) —
-only locally, per worktree, using the same Neon project (`morning-fog-11467472`).
+per pull request (`.github/workflows/dev.yml` forks `dev/pr-<N>` Neon branches for
+`preview`-labelled PRs — see [CI / PR Previews](#ci--pr-previews)) — only locally, per
+worktree, using the same Neon project (`morning-fog-11467472`).
 
 **Workflow:**
 

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,3 +1,5 @@
+# (MCO-183) no-op touch so this PR matches dev.yml's paths filter and can exercise
+# the preview-label gate end-to-end; remove before merge.
 FROM maven:3-eclipse-temurin-21 AS build
 
 # Cache maven dependencies


### PR DESCRIPTION
Gates the `deploy-dev` Fly preview behind an opt-in `preview` PR label, with a `!preview` comment escape hatch. Non-UI PRs run tests without spinning up a throwaway Fly app + Neon branch.

## Changes
- **`dev.yml`** — add `labeled` to `pull_request.types`; gate `deploy-dev.if` on the `preview` label. `compile` / `unit-tests` / `integration-tests` still run on every PR.
- **`preview-label.yml`** (new) — `issue_comment` workflow: a `!preview` comment applies the `preview` label (+ 🚀 ack). The label is the single source of truth; applying it re-fires the real compile → test → deploy pipeline.
- Created the `preview` repo label.

## Note on the escape-hatch token
The label is applied via the `GH_TOKEN_PR_COMMENTS` PAT rather than the default `GITHUB_TOKEN` — labels set by `GITHUB_TOKEN` do **not** spawn new workflow runs (GitHub's recursion guard), so the `labeled` trigger would never fire otherwise.

## Acceptance
- A PR **without** the `preview` label runs tests but does not deploy a Fly preview.
- Adding the label (directly or via `!preview`) deploys the preview and posts the URL.

This PR is intentionally opened **without** the label to verify the gate skips the deploy. Commenting `!preview` should then apply the label and trigger a preview deploy.

Closes MCO-183

🤖 Generated with [Claude Code](https://claude.com/claude-code)