### PR TITLE
test(mc-web): migrate DatabaseTestExtension to Testcontainers 2.0 container API (MCO-184)

### DIFF
--- a/webapp/mc-web/src/test/kotlin/app/mcorg/test/postgres/DatabaseTestExtension.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/test/postgres/DatabaseTestExtension.kt
@@ -1,10 +1,3 @@
-// Uses the deprecated org.testcontainers.containers.PostgreSQLContainer: Testcontainers 2.0
-// supersedes it with org.testcontainers.postgresql.PostgreSQLContainer, a redesigned API
-// (non-generic, different accessors/lifecycle). The deprecated 1.x-compatible class still ships
-// in 2.0 and keeps this extension working unchanged; new-API migration is tracked in MCO-184.
-// File-level suppress so the deprecated import line itself is also covered.
-@file:Suppress("DEPRECATION")
-
 package app.mcorg.test.postgres
 
 import app.mcorg.config.Database
@@ -12,7 +5,7 @@ import app.mcorg.config.DatabaseConnectionProvider
 import org.flywaydb.core.Flyway
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.ExtensionContext
-import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.postgresql.PostgreSQLContainer
 import org.testcontainers.utility.DockerImageName
 import java.sql.Connection
 import java.sql.DriverManager
@@ -24,7 +17,7 @@ import java.sql.DriverManager
 class DatabaseTestExtension : BeforeAllCallback {
 
     companion object {
-        private val postgres: PostgreSQLContainer<*> by lazy {
+        private val postgres: PostgreSQLContainer by lazy {
             PostgreSQLContainer(DockerImageName.parse("postgres:16.9"))
                 .withDatabaseName("mcorg_test")
                 .withUsername("test_user")


### PR DESCRIPTION
## What

Migrate `DatabaseTestExtension` from the deprecated `org.testcontainers.containers.PostgreSQLContainer` to the redesigned `org.testcontainers.postgresql.PostgreSQLContainer` introduced in Testcontainers 2.0, and drop the `@file:Suppress("DEPRECATION")` left behind by the version sweep ([MCO-181](https://linear.app/evegul/issue/MCO-181), #296).

## Why

The deprecated 1.x-compatible class still ships in 2.0 but a future TC major will remove it. Migrating now keeps the test infra current.

## The change

The 2.0 class is **non-generic** — it `extends JdbcDatabaseContainer<PostgreSQLContainer>` rather than the old self-bounded `PostgreSQLContainer<SELF>`. So the only real break is the declared type:

```diff
-private val postgres: PostgreSQLContainer<*> by lazy {
+private val postgres: PostgreSQLContainer by lazy {
```

This was the sole incompatibility the sweep hit: with the `<*>` wildcard left in place, the non-generic class fails to type-check and every member access (`jdbcUrl`, `start`, `isRunning`, `close`, …) cascades into "unresolved". The getters and lifecycle (`withDatabaseName/Username/Password`, `withReuse`, `getJdbcUrl/getUsername/getPassword`, `start`, `isRunning`, `close`) are otherwise unchanged.

## Verification

- `mvn test -pl mc-web` — 513 green
- `mvn test -pl mc-web -Dsurefire.excludedGroups= -Dgroups=database` — **66 Testcontainers tests green** against the new API

Closes MCO-184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)