### PR TITLE
build: migrate JDK 21 → 25 (Kotlin 2.3, temurin:25, CI)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,11 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
-          java-version: '21'
+          distribution: 'temurin'
+          java-version: '25'
 
       - name: Cache Maven packages
         uses: actions/cache@v5

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -19,11 +19,11 @@ jobs:
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
-          java-version: '21'
+          distribution: 'temurin'
+          java-version: '25'
       - name: Compile and install modules
         run: mvn install -DskipTests -B
       - name: Upload local Maven artifacts

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -42,11 +42,11 @@ jobs:
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
-          java-version: '21'
+          distribution: 'temurin'
+          java-version: '25'
       - name: Restore local Maven artifacts
         uses: actions/download-artifact@v8
         with:
@@ -82,11 +82,11 @@ jobs:
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
-          java-version: '21'
+          distribution: 'temurin'
+          java-version: '25'
       - name: Restore local Maven artifacts
         uses: actions/download-artifact@v8
         with:
@@ -138,11 +138,11 @@ jobs:
           branch_name: dev/pr-${{ github.event.number }}
           role: ${{ env.DB_USERNAME }}
           api_key: ${{ secrets.NEON_API_KEY }}
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
-          java-version: '21'
+          distribution: 'temurin'
+          java-version: '25'
       - name: Run flyway migrations
         run: mvn flyway:migrate
         working-directory: ./webapp/mc-web

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -46,11 +46,11 @@ jobs:
         with:
           name: maven-local-modules
           path: ~/.m2/repository/app/mcorg
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
-          java-version: '21'
+          distribution: 'temurin'
+          java-version: '25'
 
       - name: Run Flyway migrations
         run: mvn flyway:migrate

--- a/webapp/Dockerfile
+++ b/webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3-eclipse-temurin-21 AS build
+FROM maven:3-eclipse-temurin-25 AS build
 
 # Cache maven dependencies
 WORKDIR /home/maven/src
@@ -20,7 +20,7 @@ COPY mc-data/src mc-data/src
 COPY mc-web/src mc-web/src
 RUN mvn clean package -DskipTests -B
 
-FROM eclipse-temurin:21-jre-alpine AS mcorg_app
+FROM eclipse-temurin:25-jre-alpine AS mcorg_app
 
 EXPOSE "8080:8080"
 

--- a/webapp/Dockerfile.ci
+++ b/webapp/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 EXPOSE "8080:8080"
 

--- a/webapp/mc-data/pom.xml
+++ b/webapp/mc-data/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
     </properties>
 
     <repositories>

--- a/webapp/mc-domain/pom.xml
+++ b/webapp/mc-domain/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
     </properties>
 
     <repositories>

--- a/webapp/mc-engine/pom.xml
+++ b/webapp/mc-engine/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
     </properties>
 
     <repositories>

--- a/webapp/mc-nbt/pom.xml
+++ b/webapp/mc-nbt/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
     </properties>
 
     <repositories>

--- a/webapp/mc-pipeline/pom.xml
+++ b/webapp/mc-pipeline/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
     </properties>
 
     <repositories>

--- a/webapp/mc-web/pom.xml
+++ b/webapp/mc-web/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
-        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
     </properties>
 
     <repositories>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -21,7 +21,7 @@
     </modules>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>25</java.version>
         <kotlin.code.style>official</kotlin.code.style>
         <!--
           Versions below are needed by BUILD PLUGINS (which BOMs cannot manage), so they


### PR DESCRIPTION
## What

Migrate the toolchain from JDK 21 to JDK 25 (LTS). The hard part (Kotlin 2.2 → 2.3) already landed in the MCO-181 version sweep, so this is a focused runtime/image/CI bump.

- **`webapp/pom.xml`:** `java.version` 21 → 25. `jvmTarget` and the compiler `source`/`target` derive from `${java.version}`, so this single change cascades.
- **Dockerfiles:** `eclipse-temurin:21` → `25` in `Dockerfile` (build + runtime stages) and `Dockerfile.ci`.
- **CI workflows:** `setup-java` 21 → 25 in `prod.yml`, `compile.yml`, `dev.yml`, `codeql.yml`.
- **Cleanup:** removed the dead `kotlin.compiler.jvmTarget=1.8` property from the 6 child poms (overridden by the parent plugin's `<jvmTarget>${java.version}</jvmTarget>`).

## Two judgment calls beyond the issue's literal scope

1. **`distribution: 'adopt'` → `'temurin'`** across all workflows. `adopt` (frozen AdoptOpenJDK) has no JDK 25 builds, so the bump wouldn't resolve. `temurin` matches what the Dockerfiles already use.
2. **`codeql.yml` bumped to 25** (not in the issue's listed files). Its `mvn clean compile` step now targets 25 and can't build on JDK 21. Kotlin is held at 2.3.21 precisely to keep CodeQL's extractor green on 25 — see the `mc-bom` rationale — so this stays green.

## Verification

Installed Temurin 25.0.3 locally and ran the full suite on it:

- **513 unit tests** ✓ — covers mockk/ByteBuddy (class file v69), Netty/Ktor, coroutines-debug agent
- **66 integration tests** ✓ — Testcontainers PostgreSQL

Closes MCO-179

🤖 Generated with [Claude Code](https://claude.com/claude-code)