### PR TITLE
Upgrade Postgres 16 → 18 (Neon + local + Testcontainers) (MCO-180)

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -13,6 +13,7 @@ on:
       - webapp/pom.xml
       - webapp/*/pom.xml
       - webapp/Dockerfile
+      - webapp/fly.toml
 permissions:
   contents: read
 

--- a/webapp/docker-compose-local.yaml
+++ b/webapp/docker-compose-local.yaml
@@ -1,7 +1,7 @@
 services:
   db:
     container_name: mcorg-db
-    image: postgres:16.9
+    image: postgres:18
     ports:
       - 5432:5432
     environment:

--- a/webapp/fly.toml
+++ b/webapp/fly.toml
@@ -4,7 +4,7 @@ primary_region = 'arn'
 [build]
 
 [env]
-  DB_URL = 'jdbc:postgresql://ep-icy-wood-a2vogqwy-pooler.eu-central-1.aws.neon.tech/mcorg?sslmode=require'
+  DB_URL = 'jdbc:postgresql://ep-withered-truth-a2d65fv7-pooler.eu-central-1.aws.neon.tech/mcorg?sslmode=require'
   DB_USER = 'mcorg_owner'
   ENV = 'PRODUCTION'
   APP_HOST = 'app.seam.gg'

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/test/postgres/DatabaseTestExtension.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/test/postgres/DatabaseTestExtension.kt
@@ -12,13 +12,13 @@ import java.sql.DriverManager
 
 /**
  * JUnit 5 extension for managing PostgreSQL Testcontainer lifecycle during testing.
- * Provides a clean PostgreSQL 16.9 database with Flyway migrations for each test class.
+ * Provides a clean PostgreSQL 18 database with Flyway migrations for each test class.
  */
 class DatabaseTestExtension : BeforeAllCallback {
 
     companion object {
         private val postgres: PostgreSQLContainer by lazy {
-            PostgreSQLContainer(DockerImageName.parse("postgres:16.9"))
+            PostgreSQLContainer(DockerImageName.parse("postgres:18"))
                 .withDatabaseName("mcorg_test")
                 .withUsername("test_user")
                 .withPassword("test_password")

--- a/webapp/scripts/worktree-db.sh
+++ b/webapp/scripts/worktree-db.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-NEON_PROJECT_ID="morning-fog-11467472"
+NEON_PROJECT_ID="sweet-dust-00910797"
 NEON_PARENT="master"        # the production / default Neon branch
 DB_NAME="mcorg"
 DB_ROLE="mcorg_owner"


### PR DESCRIPTION
## Summary

Upgrades Postgres **16 → 18** across local, test, and production. Neon has no in-place major upgrade, so a new PG18 project (`sweet-dust-00910797`) replaces the PG16 project (`morning-fog-11467472`); production data was migrated via `pg_dump`/`pg_restore`.

## Changes

- **`docker-compose-local.yaml`**: `postgres:16.9` → `postgres:18`
- **`DatabaseTestExtension`**: Testcontainers image `16.9` → `18` (+ doc comment)
- **`worktree-db.sh`**: `NEON_PROJECT_ID` → new PG18 project
- **`fly.toml`**: `DB_URL` host → new project's pooler endpoint
- **`prod.yml`**: also trigger the production deploy on `webapp/fly.toml` changes (otherwise this DB-host change would never redeploy prod)

## Verification

- `mvn test -pl mc-web` green on PG18 via Testcontainers — **513 tests, 0 failures** — all Flyway migrations apply cleanly from scratch on 18.

## Out-of-band cutover (done / pending, tracked outside the diff)

- ✅ New PG18 project created; data restored from prod
- ✅ Stray PG17 project (created by neonctl default) deleted
- ✅ Repo var `NEON_PROJECT_ID` → new project
- ✅ Fly secret `DB_PASSWORD` staged
- ⏳ **`production` GitHub environment** `DB_URL` + `DB_PASSWORD` → new project (needed by the prod Flyway-migrate step + ingestion machine)
- ⏳ Merge → `prod.yml` runs full deploy; verify; then delete old PG16 project

🤖 Generated with [Claude Code](https://claude.com/claude-code)