### PR TITLE
chore: bump @playwright/test to ^1.55.1 (CVE-2025-59288)

### DIFF
--- a/webapp/mc-web/src/test/javascript/package-lock.json
+++ b/webapp/mc-web/src/test/javascript/package-lock.json
@@ -9,17 +9,18 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.50.0",
+        "@playwright/test": "^1.55.1",
         "@types/node": "^22.7.4"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
-      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.50.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -43,6 +44,7 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -52,12 +54,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
-      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.50.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -70,10 +73,11 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
-      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/webapp/mc-web/src/test/javascript/package.json
+++ b/webapp/mc-web/src/test/javascript/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.50.0",
+    "@playwright/test": "^1.55.1",
     "@types/node": "^22.7.4"
   }
 }


### PR DESCRIPTION
Clears Dependabot alert [#7](https://github.com/evengul/mc-org/security/dependabot/7) — **GHSA-7mvr-c777-76hp / CVE-2025-59288** (High).

## What

Bumps `@playwright/test` `^1.50.0 → ^1.55.1` in `webapp/mc-web/src/test/javascript`. npm resolves the range to **1.60.0** across `@playwright/test`, `playwright`, and `playwright-core`. `npm audit` reports **0 vulnerabilities**.

## Why

Playwright's macOS browser-reinstall helper scripts (`reinstall_chrome_*_mac.sh`, `reinstall_msedge_*_mac.sh`) fetched installer packages with `curl -k` (SSL verification disabled) and `sudo installer`'d them, allowing a MitM to deliver an arbitrary privileged executable (RCE, CWE-295). Fixed upstream in Playwright 1.55.1.

## Risk / scope

Low real-world exposure: dev-only frontend test dependency, never shipped to production; the vulnerable scripts are macOS-only and not invoked by CI. This is hygiene + clearing the alert.

## Testing

Lockfile-only regeneration (`npm install --package-lock-only`); no Kotlin touched. `npm audit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)