### PR TITLE
Rebrand product to "Seam" (front-facing names + docs)

### DIFF
--- a/CACHING_PLAN.md
+++ b/CACHING_PLAN.md
@@ -50,7 +50,7 @@ Additionally, `getUnreadNotificationsOrZero()` runs on nearly every page load (r
 | Complexity | One dependency | Connection management, serialization, another failure mode |
 | Memory | Bounded, configurable per cache | Separate memory budget |
 
-Caffeine is the right choice because MC-ORG runs as a single instance on Fly.io and the dataset is small (collaboration tool, not millions of users). If the app scales to multiple instances, a shared cache (Redis) or cache-aside with short TTLs can be revisited.
+Caffeine is the right choice because Seam runs as a single instance on Fly.io and the dataset is small (collaboration tool, not millions of users). If the app scales to multiple instances, a shared cache (Redis) or cache-aside with short TTLs can be revisited.
 
 ### Dependency
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,6 @@
-# MC-ORG Project Context
+# Seam Project Context
+
+> **Naming:** The product is called **Seam**. The internal name `mc-org` (and derivatives `app.mcorg`, Maven module names `mc-*`, Fly app, Neon project, DB) remains unchanged and should NOT be renamed — these are infrastructure and package identifiers, not the product brand.
 
 Minecraft resource planning tool — players define projects (builds, farms, contraptions),
 the app resolves their resource dependencies by traversing a graph built from Minecraft's crafting and loot data,

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# MC-ORG
+# Seam
+
+> **Naming:** The product is called **Seam**. The internal name `mc-org` (and derivatives `app.mcorg`, Maven module names `mc-*`, Fly app, Neon project, DB) remains unchanged and should NOT be renamed — these are infrastructure and package identifiers, not the product brand.
 
 ## Overview
-MC-ORG is a web-based application designed to manage Minecraft projects. This tool provides an intuitive interface for organizing and administrating your Minecraft-related projects.
+Seam is a web-based application designed to manage Minecraft projects. This tool provides an intuitive interface for organizing and administrating your Minecraft-related projects.
 
 ## Features
 - Web-based management interface
@@ -38,4 +40,4 @@ MC-ORG is a web-based application designed to manage Minecraft projects. This to
 This code is proprietary and confidential. Unauthorized copying, transferring, or reproduction of the contents of this repository, via any medium, is strictly prohibited.
 
 ## Contact
-Email: even@mcorg.app
+Email: even.gultvedt@gmail.com

--- a/documentation/THEME_SYSTEM.md
+++ b/documentation/THEME_SYSTEM.md
@@ -1,7 +1,7 @@
 # Theme Switcher Implementation
 
 ## Overview
-The MC-ORG application now supports three Minecraft-inspired themes that can be switched dynamically:
+The Seam application now supports three Minecraft-inspired themes that can be switched dynamically:
 
 ### 🌍 Overworld Theme (Light Mode - Default)
 - **Colors**: Grass greens, sky blues, and bright backgrounds

--- a/documentation/reference/AI_QUICKSTART_GUIDE.md
+++ b/documentation/reference/AI_QUICKSTART_GUIDE.md
@@ -1,4 +1,4 @@
-# AI Agent Quickstart Guide for MC-ORG
+# AI Agent Quickstart Guide for Seam
 
 **Read This First** - 10 minute orientation guide
 
@@ -17,9 +17,9 @@ Before starting ANY task:
 
 ---
 
-## 🎯 What is MC-ORG?
+## 🎯 What is Seam?
 
-MC-ORG is a **Minecraft world collaboration platform** for managing building projects, tasks, and team coordination.
+Seam is a **Minecraft world collaboration platform** for managing building projects, tasks, and team coordination.
 It's a web application that helps Minecraft builders organize large-scale projects from idea to completion.
 
 **Technology**: Ktor (Kotlin) + PostgreSQL + HTMX + Server-side HTML

--- a/documentation/reference/ARCHITECTURE_REFERENCE.md
+++ b/documentation/reference/ARCHITECTURE_REFERENCE.md
@@ -1,4 +1,4 @@
-# MC-ORG Architecture Reference
+# Seam Architecture Reference
 
 **Complete system architecture, technology stack, and domain model**
 
@@ -1073,7 +1073,7 @@ object ValidateAdminRoleStep : Step<Input, AppFailure.AuthError, Input> {
 
 ### Overview
 
-MC-ORG integrates with several external APIs for authentication and Minecraft-related data. All API calls use the `ApiProvider` pattern with built-in rate limiting, error handling, and testability.
+Seam integrates with several external APIs for authentication and Minecraft-related data. All API calls use the `ApiProvider` pattern with built-in rate limiting, error handling, and testability.
 
 ### Integrated APIs
 

--- a/documentation/reference/BUSINESS_RULES_REFERENCE.md
+++ b/documentation/reference/BUSINESS_RULES_REFERENCE.md
@@ -1,4 +1,4 @@
-# MC-ORG Business Rules Reference
+# Seam Business Rules Reference
 
 **Domain rules, workflows, and business constraints**
 
@@ -26,7 +26,7 @@
 
 ## Executive Summary
 
-MC-ORG is a web-based Minecraft world collaboration platform designed to centralize project management, task tracking,
+Seam is a web-based Minecraft world collaboration platform designed to centralize project management, task tracking,
 and team coordination for Minecraft builders. The application solves the common problem of scattered project information
 across Discord channels, spreadsheets, and in-game communication by providing a structured, role-based platform for
 managing building projects from idea to completion.
@@ -65,7 +65,7 @@ managing building projects from idea to completion.
 - Inefficient resource planning and allocation
 
 **Solution Approach:**
-MC-ORG provides a one-stop platform for organizing Minecraft projects from idea through design, planning, resource
+Seam provides a one-stop platform for organizing Minecraft projects from idea through design, planning, resource
 gathering, and building completion, with integrated team collaboration and historical progress tracking.
 
 ## Domain Model & Core Concepts
@@ -598,5 +598,5 @@ Project A wants to depend on Project B
 **Maintained By**: Development Team
 
 This functional specification provides comprehensive guidance for development teams and AI agents to understand the
-business purpose, user workflows, and technical requirements necessary to build and maintain the MC-ORG platform
+business purpose, user workflows, and technical requirements necessary to build and maintain the Seam platform
 effectively.

--- a/documentation/reference/DEVELOPMENT_GUIDE.md
+++ b/documentation/reference/DEVELOPMENT_GUIDE.md
@@ -1,4 +1,4 @@
-# MC-ORG Development Guide
+# Seam Development Guide
 
 **Complete implementation patterns, best practices, and step-by-step guides**
 
@@ -1994,7 +1994,7 @@ object ValidateNoCyclesStep : Step<AddDependencyInput, AppFailure, AddDependency
 
 ### Overview
 
-Authentication and authorization in MC-ORG are handled **outside** of pipelines using Ktor plugins. This ensures
+Authentication and authorization in Seam are handled **outside** of pipelines using Ktor plugins. This ensures
 security checks happen before any business logic executes.
 
 ### Plugin-Based Authorization
@@ -2098,7 +2098,7 @@ suspend fun ApplicationCall.handleFeature() {
 
 ### Overview
 
-MC-ORG uses environment variables for configuration, managed through the `AppConfig` object. Configuration is loaded
+Seam uses environment variables for configuration, managed through the `AppConfig` object. Configuration is loaded
 once at application startup and validated before the server starts.
 
 ### Configuration Loading
@@ -2296,7 +2296,7 @@ flyctl secrets set RSA_PRIVATE_KEY=... RSA_PUBLIC_KEY=...
 
 ### Overview
 
-MC-ORG uses `ApiProvider` (defined in `config/ApiProvider.kt`) for making HTTP requests to external APIs. ApiProvider is
+Seam uses `ApiProvider` (defined in `config/ApiProvider.kt`) for making HTTP requests to external APIs. ApiProvider is
 a sealed class that provides type-safe, Step-based HTTP operations with built-in error handling, rate limiting, and JSON
 serialization.
 
@@ -2328,7 +2328,7 @@ object FetchMinecraftVersionsStep : Step<Unit, AppFailure.ApiError, List<Minecra
         val apiStep = FabricMcApiProvider.get<Unit, VersionsResponse>(
             url = "/versions",
             headerBuilder = { builder, _ ->
-                builder.header("User-Agent", "MC-ORG/1.0")
+                builder.header("User-Agent", "Seam/1.0")
             }
         )
 

--- a/documentation/reference/GLOSSARY.md
+++ b/documentation/reference/GLOSSARY.md
@@ -1,4 +1,4 @@
-# MC-ORG Glossary
+# Seam Glossary
 
 **Quick reference for technical and domain terminology**
 

--- a/documentation/reference/README.md
+++ b/documentation/reference/README.md
@@ -1,13 +1,13 @@
-# AI Documentation for MC-ORG
+# AI Documentation for Seam
 
-**Complete documentation for AI agents working on the MC-ORG project**
+**Complete documentation for AI agents working on the Seam project**
 
 ---
 
 ## 📚 Documentation Structure
 
 This directory contains comprehensive documentation designed for AI agents (like GitHub Copilot) to understand,
-maintain, and extend the MC-ORG codebase.
+maintain, and extend the Seam codebase.
 
 ### Core Documentation Files
 

--- a/documentation/reference/TROUBLESHOOTING_GUIDE.md
+++ b/documentation/reference/TROUBLESHOOTING_GUIDE.md
@@ -1,4 +1,4 @@
-# MC-ORG Troubleshooting Guide
+# Seam Troubleshooting Guide
 
 **Solutions to common errors and issues**
 

--- a/tasks/mco-134-navigation-chrome-page-shell.md
+++ b/tasks/mco-134-navigation-chrome-page-shell.md
@@ -45,7 +45,7 @@ Replace the old `createPage()` / `TopBar` / `BreadcrumbComponent` navigation sta
 
 The `appHeader()` function renders a `<header class="app-header">` at 56px height containing:
 
-1. **Logo** — `<span class="app-header__logo">` displaying "MC-ORG" in IBM Plex Mono.
+1. **Logo** — `<span class="app-header__logo">` displaying "Seam" in IBM Plex Mono.
 2. **Breadcrumb nav** — `<nav class="breadcrumb">` with segments separated by `›` (`\u203A`) in `--text-disabled`. Prior segments are `<a class="breadcrumb__item">` links. Current segment is a `<span class="breadcrumb__item breadcrumb__item--current">` in `--text-primary`. Font: IBM Plex Mono, `--text-sm`. Separator spans use class `breadcrumb__sep`.
 3. **Actions** — right-aligned `<div class="app-header__actions">` containing:
    - "Ideas" link (`/ideas`) — always visible
@@ -69,7 +69,7 @@ The `Worlds` segment links to `/worlds`. World name links to `/worlds/:worldId/p
 
 The `appHeader()` function renders a second div `<div class="app-header__mobile">` containing:
 
-1. **World name** — `<span class="app-header__world-name">` showing the current world name (or "MC-ORG" if no world context), centered, IBM Plex Mono
+1. **World name** — `<span class="app-header__world-name">` showing the current world name (or "Seam" if no world context), centered, IBM Plex Mono
 2. **Gear** — `<a class="app-header__link">` with `⚙` (`\u2699`) and `aria-label="Settings"`, right-aligned — conditionally rendered (same rules as desktop)
 
 No hamburger button is rendered. The existing hamburger button from the MCO-130 stub must be removed. Mobile navigation for this phase relies on breadcrumb/back links and in-page contextual links.
@@ -153,7 +153,7 @@ pageShell(pageTitle = "Ideas - MC-ORG", user = user) {
 ### Empty states
 
 - When `breadcrumbBlock` is null, the `<nav class="breadcrumb">` element is not rendered.
-- When `worldName` is null, the mobile world name displays "MC-ORG".
+- When `worldName` is null, the mobile world name displays "Seam".
 
 ### Edge cases
 
@@ -200,7 +200,7 @@ pageShell(pageTitle = "Ideas - MC-ORG", user = user) {
 - [ ] Current breadcrumb segment is `<span class="breadcrumb__item breadcrumb__item--current">` in `--text-primary`
 - [ ] Prior breadcrumb segments are `<a class="breadcrumb__item">` links
 - [ ] When `breadcrumbBlock` is null, no `<nav class="breadcrumb">` rendered
-- [ ] When `worldName` is null, mobile displays "MC-ORG"
+- [ ] When `worldName` is null, mobile displays "Seam"
 - [ ] Gear links to `/profile` when `worldId` and `projectId` are both null
 - [ ] Gear links to `/worlds/:worldId/settings` when `worldId` is set and `projectId` is null
 - [ ] Gear is NOT rendered (desktop or mobile) when `projectId` is set

--- a/tasks/mco-136-project-list-execute-view.md
+++ b/tasks/mco-136-project-list-execute-view.md
@@ -89,7 +89,7 @@ Mobile: stacked vertically, equal size.
 
 ### Breadcrumb / header
 
-Desktop: `[MC-ORG] Worlds › [World Name] ... Ideas ⚙`
+Desktop: `[Seam] Worlds › [World Name] ... Ideas ⚙`
 Mobile: `[World Name] ⚙`
 
 ### Mobile behaviour

--- a/tasks/mco-156-status-error-pages.md
+++ b/tasks/mco-156-status-error-pages.md
@@ -124,7 +124,7 @@ Triggered by `BannedPlugin` for any authenticated request from a user with
 `RolePlugins.kt`).
 
 - Heading: `Account Suspended`
-- Body: `Your account has been suspended from MC-ORG. If you believe this is in error,
+- Body: `Your account has been suspended from Seam. If you believe this is in error,
   contact support.`
 - **No CTA** — copy only
 - HTTP status: `403 Forbidden`, `Content-Type: text/html`

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,1 +1,1 @@
-# MC-ORG: A web-based tool for managing and organizing Minecraft projects
+# Seam: A web-based tool for managing and organizing Minecraft projects

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/config/ApiConfig.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/config/ApiConfig.kt
@@ -38,7 +38,7 @@ sealed class ApiConfig(
 }
 
 object ModrinthApiConfig : ApiConfig(AppConfig.modrinthBaseUrl) {
-    override fun getUserAgent() = "evegul/mcorg/main (even@mcorg.com)"
+    override fun getUserAgent() = "evegul/seam/main (even.gultvedt@gmail.com)"
 
     override fun getContentType() = ContentType.Application.FormUrlEncoded
 
@@ -79,5 +79,5 @@ object MojangLauncherMetaApiConfig : ApiConfig(AppConfig.launcherMetaBaseUrl) {
 class TestApiConfig : ApiConfig("https://api.example.com") {
     override fun getContentType(): ContentType = ContentType.Application.Json
     override fun acceptContentType(): ContentType = ContentType.Application.Json
-    override fun getUserAgent(): String = "MC-ORG-Test/1.0"
+    override fun getUserAgent(): String = "Seam-Test/1.0"
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/auth/commonsteps/CreateTokenStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/auth/commonsteps/CreateTokenStep.kt
@@ -4,6 +4,7 @@ import app.mcorg.domain.model.user.TokenProfile
 import app.mcorg.pipeline.Result
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.presentation.consts.ISSUER
 import app.mcorg.presentation.security.EIGHT_HOURS
 import app.mcorg.presentation.security.JwtHelper
 import app.mcorg.presentation.security.getKeys
@@ -20,7 +21,7 @@ data object CreateTokenStep : Step<TokenProfile, AppFailure.AuthError.CouldNotCr
         try {
             val builder = JWT.create()
                 .withAudience(JwtHelper.AUDIENCE)
-                .withIssuer("mcorg")
+                .withIssuer(ISSUER)
                 .withClaim("sub", input.id)
                 .withClaim("minecraft_username", input.minecraftUsername)
                 .withClaim("minecraft_uuid", input.uuid)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/consts/AuthConsts.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/consts/AuthConsts.kt
@@ -1,4 +1,4 @@
 package app.mcorg.presentation.consts
 
-const val AUTH_COOKIE = "MCORG-USER-TOKEN-V2"
-const val ISSUER = "mcorg"
+const val AUTH_COOKIE = "SEAM-USER-TOKEN-V2"
+const val ISSUER = "seam"

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/handleAuth.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/handleAuth.kt
@@ -30,7 +30,7 @@ suspend fun ApplicationCall.handleGetSignOut() {
         .toMap()
         .map { it.key to it.value.first() }
 
-    respondHtml(pageShell(pageTitle = "MC-ORG — Error") {
+    respondHtml(pageShell(pageTitle = "Seam — Error") {
         h1 {
             + "An error occurred"
         }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/security/jwt.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/security/jwt.kt
@@ -12,7 +12,7 @@ const val EIGHT_HOURS = 8 * 60 * 60 * 1000
 
 class JwtHelper {
     companion object {
-        const val AUDIENCE = "mcorg-webapp"
+        const val AUDIENCE = "seam-webapp"
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/admin/AdminPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/admin/AdminPage.kt
@@ -69,7 +69,7 @@ fun adminPage(
     totalUserCount: Int,
     totalWorldCount: Int,
 ): String = pageShell(
-    pageTitle = "MC-ORG — Admin",
+    pageTitle = "Seam — Admin",
     user = currentUser,
     stylesheets = listOf(
         "/static/styles/pages/admin-page.css",

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/Layout.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/Layout.kt
@@ -7,7 +7,7 @@ import kotlinx.html.p
 import kotlinx.html.stream.createHTML
 
 fun pageShell(
-    pageTitle: String = "MC-ORG",
+    pageTitle: String = "Seam",
     user: TokenProfile? = null,
     stylesheets: List<String> = emptyList(),
     scripts: List<String> = emptyList(),

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/Navigation.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/Navigation.kt
@@ -53,7 +53,7 @@ fun FlowContent.appHeader(
         div("app-header__desktop") {
             a(classes = "app-header__logo") {
                 href = "/"
-                +"MC-ORG"
+                +"Seam"
             }
 
             if (breadcrumbBlock != null) {
@@ -100,7 +100,7 @@ fun FlowContent.appHeader(
 
         div("app-header__mobile") {
             span("app-header__world-name") {
-                +(worldName ?: "MC-ORG")
+                +(worldName ?: "Seam")
             }
             if (showProfile) {
                 a(classes = "app-header__link") {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -34,7 +34,7 @@ fun projectDetailPage(
     view: String = "execute",
     isWorldAdmin: Boolean = false,
 ): String = pageShell(
-    pageTitle = "MC-ORG — ${project.name}",
+    pageTitle = "Seam — ${project.name}",
     user = user,
     stylesheets = listOf(
         "/static/styles/components/btn.css",

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectListPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectListPage.kt
@@ -54,7 +54,7 @@ fun projectListPage(
     edges: List<ProjectResourceEdge> = emptyList(),
     resume: ResumeHeroData? = null,
 ): String = pageShell(
-    pageTitle = "MC-ORG — ${world.name}",
+    pageTitle = "Seam — ${world.name}",
     user = user,
     stylesheets = listOf(
         "/static/styles/components/btn.css",
@@ -93,7 +93,7 @@ fun projectListPageWithPlanView(
     projects: List<ProjectPlanListItem>,
     isWorldAdmin: Boolean = false,
 ): String = pageShell(
-    pageTitle = "MC-ORG — ${world.name}",
+    pageTitle = "Seam — ${world.name}",
     user = user,
     stylesheets = listOf(
         "/static/styles/components/btn.css",

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/WorldListPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/WorldListPage.kt
@@ -36,7 +36,7 @@ fun worldListPage(
     supportedVersions: List<MinecraftVersion.Release>,
     pendingInvitations: List<Invite> = emptyList()
 ): String = pageShell(
-    pageTitle = "MC-ORG — Worlds",
+    pageTitle = "Seam — Worlds",
     user = user,
     stylesheets = listOf(
         "/static/styles/components/common.css",

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/error/BannedPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/error/BannedPage.kt
@@ -1,7 +1,7 @@
 package app.mcorg.presentation.templated.error
 
 fun bannedPage(): String = errorPageLayout(
-    pageTitle = "Account Suspended · MC-ORG",
+    pageTitle = "Account Suspended · Seam",
     heading = "Account Suspended",
-    body = "Your account has been suspended from MC-ORG. If you believe this is in error, contact support.",
+    body = "Your account has been suspended from Seam. If you believe this is in error, contact support.",
 )

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/error/ErrorPageLayout.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/error/ErrorPageLayout.kt
@@ -22,7 +22,7 @@ fun errorPageLayout(
     header("error-brand-bar") {
         a(classes = "error-brand-bar__logo") {
             href = "/"
-            +"MC-ORG"
+            +"Seam"
         }
     }
     main {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/error/NotFoundPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/error/NotFoundPage.kt
@@ -1,7 +1,7 @@
 package app.mcorg.presentation.templated.error
 
 fun notFoundPage(): String = errorPageLayout(
-    pageTitle = "404 — Not Found · MC-ORG",
+    pageTitle = "404 — Not Found · Seam",
     heading = "404 — Not Found",
     body = "That page doesn't exist or has moved.",
     ctaText = "Back to worlds",

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/error/ServerErrorPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/error/ServerErrorPage.kt
@@ -1,7 +1,7 @@
 package app.mcorg.presentation.templated.error
 
 fun serverErrorPage(): String = errorPageLayout(
-    pageTitle = "500 — Something Broke · MC-ORG",
+    pageTitle = "500 — Something Broke · Seam",
     heading = "500 — Something Broke",
     body = "An unexpected error occurred. The error has been logged. Try again, or head back to your worlds.",
     ctaText = "Back to worlds",

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/DraftListPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/DraftListPage.kt
@@ -27,7 +27,7 @@ fun draftListPage(
     user: TokenProfile,
     drafts: List<IdeaDraft>
 ): String = pageShell(
-    pageTitle = "MC-ORG — My Drafts",
+    pageTitle = "Seam — My Drafts",
     user = user,
     stylesheets = listOf(
         "/static/styles/components/btn.css",

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaPage.kt
@@ -27,7 +27,7 @@ fun ideaPage(
     idea: Idea,
     comments: List<Comment>,
 ): String = pageShell(
-    pageTitle = "MC-ORG — ${idea.name}",
+    pageTitle = "Seam — ${idea.name}",
     user = user,
     stylesheets = listOf(
         "/static/styles/components/btn.css",

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeasPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeasPage.kt
@@ -15,7 +15,7 @@ fun ideasPage(
     result: PaginatedResult<Idea>,
     filters: IdeaSearchFilters = IdeaSearchFilters()
 ): String = pageShell(
-    pageTitle = "MC-ORG — Ideas",
+    pageTitle = "Seam — Ideas",
     user = user,
     stylesheets = listOf(
         "/static/styles/components/btn.css",

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftWizardPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftWizardPage.kt
@@ -62,7 +62,7 @@ fun draftWizardPage(
     stage: DraftWizardStage,
     supportedVersions: List<MinecraftVersion.Release>
 ): String = pageShell(
-    pageTitle = "MC-ORG — Edit Draft",
+    pageTitle = "Seam — Edit Draft",
     user = user,
     stylesheets = listOf(
         "/static/styles/components/btn.css",

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/landing/LandingPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/landing/LandingPage.kt
@@ -15,7 +15,7 @@ import kotlinx.html.span
 import kotlinx.html.ul
 
 fun landingPage(microsoftUrl: String): String = pageShell(
-    pageTitle = "MC-ORG — Minecraft Resource Planner",
+    pageTitle = "Seam — Minecraft Resource Planner",
     stylesheets = listOf(
         "/static/styles/pages/landing-page.css",
     )
@@ -23,7 +23,7 @@ fun landingPage(microsoftUrl: String): String = pageShell(
     header("landing-brand-bar") {
         a(classes = "landing-brand-bar__logo") {
             href = "/"
-            +"MC-ORG"
+            +"Seam"
         }
     }
     main {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/profile/ProfilePage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/profile/ProfilePage.kt
@@ -16,7 +16,7 @@ import kotlinx.html.div
 import kotlinx.html.main
 
 fun profilePage(user: TokenProfile): String = pageShell(
-    pageTitle = "MC-ORG — Profile",
+    pageTitle = "Seam — Profile",
     user = user,
     stylesheets = listOf(
         "/static/styles/components/danger-zone.css",

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/settings/SettingsPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/settings/SettingsPage.kt
@@ -28,7 +28,7 @@ data class SettingsPageData(
 )
 
 fun worldSettingsPage(user: TokenProfile, data: SettingsPageData): String = pageShell(
-    pageTitle = "MC-ORG — ${data.world.name} Settings",
+    pageTitle = "Seam — ${data.world.name} Settings",
     user = user,
     stylesheets = listOf(
         "/static/styles/components/form.css",

--- a/webapp/mc-web/src/main/resources/static/styleguide.html
+++ b/webapp/mc-web/src/main/resources/static/styleguide.html
@@ -9,7 +9,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>MC-ORG — palette test</title>
+    <title>Seam — palette test</title>
     <link rel="stylesheet" href="/static/styles/reset.css">
     <link rel="stylesheet" href="/static/styles/design-tokens.css">
     <link rel="stylesheet" href="/static/styles/components/btn.css">

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/auth/CreateTokenStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/auth/CreateTokenStepTest.kt
@@ -3,6 +3,7 @@ package app.mcorg.pipeline.auth
 import app.mcorg.pipeline.auth.commonsteps.CreateTokenStep
 import app.mcorg.test.fixtures.TestDataFactory
 import app.mcorg.pipeline.TestUtils
+import app.mcorg.presentation.consts.ISSUER
 import app.mcorg.presentation.security.JwtHelper
 import com.auth0.jwt.JWT
 import org.junit.jupiter.api.Test
@@ -36,7 +37,7 @@ class CreateTokenStepTest {
 
         // Verify JWT structure
         val decodedJWT = JWT.decode(result)
-        assertEquals("mcorg", decodedJWT.issuer)
+        assertEquals(ISSUER, decodedJWT.issuer)
         assertEquals(JwtHelper.AUDIENCE, decodedJWT.audience.first())
         assertEquals(123, decodedJWT.getClaim("sub").asInt())
         assertEquals("TestPlayer", decodedJWT.getClaim("minecraft_username").asString())

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/NavigationTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/NavigationTest.kt
@@ -30,7 +30,7 @@ class NavigationTest {
     fun `appHeader renders logo`() {
         val html = render { appHeader() }
         assertTrue(html.contains("app-header__logo"))
-        assertTrue(html.contains("MC-ORG"))
+        assertTrue(html.contains("Seam"))
     }
 
     @Test
@@ -94,13 +94,13 @@ class NavigationTest {
     }
 
     @Test
-    fun `mobile header shows MC-ORG when no world name`() {
+    fun `mobile header shows Seam when no world name`() {
         val html = render { appHeader() }
         assertTrue(html.contains("app-header__world-name"))
-        // The mobile section should contain MC-ORG as fallback
+        // The mobile section should contain Seam as fallback
         val mobileStart = html.indexOf("app-header__mobile")
         val mobileSection = html.substring(mobileStart)
-        assertTrue(mobileSection.contains("MC-ORG"))
+        assertTrue(mobileSection.contains("Seam"))
     }
 
     @Test


### PR DESCRIPTION
Renames the **user-visible product name** from MC-ORG to **Seam**. The internal name (`mc-org` / `app.mcorg`) is deliberately left untouched for the repo, Maven modules, Java package, and infrastructure (Fly app, Neon project, DB).

## Changes

**User-visible UI**
- All page titles, nav brand + mobile fallback, landing/error-page brand, banned-page copy, styleguide `<title>`

**Auth identity** (one-time forced re-login — currently a single user)
- Cookie `MCORG-USER-TOKEN-V2` → `SEAM-USER-TOKEN-V2`
- JWT issuer `"mcorg"` → `"seam"`, audience `"mcorg-webapp"` → `"seam-webapp"`
- `CreateTokenStep` now uses the `ISSUER` constant instead of a hardcoded literal (token creation/validation can't drift)

**External identity**
- Modrinth `User-Agent` → `evegul/seam/main (even.gultvedt@gmail.com)`
- README contact email (dead `mcorg.app` domain) → personal email

**Docs**
- Product-name mentions → Seam across README / CLAUDE.md / reference docs / task specs
- Root README + CLAUDE.md gain a **Naming note**: `mc-org` / `app.mcorg` remain the internal name and must not be renamed

## Kept internal (unchanged)
`app.mcorg` package, module names, `SourceType("mcorg:...")` data ids, `mcorg.fly.dev` / Fly app / Neon / DB / pool names, `mcorg-webapp` Docker image tag.

## Note on `const val`
`ISSUER`/`AUDIENCE` are Kotlin `const val` (inlined at compile time). After changing them, a **clean rebuild** is required or tests fail on stale inlined values — CI builds clean so it's unaffected.

## Verification
- `mvn clean compile` — pass
- Unit: **535/0**
- Database: **74/0**
- Grep audit: no stray user-visible `MC-ORG`; all internal identifiers preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)