### PR TITLE
Seam polish: breadcrumb, MS sign-in button, world-card a11y

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -14,6 +14,7 @@ import app.mcorg.presentation.templated.dsl.pages.projectDetailPage
 import app.mcorg.presentation.utils.getProjectId
 import app.mcorg.presentation.utils.getUser
 import app.mcorg.presentation.utils.getWorldId
+import app.mcorg.presentation.utils.getWorldName
 import app.mcorg.presentation.utils.respondBadRequest
 import app.mcorg.presentation.utils.respondHtml
 import io.ktor.server.application.ApplicationCall
@@ -46,5 +47,7 @@ suspend fun ApplicationCall.handleGetProject() {
 
     val isAdmin = ValidateWorldMemberRole<Unit>(user, Role.ADMIN, worldId).process(Unit) is Result.Success
 
-    respondHtml(projectDetailPage(user, project, resources, tasks, view, isWorldAdmin = isAdmin))
+    val worldName = getWorldName(worldId)
+
+    respondHtml(projectDetailPage(user, project, worldName, resources, tasks, view, isWorldAdmin = isAdmin))
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/WorldCard.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/WorldCard.kt
@@ -28,6 +28,7 @@ fun FlowContent.worldCard(world: World) {
                 div("world-card__progress-fill${if (complete) " world-card__progress-fill--complete" else ""}") {
                     attributes["style"] = "width: ${progressPercent}%"
                     attributes["role"] = "progressbar"
+                    attributes["aria-label"] = "Projects completed in ${world.name}"
                     attributes["aria-valuenow"] = world.completedProjects.toString()
                     attributes["aria-valuemin"] = "0"
                     attributes["aria-valuemax"] = world.totalProjects.toString()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -29,6 +29,7 @@ import kotlinx.html.stream.createHTML
 fun projectDetailPage(
     user: TokenProfile,
     project: Project,
+    worldName: String,
     resources: List<ResourceGatheringItem>,
     tasks: List<ActionTask>,
     view: String = "execute",
@@ -62,7 +63,7 @@ fun projectDetailPage(
         isWorldAdmin = isWorldAdmin,
         breadcrumbBlock = {
             link("Worlds", "/worlds")
-                .link(project.name, "/worlds/${project.worldId}/projects")
+                .link(worldName, "/worlds/${project.worldId}/projects")
                 .current(project.name)
         }
     )

--- a/webapp/mc-web/src/main/resources/static/styles/pages/landing-page.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/landing-page.css
@@ -74,10 +74,10 @@
     height: 41px;
     min-width: 215px;
     padding: 0 12px;
-    background: #2F2F2F;
-    border: none;
+    background: #FFFFFF;
+    border: 1px solid #8C8C8C;
     border-radius: 0;
-    color: #FFFFFF;
+    color: #5E5E5E;
     font-family: "Segoe UI", "Segoe UI Web (West European)", -apple-system, "Helvetica Neue", Arial, sans-serif;
     font-size: 15px;
     font-weight: 600;
@@ -88,8 +88,8 @@
 
 .btn-microsoft:hover,
 .btn-microsoft:focus-visible {
-    background: #1F1F1F;
-    color: #FFFFFF;
+    background: #F3F3F3;
+    color: #5E5E5E;
     text-decoration: none;
 }
 


### PR DESCRIPTION
Page-by-page review fixes — three small, independent polish items.

## Changes
- **Project breadcrumb bug** — was `Worlds > {project} > {project}` (middle crumb repeated the project name). Now `Worlds > {world} > {project}`: `projectDetailPage` takes a `worldName`, and `handleGetProject` resolves it via `getWorldName(worldId)`.
- **Microsoft sign-in button** — was dark-mode (`#2F2F2F`/white/no border). Switched to Microsoft's light branding variant: `#FFFFFF` bg, `#5E5E5E` text, `1px solid #8C8C8C` border. (MCO-213 acceptance criterion.)
- **World-card progress bar a11y** (MCO-99) — added `aria-label` so screen readers announce what the progress value measures (it had `role=progressbar` + `aria-value*` but no label).

## Testing
- `mvn clean compile` — clean
- `./webapp/scripts/test.sh --database` — 74 tests pass, 0 failures

## Notes
- The landing page itself is already rewritten (token-based, responsive); only the dark-mode button remained from the writeup. Broader landing rewrite is tracked in MCO-213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)