### PR TITLE
Align app sign-in page with seam.gg marketing site

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/Layout.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/Layout.kt
@@ -21,7 +21,18 @@ fun pageShell(
                 name = "viewport"
                 content = "width=device-width, initial-scale=1"
             }
+            // The app is behind auth and not a marketing surface — keep it out
+            // of search indexes so seam.gg stays the canonical result.
+            meta {
+                name = "robots"
+                content = "noindex"
+            }
             title { +pageTitle }
+            link {
+                rel = "icon"
+                type = "image/svg+xml"
+                href = "/static/seam-favicon.svg"
+            }
             link {
                 rel = "stylesheet"
                 href = "/static/styles/reset.css"

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/landing/LandingPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/landing/LandingPage.kt
@@ -5,14 +5,11 @@ import app.mcorg.presentation.templated.dsl.pageShell
 import kotlinx.html.a
 import kotlinx.html.div
 import kotlinx.html.h1
-import kotlinx.html.h2
 import kotlinx.html.header
 import kotlinx.html.img
-import kotlinx.html.li
 import kotlinx.html.main
 import kotlinx.html.p
 import kotlinx.html.span
-import kotlinx.html.ul
 
 fun landingPage(microsoftUrl: String): String = pageShell(
     pageTitle = "Seam — Minecraft Resource Planner",
@@ -30,7 +27,6 @@ fun landingPage(microsoftUrl: String): String = pageShell(
         container {
             div("landing-page") {
                 landingHero(microsoftUrl)
-                landingFeatures()
             }
         }
     }
@@ -54,27 +50,11 @@ private fun kotlinx.html.FlowContent.landingHero(microsoftUrl: String) {
             }
             span { +"Sign in with Microsoft" }
         }
-    }
-}
-
-private fun kotlinx.html.FlowContent.landingFeatures() {
-    ul("landing-features") {
-        li("landing-feature") {
-            h2("landing-feature__title") { +"Define projects" }
-            p("landing-feature__body") {
-                +"Capture each build, farm, or contraption with the resources it needs and the tasks it depends on."
-            }
-        }
-        li("landing-feature") {
-            h2("landing-feature__title") { +"Track resources" }
-            p("landing-feature__body") {
-                +"Increment counters one stack at a time while mining; see progress at a glance from anywhere."
-            }
-        }
-        li("landing-feature") {
-            h2("landing-feature__title") { +"Resolve dependencies" }
-            p("landing-feature__body") {
-                +"Generate a production path that respects what you've already built and what's still planned."
+        p("landing-hero__learn-more") {
+            +"New to Seam? "
+            a {
+                href = "https://seam.gg"
+                +"See how it works →"
             }
         }
     }

--- a/webapp/mc-web/src/main/resources/static/seam-favicon.svg
+++ b/webapp/mc-web/src/main/resources/static/seam-favicon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <defs>
+    <clipPath id="bounds">
+      <rect width="32" height="32" rx="6"/>
+    </clipPath>
+  </defs>
+
+  <!-- Background (raised note paper) -->
+  <rect width="32" height="32" rx="6" fill="#FCF7EA"/>
+
+  <!-- Top-left triangle (aged tan paper) — line anchored bottom-left, top floating -->
+  <polygon points="0,0 24,0 0,32" fill="#EBE1C8" clip-path="url(#bounds)"/>
+
+  <!-- Seam line — bottom end at bottom-left corner, top end floating -->
+  <line x1="-1" y1="33" x2="25" y2="-1" stroke="#D6C6A2" stroke-width="2.5" stroke-linecap="round"/>
+  <line x1="0" y1="32" x2="24" y2="0" stroke="#2C6E9E" stroke-width="1.5" stroke-linecap="round"/>
+
+  <!-- Border (pencil rule) -->
+  <rect width="32" height="32" rx="6" fill="none" stroke="#C2AE82" stroke-width="1"/>
+</svg>

--- a/webapp/mc-web/src/main/resources/static/styles/pages/landing-page.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/landing-page.css
@@ -1,6 +1,8 @@
 /* ==========================================================================
    LANDING PAGE
-   Unauthenticated marketing surface — brand bar + hero + feature cards
+   Unauthenticated sign-in surface — brand bar + hero + sign-in CTA. The
+   product pitch lives on the marketing site (seam.gg); this page only gets
+   people into the app, with a "learn more" link back to seam.gg.
    ========================================================================== */
 
 .landing-brand-bar {
@@ -61,6 +63,13 @@
     margin-top: var(--space-2);
 }
 
+.landing-hero__learn-more {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    margin: 0;
+}
+
 /*
    Microsoft "Sign in with Microsoft" button — branded per Microsoft's identity
    platform guidelines. Colors, typography, and dimensions are dictated by
@@ -104,47 +113,8 @@
     flex-shrink: 0;
 }
 
-.landing-features {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: var(--space-4);
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-
-.landing-feature {
-    background: var(--bg-surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: var(--space-5);
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2);
-}
-
-.landing-feature__title {
-    font-family: var(--font-ui);
-    font-size: var(--text-base);
-    font-weight: 600;
-    color: var(--text-primary);
-    margin: 0;
-}
-
-.landing-feature__body {
-    font-family: var(--font-body);
-    font-size: var(--text-sm);
-    color: var(--text-muted);
-    margin: 0;
-    line-height: 1.5;
-}
-
 @media (max-width: 768px) {
     .landing-hero__title {
         font-size: 24px;
-    }
-
-    .landing-features {
-        grid-template-columns: 1fr;
     }
 }


### PR DESCRIPTION
## What

Trims the unauthenticated app sign-in page (`app.seam.gg`) to its real job — getting people into the app — and hands the product pitch off to the marketing site (`seam.gg`). Done as part of aligning the two surfaces now that the marketing landing page uses the shared "Daylight Field Notebook" theme.

## Changes

- **Remove the duplicated feature-card pitch** from the landing page. The "Define projects / Track resources / Resolve dependencies" cards re-sold what `seam.gg` already covers, in a slightly different voice — duplicate content split across two domains.
- **Add a "New to Seam? See how it works →" link** back to `https://seam.gg`, closing the funnel loop (marketing → app already existed; this adds app → marketing).
- **`noindex` the app** via a `robots` meta in `pageShell` — the app is behind auth and not a marketing surface, so keep it out of search indexes and let `seam.gg` be the canonical result.
- **Shared favicon** — add `seam-favicon.svg` (identical to the one on `seam.gg`) and link it in `pageShell` so the browser tab matches across both domains.
- Clean up the now-dead `.landing-feature*` CSS and unused Kotlin imports.

The product rename to "Seam" already landed in #310; this builds on it.

## Verification

`mvn -pl mc-web -am compile` → BUILD SUCCESS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)