### PR TITLE
Gate TEST preview behind Basic Auth + allowlist demo sign-in

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -194,6 +194,7 @@ jobs:
             DB_USER=${{ env.DB_USERNAME }} \
             RSA_PUBLIC_KEY="${{ secrets.RSA_PUBLIC_KEY }}" \
             RSA_PRIVATE_KEY="${{ secrets.RSA_PRIVATE_KEY }}" \
+            PREVIEW_PASSWORD="${{ secrets.PREVIEW_PASSWORD }}" \
             --app mcorg-dev-${{ github.event.number }} --stage
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/Application.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/Application.kt
@@ -2,6 +2,7 @@ package app.mcorg
 
 import app.mcorg.presentation.plugins.configureHTTP
 import app.mcorg.presentation.plugins.configureMonitoring
+import app.mcorg.presentation.plugins.configurePreviewGate
 import app.mcorg.presentation.plugins.configureSessions
 import app.mcorg.presentation.plugins.configureStatusStaticRouter
 import app.mcorg.presentation.router.configureAppRouter
@@ -28,6 +29,7 @@ private fun defaultServer(module: Application.() -> Unit) =
     )
 
 private fun Application.module() {
+    configurePreviewGate()
     configureHTTP()
     configureMonitoring()
     configureAppRouter()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/config/AppConfig.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/config/AppConfig.kt
@@ -36,6 +36,10 @@ object AppConfig {
 
     var demoUser: String = "evegul"
 
+    // Shared secret for the TEST preview's HTTP Basic Auth gate. Required in TEST (fails closed
+    // if unset); unused in LOCAL and PRODUCTION. See PreviewGate.
+    var previewPassword: String? = null
+
     init {
         val errors = mutableListOf<String>()
         System.getenv("DB_URL")?.let { dbUrl = it } ?: errors.add("DB_URL is not set")
@@ -114,6 +118,11 @@ object AppConfig {
         System.getenv("LAUNCHER_META_BASE_URL")?.let { launcherMetaBaseUrl = it }
 
         System.getenv("DEMO_USER")?.let { demoUser = it }
+
+        System.getenv("PREVIEW_PASSWORD")?.let { previewPassword = it }
+        if (env == Test && previewPassword.isNullOrBlank()) {
+            errors.add("PREVIEW_PASSWORD is not set (required in TEST to gate the public preview)")
+        }
 
         if (errors.isNotEmpty()) {
             logger.error("Invalid configuration:\n${errors.joinToString("\n")}")

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/auth/DemoSignInPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/auth/DemoSignInPipeline.kt
@@ -1,6 +1,7 @@
 package app.mcorg.pipeline.auth
 
 import app.mcorg.config.AppConfig
+import app.mcorg.domain.Env
 import app.mcorg.domain.Production
 import app.mcorg.domain.model.user.MinecraftProfile
 import app.mcorg.domain.pipeline.pipeline
@@ -14,14 +15,25 @@ import io.ktor.server.application.*
 import io.ktor.server.response.*
 import kotlin.random.Random
 
-suspend fun ApplicationCall.handleDemoSignIn() {
-    val demoUsername = if (AppConfig.env == Production) {
-        AppConfig.demoUser
-    } else when(val requestedUsername = request.queryParameters["username"]?.trim()) {
-        null, "" -> AppConfig.demoUser
-        "random" -> "DemoUser_${Random.nextInt(1000, 9999)}"
-        else -> requestedUsername
+// Fixed roster of demo identities selectable via ?username= in non-production environments.
+// A closed allowlist keeps the caller from steering the UUID lookup (uuid = "$username-uuid")
+// onto an arbitrary — or future privileged — existing account. Unknown values fall back to
+// the default demo user rather than being honoured.
+internal val TEST_DEMO_USERNAMES = setOf("alex", "steve", "lilpebblez")
+
+internal fun resolveDemoUsername(env: Env, requested: String?, defaultUser: String): String {
+    val name = requested?.trim()
+    return when {
+        env == Production -> defaultUser
+        name.isNullOrEmpty() -> defaultUser
+        name == "random" -> "DemoUser_${Random.nextInt(1000, 9999)}"
+        name == defaultUser || name in TEST_DEMO_USERNAMES -> name
+        else -> defaultUser
     }
+}
+
+suspend fun ApplicationCall.handleDemoSignIn() {
+    val demoUsername = resolveDemoUsername(AppConfig.env, request.queryParameters["username"], AppConfig.demoUser)
     val demoUuid = "${demoUsername}-uuid"
     val redirectPath = parameters["redirect_to"] ?: "/"
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/plugins/PreviewGate.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/plugins/PreviewGate.kt
@@ -1,0 +1,71 @@
+package app.mcorg.presentation.plugins
+
+import app.mcorg.config.AppConfig
+import app.mcorg.domain.Test
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCallPipeline
+import io.ktor.server.application.call
+import io.ktor.server.request.header
+import io.ktor.server.request.path
+import io.ktor.server.response.header
+import io.ktor.server.response.respondText
+import org.slf4j.LoggerFactory
+import java.security.MessageDigest
+import java.util.Base64
+
+private val logger = LoggerFactory.getLogger("PreviewGate")
+private const val REALM = "Seam Preview"
+private const val GATE_USERNAME = "admin"
+
+// Liveness probes must reach the app without credentials so the platform can tell it is up.
+private val UNGATED_PATHS = setOf("/test/ping")
+
+/**
+ * HTTP Basic Auth gate for the public preview deployment.
+ *
+ * Active only when ENV=TEST — the ephemeral Fly/Neon preview that is reachable from the
+ * internet and fronts a copy-on-write fork of production data. LOCAL (localhost-only, even
+ * with SKIP_MICROSOFT_SIGN_IN) and PRODUCTION (real Microsoft sign-in) are never gated.
+ *
+ * Fails closed: if PREVIEW_PASSWORD is unset in TEST, every request is rejected rather than
+ * leaving the preview open. Sits ahead of routing, so it covers demo sign-in, app routes,
+ * and static assets uniformly.
+ */
+fun Application.configurePreviewGate() {
+    if (AppConfig.env != Test) return
+
+    intercept(ApplicationCallPipeline.Plugins) {
+        if (call.request.path() in UNGATED_PATHS) return@intercept
+
+        val password = AppConfig.previewPassword
+        if (password.isNullOrBlank()) {
+            logger.error("PREVIEW_PASSWORD is not set in TEST environment — denying all requests")
+            call.respondText("Preview gate is misconfigured.", status = HttpStatusCode.ServiceUnavailable)
+            return@intercept finish()
+        }
+
+        if (!call.request.header(HttpHeaders.Authorization).isValidBasic(password)) {
+            call.response.header(HttpHeaders.WWWAuthenticate, "Basic realm=\"$REALM\", charset=\"UTF-8\"")
+            call.respondText("Preview access required.", status = HttpStatusCode.Unauthorized)
+            return@intercept finish()
+        }
+    }
+}
+
+/** Validates a `Basic` Authorization header against the pinned username and expected password. */
+private fun String?.isValidBasic(expectedPassword: String): Boolean {
+    if (this == null || !startsWith("Basic ")) return false
+    val decoded = try {
+        String(Base64.getDecoder().decode(removePrefix("Basic ").trim()), Charsets.UTF_8)
+    } catch (_: IllegalArgumentException) {
+        return false
+    }
+    val username = decoded.substringBefore(':')
+    val password = decoded.substringAfter(':', missingDelimiterValue = "")
+    return constantTimeEquals(username, GATE_USERNAME) && constantTimeEquals(password, expectedPassword)
+}
+
+private fun constantTimeEquals(a: String, b: String): Boolean =
+    MessageDigest.isEqual(a.toByteArray(Charsets.UTF_8), b.toByteArray(Charsets.UTF_8))

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/auth/ResolveDemoUsernameTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/auth/ResolveDemoUsernameTest.kt
@@ -1,0 +1,49 @@
+package app.mcorg.pipeline.auth
+
+import app.mcorg.domain.Local
+import app.mcorg.domain.Production
+import app.mcorg.domain.Test as TestEnv
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ResolveDemoUsernameTest {
+
+    private val default = "evegul"
+
+    @Test
+    fun `allowlisted persona is honoured in non-production`() {
+        assertEquals("alex", resolveDemoUsername(TestEnv, "alex", default))
+        assertEquals("steve", resolveDemoUsername(Local, "steve", default))
+        assertEquals("lilpebblez", resolveDemoUsername(TestEnv, "lilpebblez", default))
+    }
+
+    @Test
+    fun `default demo user is always allowed`() {
+        assertEquals(default, resolveDemoUsername(TestEnv, default, default))
+    }
+
+    @Test
+    fun `unknown username falls back to the default user`() {
+        assertEquals(default, resolveDemoUsername(TestEnv, "attacker", default))
+        assertEquals(default, resolveDemoUsername(TestEnv, "superadmin", default))
+    }
+
+    @Test
+    fun `null or blank falls back to the default user`() {
+        assertEquals(default, resolveDemoUsername(TestEnv, null, default))
+        assertEquals(default, resolveDemoUsername(TestEnv, "   ", default))
+    }
+
+    @Test
+    fun `random yields a generated demo user`() {
+        assertTrue(resolveDemoUsername(TestEnv, "random", default).startsWith("DemoUser_"))
+    }
+
+    @Test
+    fun `production ignores the requested username`() {
+        assertEquals(default, resolveDemoUsername(Production, "alex", default))
+        assertEquals(default, resolveDemoUsername(Production, "random", default))
+        assertEquals(default, resolveDemoUsername(Production, "attacker", default))
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/plugins/PreviewGateIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/plugins/PreviewGateIT.kt
@@ -1,0 +1,117 @@
+package app.mcorg.presentation.plugins
+
+import app.mcorg.config.AppConfig
+import app.mcorg.domain.Local
+import app.mcorg.domain.Test as TestEnv
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import java.util.Base64
+import kotlin.test.assertEquals
+
+class PreviewGateIT {
+
+    @AfterEach
+    fun reset() {
+        AppConfig.env = Local
+        AppConfig.previewPassword = null
+    }
+
+    private fun basic(user: String, pass: String) =
+        "Basic " + Base64.getEncoder().encodeToString("$user:$pass".toByteArray())
+
+    private fun ApplicationTestBuilder.gatedApp() {
+        application { configurePreviewGate() }
+        routing {
+            get("/x") { call.respondText("ok") }
+            get("/test/ping") { call.respondText("OK") }
+        }
+    }
+
+    @Test
+    fun `TEST without credentials returns 401 with a Basic challenge`() = testApplication {
+        AppConfig.env = TestEnv
+        AppConfig.previewPassword = "s3cret"
+        gatedApp()
+
+        val res = client.get("/x")
+
+        assertEquals(HttpStatusCode.Unauthorized, res.status)
+        assertEquals("Basic realm=\"Seam Preview\", charset=\"UTF-8\"", res.headers[HttpHeaders.WWWAuthenticate])
+    }
+
+    @Test
+    fun `TEST with the correct username and password passes through`() = testApplication {
+        AppConfig.env = TestEnv
+        AppConfig.previewPassword = "s3cret"
+        gatedApp()
+
+        val res = client.get("/x") { header(HttpHeaders.Authorization, basic("admin", "s3cret")) }
+
+        assertEquals(HttpStatusCode.OK, res.status)
+        assertEquals("ok", res.bodyAsText())
+    }
+
+    @Test
+    fun `TEST with a wrong password returns 401`() = testApplication {
+        AppConfig.env = TestEnv
+        AppConfig.previewPassword = "s3cret"
+        gatedApp()
+
+        val res = client.get("/x") { header(HttpHeaders.Authorization, basic("admin", "nope")) }
+
+        assertEquals(HttpStatusCode.Unauthorized, res.status)
+    }
+
+    @Test
+    fun `TEST with a wrong username returns 401`() = testApplication {
+        AppConfig.env = TestEnv
+        AppConfig.previewPassword = "s3cret"
+        gatedApp()
+
+        val res = client.get("/x") { header(HttpHeaders.Authorization, basic("root", "s3cret")) }
+
+        assertEquals(HttpStatusCode.Unauthorized, res.status)
+    }
+
+    @Test
+    fun `TEST fails closed with 503 when the password is unset`() = testApplication {
+        AppConfig.env = TestEnv
+        AppConfig.previewPassword = null
+        gatedApp()
+
+        val res = client.get("/x") { header(HttpHeaders.Authorization, basic("admin", "whatever")) }
+
+        assertEquals(HttpStatusCode.ServiceUnavailable, res.status)
+    }
+
+    @Test
+    fun `LOCAL is never gated`() = testApplication {
+        AppConfig.env = Local
+        AppConfig.previewPassword = "s3cret"
+        gatedApp()
+
+        val res = client.get("/x")
+
+        assertEquals(HttpStatusCode.OK, res.status)
+    }
+
+    @Test
+    fun `health probe path is reachable without credentials in TEST`() = testApplication {
+        AppConfig.env = TestEnv
+        AppConfig.previewPassword = "s3cret"
+        gatedApp()
+
+        val res = client.get("/test/ping")
+
+        assertEquals(HttpStatusCode.OK, res.status)
+    }
+}


### PR DESCRIPTION
## Why

The ephemeral preview (`mcorg-dev-<PR#>.fly.dev`, `ENV=TEST` + `SKIP_MICROSOFT_SIGN_IN=true`) was a **public, unauthenticated** endpoint fronting a copy-on-write **fork of production data**, with demo sign-in accepting an **arbitrary `?username=`**. Anyone on the internet could sign in as any identity and read/write the forked data. Found during a security review of the demo sign-in.

## What

**1. `PreviewGate` (new)** — application-level HTTP Basic Auth, intercepting ahead of routing so it covers demo sign-in, app routes, and static assets uniformly.
- Active **only when `ENV=TEST`**. Local (localhost-only) and Production are never gated.
- Pinned username **`admin`** + `PREVIEW_PASSWORD` secret; constant-time compare.
- **Fails closed**: 503 for all requests if `PREVIEW_PASSWORD` is unset in TEST (logs a startup config error too).
- Exempts `/test/ping` so liveness probes work without credentials.

**2. `resolveDemoUsername`** — `?username=` now honours only a closed allowlist (`alex`, `steve`, `lilpebblez`, + the configured demo user) plus `random`; unknown values fall back to the default user instead of steering the `"$username-uuid"` lookup onto an arbitrary or future-privileged account. Production still ignores the param.

**3. `dev.yml`** — passes `PREVIEW_PASSWORD` through to the preview Fly app secrets.

## ⚠️ Required before this gate works
Add a **`PREVIEW_PASSWORD`** GitHub Actions secret (repo / `dev` environment). Without it the preview deploy fails closed (503). Sign in to the preview with username `admin` + that password.

## Tests
- `ResolveDemoUsernameTest` — allowlist, fallback, random, production-ignores-param (6).
- `PreviewGateIT` — 401 challenge, correct creds pass, wrong password/username rejected, fail-closed 503, Local ungated, health path open (7).
- Existing `DemoSignInIT` / `GetSignInIT` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)