### PR TITLE
feat: Litematica upload in project "Add resources" flow (MCO-216)

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
@@ -65,7 +65,7 @@ suspend fun ApplicationCall.handleCreateProjectFromSchematic() {
     }
 }
 
-private object ReceiveSchematicStep : Step<MultiPartData, AppFailure, SchematicUpload> {
+object ReceiveSchematicStep : Step<MultiPartData, AppFailure, SchematicUpload> {
     override suspend fun process(input: MultiPartData): Result<AppFailure, SchematicUpload> {
         var content: ByteArray? = null
         var fileName: String? = null
@@ -98,7 +98,7 @@ private object ReceiveSchematicStep : Step<MultiPartData, AppFailure, SchematicU
     }
 }
 
-private object ParseSchematicStep : Step<SchematicUpload, AppFailure, Litematica> {
+object ParseSchematicStep : Step<SchematicUpload, AppFailure, Litematica> {
     override suspend fun process(input: SchematicUpload): Result<AppFailure, Litematica> {
         return when (val parsed = LitematicaReader.readLitematica(input.content)) {
             is Result.Failure -> Result.failure(
@@ -109,11 +109,14 @@ private object ParseSchematicStep : Step<SchematicUpload, AppFailure, Litematica
     }
 }
 
-private data class MapSchematicToProjectStep(
+/**
+ * Resolves a parsed [Litematica]'s materials against the world version's item catalog.
+ * Shared by the "create project from schematic" and "add resources from schematic" flows.
+ */
+data class MapSchematicToMaterialsStep(
     val availableItems: List<Item>,
-    val upload: SchematicUpload,
-) : Step<Litematica, AppFailure, SchematicProject> {
-    override suspend fun process(input: Litematica): Result<AppFailure, SchematicProject> {
+) : Step<Litematica, AppFailure, List<Pair<Item, Int>>> {
+    override suspend fun process(input: Litematica): Result<AppFailure, List<Pair<Item, Int>>> {
         if (input.items.isEmpty()) {
             return Result.failure(
                 AppFailure.customValidationError("schematicFile", "The schematic contains no materials")
@@ -121,12 +124,8 @@ private data class MapSchematicToProjectStep(
         }
 
         val byId = availableItems.associateBy { it.id }
-        val requirements = mutableMapOf<Item, Int>()
-        val unknown = mutableListOf<String>()
-
-        for ((itemId, amount) in input.items) {
-            val item = byId[itemId]
-            if (item == null) unknown.add(itemId) else requirements[item] = amount
+        val requirements = input.items.mapNotNull { (itemId, amount) ->
+            byId[itemId]?.let { it to amount }
         }
 
         if (requirements.isEmpty()) {
@@ -142,12 +141,26 @@ private data class MapSchematicToProjectStep(
             )
         }
 
+        return Result.success(requirements)
+    }
+}
+
+private data class MapSchematicToProjectStep(
+    val availableItems: List<Item>,
+    val upload: SchematicUpload,
+) : Step<Litematica, AppFailure, SchematicProject> {
+    override suspend fun process(input: Litematica): Result<AppFailure, SchematicProject> {
+        val requirements = when (val materials = MapSchematicToMaterialsStep(availableItems).process(input)) {
+            is Result.Failure -> return Result.Failure(materials.error)
+            is Result.Success -> materials.value
+        }
+
         val name = upload.providedName
             ?: input.name.takeIf { it.isNotBlank() && it != "Unnamed" }
             ?: upload.fileName?.removeSuffix(".litematic")
             ?: "Imported build"
 
-        return Result.success(SchematicProject(name.take(100), requirements))
+        return Result.success(SchematicProject(name.take(100), requirements.toMap()))
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/resources/AddResourcesFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/resources/AddResourcesFromSchematicPipeline.kt
@@ -1,0 +1,107 @@
+package app.mcorg.pipeline.project.resources
+
+import app.mcorg.config.CacheManager
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.user.Role
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.project.MapSchematicToMaterialsStep
+import app.mcorg.pipeline.project.ParseSchematicStep
+import app.mcorg.pipeline.project.ReceiveSchematicStep
+import app.mcorg.pipeline.project.SchematicUpload
+import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
+import app.mcorg.pipeline.world.ValidateWorldMemberRole
+import app.mcorg.presentation.handler.handlePipeline
+import app.mcorg.presentation.hxOutOfBands
+import app.mcorg.presentation.templated.dsl.pages.planResourceTableFragment
+import app.mcorg.presentation.utils.getProjectId
+import app.mcorg.presentation.utils.getUser
+import app.mcorg.presentation.utils.getWorldId
+import app.mcorg.presentation.utils.respondHtml
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveMultipart
+import kotlinx.html.div
+import kotlinx.html.stream.createHTML
+
+/**
+ * Replaces a project's resource list with the exact material counts from an uploaded
+ * Litematica file — the project-page counterpart to "create project from schematic".
+ *
+ * A schematic is the complete material list for a build, so an upload **replaces** the
+ * project's resources rather than merging. The receive/parse/map steps are shared with
+ * [app.mcorg.pipeline.project.handleCreateProjectFromSchematic].
+ */
+suspend fun ApplicationCall.handleAddResourcesFromSchematic() {
+    val user = this.getUser()
+    val worldId = this.getWorldId()
+    val projectId = this.getProjectId()
+    val multipart = receiveMultipart()
+
+    val items = GetItemsInWorldVersionStep.process(worldId).getOrNull() ?: emptyList()
+    val previousIds = GetAllResourceGatheringItemsStep.process(projectId).getOrNull()?.map { it.id } ?: emptyList()
+
+    handlePipeline(
+        onSuccess = { resources ->
+            respondHtml(
+                planResourceTableFragment(worldId, projectId, resources) +
+                    createHTML().div { hxOutOfBands("delete:#plan-empty-state") }
+            )
+        }
+    ) {
+        val upload = ReceiveSchematicStep.run(multipart)
+        ValidateWorldMemberRole<SchematicUpload>(user, Role.ADMIN, worldId).run(upload)
+        val litematica = ParseSchematicStep.run(upload)
+        val materials = MapSchematicToMaterialsStep(items).run(litematica)
+        ReplaceProjectResourcesStep(projectId).run(materials)
+
+        previousIds.forEach { CacheManager.onResourceGatheringDeleted(projectId, it) }
+        val resources = GetAllResourceGatheringItemsStep.run(projectId)
+        resources.forEach { CacheManager.onResourceGatheringCreated(projectId, it.id) }
+        resources
+    }
+}
+
+private data class ReplaceProjectResourcesStep(
+    val projectId: Int,
+) : Step<List<Pair<Item, Int>>, AppFailure.DatabaseError, Unit> {
+    override suspend fun process(input: List<Pair<Item, Int>>): Result<AppFailure.DatabaseError, Unit> {
+        return DatabaseSteps.transaction { connection ->
+            object : Step<List<Pair<Item, Int>>, AppFailure.DatabaseError, Unit> {
+                override suspend fun process(input: List<Pair<Item, Int>>): Result<AppFailure.DatabaseError, Unit> {
+                    val deleteResult = DatabaseSteps.update<List<Pair<Item, Int>>>(
+                        sql = SafeSQL.delete("DELETE FROM resource_gathering WHERE project_id = ?"),
+                        parameterSetter = { statement, _ -> statement.setInt(1, projectId) },
+                        transactionConnection = connection
+                    ).process(input)
+
+                    if (deleteResult is Result.Failure) {
+                        return Result.Failure(deleteResult.error)
+                    }
+
+                    val insertResult = DatabaseSteps.batchUpdate<Pair<Item, Int>>(
+                        SafeSQL.insert("""
+                            INSERT INTO resource_gathering (project_id, name, required, item_id)
+                            VALUES (?, ?, ?, ?)
+                        """.trimIndent()),
+                        parameterSetter = { statement, requirement ->
+                            statement.setInt(1, projectId)
+                            statement.setString(2, requirement.first.name)
+                            statement.setInt(3, requirement.second)
+                            statement.setString(4, requirement.first.id)
+                        },
+                        transactionConnection = connection
+                    ).process(input)
+
+                    if (insertResult is Result.Failure) {
+                        return Result.Failure(insertResult.error)
+                    }
+
+                    return Result.success(Unit)
+                }
+            }
+        }.process(input)
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -8,6 +8,7 @@ import app.mcorg.pipeline.project.handleCreateProjectFromSchematic
 import app.mcorg.pipeline.project.handleDeleteProject
 import app.mcorg.pipeline.project.handleGetProject
 import app.mcorg.pipeline.project.handleGetDetailContent
+import app.mcorg.pipeline.project.resources.handleAddResourcesFromSchematic
 import app.mcorg.pipeline.resources.handleClearResourceSource
 import app.mcorg.pipeline.resources.handleCreateResourceGatheringItem
 import app.mcorg.pipeline.resources.handleDeleteResourceGatheringItem
@@ -133,6 +134,9 @@ class WorldHandler {
                             call.handleGetFieldLogSliceItems()
                         }
                         route("/resources") {
+                            post("/from-schematic") {
+                                call.handleAddResourcesFromSchematic()
+                            }
                             route("/gathering") {
                                 post {
                                     call.handleCreateResourceGatheringItem()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -8,8 +8,10 @@ import app.mcorg.presentation.hxDelete
 import app.mcorg.presentation.hxGet
 import app.mcorg.presentation.hxOutOfBands
 import app.mcorg.presentation.hxPatch
+import app.mcorg.presentation.hxPost
 import app.mcorg.presentation.hxSwap
 import app.mcorg.presentation.hxTarget
+import app.mcorg.presentation.hxTargetError
 import app.mcorg.presentation.hxTrigger
 import app.mcorg.presentation.templated.dsl.BreadcrumbBuilder
 import app.mcorg.presentation.templated.dsl.addTaskInline
@@ -229,10 +231,19 @@ fun FlowContent.planViewContent(
     div("project-detail__section") {
         div("project-detail__section-header") {
             span("project-detail__section-title section-label") { +"Resources" }
-            button(classes = "btn btn--secondary btn--sm plan-add-resource-btn") {
-                id = "plan-add-resource-btn"
-                type = ButtonType.button
-                +"+ Add resource"
+            div("project-detail__section-actions") {
+                button(classes = "btn btn--ghost btn--sm") {
+                    id = "plan-upload-schematic-btn"
+                    type = ButtonType.button
+                    attributes["onclick"] =
+                        "document.getElementById('resource-schematic-modal')?.showModal()"
+                    +"Upload schematic"
+                }
+                button(classes = "btn btn--secondary btn--sm plan-add-resource-btn") {
+                    id = "plan-add-resource-btn"
+                    type = ButtonType.button
+                    +"+ Add resource"
+                }
             }
         }
 
@@ -305,28 +316,10 @@ fun FlowContent.planViewContent(
         }
 
         // Resource table (always render for HTMX swap target)
-        table("data-table plan-resource-table") {
-            id = "plan-resource-table"
-            if (filteredResources.isNotEmpty()) {
-                thead {
-                    tr {
-                        th { classes = setOf("plan-resource-table__col-status") }
-                        th { classes = setOf("plan-resource-table__col-item"); +"Item" }
-                        th { classes = setOf("plan-resource-table__col-qty"); +"Qty" }
-                        th { classes = setOf("plan-resource-table__col-source"); +"Source" }
-                        th { classes = setOf("plan-resource-table__col-action") }
-                    }
-                }
-            }
-            tbody {
-                id = "plan-resource-table-body"
-                filteredResources.forEach { item ->
-                    tr {
-                        planResourceRow(project.worldId, project.id, item)
-                    }
-                }
-            }
-        }
+        planResourceTable(project.worldId, project.id, resources)
+
+        // Schematic upload modal — replaces the project's resource list with a build's materials
+        resourceSchematicModal(project.worldId, project.id, filteredResources.size)
     }
 
     // Tasks section (collapsed)
@@ -405,6 +398,124 @@ fun TR.planResourceRow(worldId: Int, projectId: Int, item: ResourceGatheringItem
             hxTarget("#plan-row-${item.id}")
             hxSwap("outerHTML")
             +"\u00d7"
+        }
+    }
+}
+
+/**
+ * The plan-view resource table. Rendered both inline and as the HTMX swap target for
+ * the schematic-upload flow (`outerHTML` swap of `#plan-resource-table`).
+ */
+fun FlowContent.planResourceTable(worldId: Int, projectId: Int, resources: List<ResourceGatheringItem>) {
+    val filteredResources = resources.filter { it.required > 0 }
+    table("data-table plan-resource-table") {
+        id = "plan-resource-table"
+        if (filteredResources.isNotEmpty()) {
+            thead {
+                tr {
+                    th { classes = setOf("plan-resource-table__col-status") }
+                    th { classes = setOf("plan-resource-table__col-item"); +"Item" }
+                    th { classes = setOf("plan-resource-table__col-qty"); +"Qty" }
+                    th { classes = setOf("plan-resource-table__col-source"); +"Source" }
+                    th { classes = setOf("plan-resource-table__col-action") }
+                }
+            }
+        }
+        tbody {
+            id = "plan-resource-table-body"
+            filteredResources.forEach { item ->
+                tr {
+                    planResourceRow(worldId, projectId, item)
+                }
+            }
+        }
+    }
+}
+
+/** Renders the full plan-view resource table as a standalone HTML fragment (HTMX swap response). */
+fun planResourceTableFragment(worldId: Int, projectId: Int, resources: List<ResourceGatheringItem>): String =
+    createHTML().table("data-table plan-resource-table") {
+        id = "plan-resource-table"
+        val filteredResources = resources.filter { it.required > 0 }
+        if (filteredResources.isNotEmpty()) {
+            thead {
+                tr {
+                    th { classes = setOf("plan-resource-table__col-status") }
+                    th { classes = setOf("plan-resource-table__col-item"); +"Item" }
+                    th { classes = setOf("plan-resource-table__col-qty"); +"Qty" }
+                    th { classes = setOf("plan-resource-table__col-source"); +"Source" }
+                    th { classes = setOf("plan-resource-table__col-action") }
+                }
+            }
+        }
+        tbody {
+            id = "plan-resource-table-body"
+            filteredResources.forEach { item ->
+                tr {
+                    planResourceRow(worldId, projectId, item)
+                }
+            }
+        }
+    }
+
+/**
+ * Modal that uploads a Litematica file and replaces the project's resource list with the
+ * build's exact material counts. When the project already has resources it warns that
+ * the upload replaces them, since a schematic is the complete material list for a build.
+ */
+fun FlowContent.resourceSchematicModal(worldId: Int, projectId: Int, existingResourceCount: Int) {
+    dialog {
+        id = "resource-schematic-modal"
+        classes = setOf("modal-backdrop")
+        div("modal") {
+            div("modal__heading") { +"Upload schematic" }
+            div("modal__body") {
+                if (existingResourceCount > 0) {
+                    val noun = if (existingResourceCount == 1) "resource" else "resources"
+                    p("modal__warning") {
+                        +"This replaces the project's $existingResourceCount existing $noun."
+                    }
+                }
+                form {
+                    hxPost("/worlds/$worldId/projects/$projectId/resources/from-schematic")
+                    hxTarget("#plan-resource-table")
+                    hxSwap("outerHTML")
+                    hxTargetError(".form-error")
+                    attributes["hx-encoding"] = "multipart/form-data"
+                    attributes["hx-on::after-request"] =
+                        "if(event.detail.successful) { this.reset(); this.closest('dialog')?.close() }"
+
+                    label {
+                        htmlFor = "resource-schematic-file"
+                        +"Schematic file"
+                        span("required-indicator") { +"*" }
+                    }
+                    input(classes = "form-control") {
+                        id = "resource-schematic-file"
+                        type = InputType.file
+                        name = "schematicFile"
+                        accept = ".litematic"
+                        required = true
+                    }
+                    p("form-error") {
+                        id = "validation-error-schematicFile"
+                    }
+
+                    div("modal__actions") {
+                        button {
+                            classes = setOf("btn", "btn--primary")
+                            type = ButtonType.submit
+                            +"Replace resources"
+                        }
+                        button {
+                            classes = setOf("btn", "btn--ghost")
+                            type = ButtonType.button
+                            attributes["onclick"] = "this.closest('dialog')?.close()"
+                            +"Cancel"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
@@ -63,6 +63,13 @@
     border-bottom: 1px solid var(--border);
 }
 
+.project-detail__section-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-left: auto;
+}
+
 .project-detail__section-title {
     font-family: var(--font-ui);
     font-size: var(--text-xs);

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/AddResourcesFromSchematicIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/AddResourcesFromSchematicIT.kt
@@ -1,0 +1,236 @@
+package app.mcorg.presentation.handler.project
+
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.user.Role
+import app.mcorg.nbt.util.LitematicaReader
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.project.resources.handleAddResourcesFromSchematic
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.ProjectParamPlugin
+import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
+import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.forms.MultiPartFormDataContent
+import io.ktor.client.request.forms.formData
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class AddResourcesFromSchematicIT : WithUser() {
+
+    private var worldId: Int = 0
+    private lateinit var litematicBytes: ByteArray
+    private lateinit var expectedItemIds: Set<String>
+
+    @BeforeAll
+    fun setup() {
+        worldId = createWorld()
+        litematicBytes = javaClass.getResourceAsStream("/litematica-test.litematic")!!.readBytes()
+
+        val litematica = (LitematicaReader.readLitematica(litematicBytes) as Result.Success).value
+        expectedItemIds = litematica.items.keys.toSet()
+        runBlocking {
+            DatabaseSteps.update<Unit>(
+                sql = SafeSQL.insert("INSERT INTO minecraft_version (version) VALUES ('1.21.4') ON CONFLICT DO NOTHING"),
+                parameterSetter = { _, _ -> }
+            ).process(Unit)
+        }
+        litematica.items.keys.forEach { itemId ->
+            runBlocking {
+                DatabaseSteps.update<Unit>(
+                    sql = SafeSQL.insert(
+                        "INSERT INTO minecraft_items (version, item_id, item_name) VALUES ('1.21.4', ?, ?) ON CONFLICT DO NOTHING"
+                    ),
+                    parameterSetter = { stmt, _ ->
+                        stmt.setString(1, itemId)
+                        stmt.setString(2, itemId.removePrefix("minecraft:").replace('_', ' '))
+                    }
+                ).process(Unit)
+            }
+        }
+    }
+
+    @Test
+    fun `upload populates an empty project with the schematic's materials`() = testApplication {
+        setupRoutes()
+        val projectId = createProject()
+
+        val response = client.post("/worlds/$worldId/projects/$projectId/resources/from-schematic") {
+            addAuthCookie(this)
+            setBody(multipart(fileName = "loader.litematic", bytes = litematicBytes))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        assertEquals(expectedItemIds, getResourceItemIds(projectId))
+    }
+
+    @Test
+    fun `upload replaces a project's pre-existing resources`() = testApplication {
+        setupRoutes()
+        val projectId = createProject()
+        addResource(projectId, "minecraft:dirt", "Dirt", 64)
+        assertEquals(setOf("minecraft:dirt"), getResourceItemIds(projectId))
+
+        val response = client.post("/worlds/$worldId/projects/$projectId/resources/from-schematic") {
+            addAuthCookie(this)
+            setBody(multipart(fileName = "loader.litematic", bytes = litematicBytes))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        // The pre-existing manual resource (dirt, not in the fixture) is gone; only the parsed set remains.
+        assertEquals(expectedItemIds, getResourceItemIds(projectId))
+        assertTrue("minecraft:dirt" !in expectedItemIds, "fixture unexpectedly contains dirt; pick another sentinel item")
+    }
+
+    @Test
+    fun `non-admin member cannot replace resources`() = testApplication {
+        setupRoutes()
+        val projectId = createProject()
+        addResource(projectId, "minecraft:dirt", "Dirt", 64)
+        val member = createExtraUser("schematic-resources-member")
+        addWorldMember(member.id, Role.MEMBER)
+
+        val response = client.post("/worlds/$worldId/projects/$projectId/resources/from-schematic") {
+            addAuthCookie(this, member)
+            setBody(multipart(fileName = "loader.litematic", bytes = litematicBytes))
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertEquals(setOf("minecraft:dirt"), getResourceItemIds(projectId))
+    }
+
+    @Test
+    fun `malformed file surfaces a validation error and leaves resources untouched`() = testApplication {
+        setupRoutes()
+        val projectId = createProject()
+        addResource(projectId, "minecraft:dirt", "Dirt", 64)
+
+        val response = client.post("/worlds/$worldId/projects/$projectId/resources/from-schematic") {
+            addAuthCookie(this)
+            setBody(multipart(fileName = "broken.litematic", bytes = byteArrayOf(1, 2, 3, 4)))
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertEquals(setOf("minecraft:dirt"), getResourceItemIds(projectId))
+    }
+
+    @Test
+    fun `missing file surfaces a validation error`() = testApplication {
+        setupRoutes()
+        val projectId = createProject()
+
+        val response = client.post("/worlds/$worldId/projects/$projectId/resources/from-schematic") {
+            addAuthCookie(this)
+            setBody(MultiPartFormDataContent(formData { append("ignored", "value") }))
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+    }
+
+    // -------------------------------------------------------------------------
+
+    private fun multipart(fileName: String, bytes: ByteArray) =
+        MultiPartFormDataContent(formData {
+            append("schematicFile", bytes, Headers.build {
+                append(HttpHeaders.ContentDisposition, "form-data; name=\"schematicFile\"; filename=\"$fileName\"")
+            })
+        })
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(UpdateActiveWorldPlugin)
+                route("/projects/{projectId}") {
+                    install(ProjectParamPlugin)
+                    post("/resources/from-schematic") { call.handleAddResourcesFromSchematic() }
+                }
+            }
+        }
+    }
+
+    private fun createWorld(): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(
+                name = "Add Resources Schematic IT World",
+                description = "test",
+                version = MinecraftVersion.fromString("1.21.4")
+            )
+        )
+        (result as Result.Success).value
+    }
+
+    private fun createProject(): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, state, location_x, location_y, location_z, location_dimension) " +
+                        "VALUES ('Schematic Resources IT', ?, '', 'BUILDING', 'RESOURCE_GATHERING', 'ACTIVE', NULL, NULL, NULL, NULL) RETURNING id"
+            ),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, worldId) }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun addResource(projectId: Int, itemId: String, name: String, required: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert("INSERT INTO resource_gathering (project_id, name, required, item_id) VALUES (?, ?, ?, ?) RETURNING id"),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, name)
+                stmt.setInt(3, required)
+                stmt.setString(4, itemId)
+            }
+        ).process(Unit)
+    }
+
+    private fun addWorldMember(userId: Int, role: Role) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO world_members (world_id, user_id, display_name, world_role, created_at, updated_at) " +
+                        "VALUES (?, ?, 'member', ?, NOW(), NOW())"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, worldId)
+                stmt.setInt(2, userId)
+                stmt.setInt(3, role.level)
+            }
+        ).process(Unit)
+    }
+
+    private fun getResourceItemIds(projectId: Int): Set<String> = runBlocking {
+        val result = DatabaseSteps.query<Unit, Set<String>>(
+            sql = SafeSQL.select("SELECT item_id FROM resource_gathering WHERE project_id = ?"),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, projectId) },
+            resultMapper = { rs ->
+                val ids = mutableSetOf<String>()
+                while (rs.next()) ids.add(rs.getString("item_id"))
+                ids
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+}


### PR DESCRIPTION
## Summary

Adds an **Upload schematic** button to the project-detail resources toolbar (plan view) that opens a modal accepting a `.litematic` upload and **replaces** the project's resource list with the build's exact material counts — the project-side counterpart to the world page's "create from schematic" flow.

A schematic is the complete material list for a build, so an upload replaces (not merges) the project's resources. The modal warns when resources already exist (*"This replaces the project's N existing resources"*).

## Changes

- **`CreateProjectFromSchematicPipeline.kt`** — made `ReceiveSchematicStep`/`ParseSchematicStep` reusable and extracted a shared `MapSchematicToMaterialsStep` (`Litematica → List<Pair<Item, Int>>`) used by both flows. No behavioural change to the world-page flow.
- **`AddResourcesFromSchematicPipeline.kt`** (new) — `handleAddResourcesFromSchematic`: receive → in-pipeline ADMIN role check (`ValidateWorldMemberRole`, mirroring `UpdateProjectState`) → parse → map → `ReplaceProjectResourcesStep` (transactional `DELETE` + batch-insert) → cache invalidation → returns the refreshed `#plan-resource-table` fragment + OOB removal of `#plan-empty-state`.
- **`WorldHandler.kt`** — `post("/resources/from-schematic")` under the project's `/resources` block.
- **`ProjectDetailPage.kt`** — extracted `planResourceTable`/`planResourceTableFragment` (page render and HTMX swap share identical markup), added the upload button and `resourceSchematicModal`.
- **`project-detail.css`** — new `.project-detail__section-actions` class (no inline styles).

## Tests

New `AddResourcesFromSchematicIT` (`@Tag("database")`), mirroring `ProjectStateIT`:
- success (empty project → parsed set)
- replace (pre-existing resources fully replaced)
- non-admin member → 403
- malformed file → 422 (resources untouched)
- missing file → 422

`mvn clean compile` clean; full unit + database tiers green (74 db tests). The existing `CreateProjectFromSchematicIT` still passes.

Closes MCO-216

🤖 Generated with [Claude Code](https://claude.com/claude-code)