### PR TITLE
Gathering Planner Phase 1: wire GatheringPlan into the web layer (MCO-220)

### DIFF
--- a/documentation/work-documents/gathering-planner/README.md
+++ b/documentation/work-documents/gathering-planner/README.md
@@ -1,0 +1,182 @@
+# Gathering Planner — developer handoff
+
+A quantity-aware **gathering planner** for SEAM: import a Minecraft schematic, the
+path generator produces a plan of everything you must gather (each item once,
+ingredients before what they build), and you work it down. This package is the
+design reference for re-implementing it in the production stack
+(**server-rendered Kotlin `kotlinx.html` DSL + HTMX**, SEAM design system).
+
+> Scope note: this is a **design prototype**, not production code. It models the
+> UI/UX and the two persisted decisions. The actual path-generation engine
+> (`mc-engine`) already exists; this does not re-implement it.
+
+---
+
+## What's in this folder
+
+| Path | What it is |
+|------|------------|
+| `screens.html` | **Start here.** Flattened, framework-free static HTML of the 4 key states, using only real SEAM classes + `var(--*)` tokens. Maps 1:1 to `kotlinx.html` fragments. |
+| `seam/` | The SEAM design-system stylesheets the screens depend on (tokens + css). Already present in the real app under `/static/styles/` — included here so `screens.html` renders standalone. |
+| `reference/` | The original interactive prototypes (`*.dc.html`). Open in a browser to click through. `Gathering Planner.dc.html` = the hi-fi flow; `Gathering Planner — Wireframes.dc.html` = the full Round 1–5 exploration with rationale for every decision. |
+| `README.md` | This file. |
+
+---
+
+## The flow (4 states)
+
+```
+IMPORT ──▶ SHARPEN ──▶ PLAN ◀──▶ DRILL (per item)
+                          │
+                          └─ lenses: List · Next up · Sessions
+```
+
+1. **Import** — upload a `.litematic` / `.schem` / `.nbt`. Returns the Sharpen view.
+2. **Sharpen** — the plan already exists; a short list of **cold-start questions
+   ranked by plan impact** ("declare your iron farm → −2,400 cobble"). Each is
+   independent, answerable or skippable. This is the *only* gate, and only at cold
+   start — never a recurring mode. "See the plan" (or "Skip") → Plan.
+3. **Plan** — the working view, with three **lenses** over the same data:
+   - **List** (default) — gather rows grouped by world **geography** (do neighbouring
+     farms in one trip), then base smelt/craft.
+   - **Next up** — one suggested move at a time + a "↻ something else" reshuffle.
+   - **Sessions** — items bundled into suggested trips; **degrades to List** when the
+     engine can't group confidently.
+4. **Drill** — from any row's `⇄`, the item's **chosen chain** collapsed to the picked
+   source per node, where you can **override** any node's source.
+
+---
+
+## Domain model (what a Plan is made of)
+
+A plan is an ordered list of **activities**. Each activity ≈ one item to obtain:
+
+| Field | Meaning |
+|-------|---------|
+| `item` | Minecraft item id (e.g. `hopper`, `raw_copper`) |
+| `required` | quantity needed (the honest, rolled-up total) |
+| `current` | quantity gathered so far (drives the counter + progress) |
+| `source` | the chosen way to obtain it (mine / smelt / craft / barter / loot / **supplied**) |
+| `group` | session phase — used for ordering (gather → smelt → craft …) |
+| `area` | world location cluster, for the geography grouping in the List lens |
+| `status` | derived: `resolved` / `supplied` / `raw_gather` / `open_tag` / `blocked` |
+| `children` | for craftables, the sub-activities it consumes (the chain) |
+
+**Counter tiers are Minecraft-native: 1 / 64 / 1728** (item / stack / double-shulker) —
+never round decimals. `ResourceRow` renders `-1728 -64 -1 +1 +64 +1728` and goes
+complete (strikethrough, buttons hidden) at `current >= required`.
+
+### Status → presentation (colour is never the only signal)
+| status | shown as |
+|--------|----------|
+| `resolved` / done | normal row / green progress |
+| `supplied` | **Supplied** `badge--accent`, **no counter** (comes from a farm/linked project) |
+| `raw_gather` | counter row |
+| `open_tag` | amber — needs a concrete variant picked (e.g. "any planks" → Oak) |
+| `blocked` | `callout--warning`, labelled "Blocked" |
+
+---
+
+## The two persisted decisions (the whole point)
+
+The engine derives everything else; the user only ever persists **two kinds of override**.
+Everything in the UI funnels to these:
+
+1. **`tagChoiceByItem`** — resolving an **open tag** to a concrete item
+   (`#planks` → `oak_planks`). Surfaced in Sharpen, in the Plan attention callout, and
+   in the Drill picker. *One value per open tag.*
+2. **`sourceByItem`** — **pinning a source** for a node when several exist
+   (`obsidian` → `mine` vs `barter`; `sand`/`red_sand` for glass). Surfaced in the Drill
+   view. *One value per overridden item; absence = use the engine's scored pick.*
+
+> Pinning either one **re-derives** the plan (a pin can prune or introduce whole
+> sub-chains — e.g. declaring an iron farm removes the cobble/smelt chain; bartering
+> obsidian introduces a gold chain).
+
+---
+
+## Drill & the fan-out-aware picker
+
+A target can be a **deep chain**, and most nodes have **many** candidate sources (there
+can be ~1,000 ways to obtain sticks). So:
+
+- The drill view shows the **chosen chain only**, collapsed to the picked source per
+  node. Deep sub-chains fold to one line with a "+N steps" affordance.
+- Each node shows how many sources it has. **1-way nodes** show "· 1 way" with no control.
+  **Multi-source nodes** show a `⇄ {currentPick}` chip.
+- Tapping the chip opens a picker that **scales to fan-out**:
+  - **few sources (2–3):** a short radio list with trade-off notes.
+  - **high fan-out:** a **search field + ranked "top picks"** (engine-scored, best
+    starred) + "997 more · search to narrow".
+
+---
+
+## HTMX swap points (suggested)
+
+Everything is a server-rendered fragment; no client state beyond the DOM.
+
+| Action | Request | Swaps |
+|--------|---------|-------|
+| Import file | `POST /worlds/{id}/plan` (multipart) | → Sharpen fragment |
+| Answer a sharpen question | `POST .../plan/sharpen/{q}` | the questions card + activity count |
+| Skip / See the plan | `GET .../plan` | → Plan fragment |
+| Switch lens | `GET .../plan?lens=list\|next\|sessions` | the plan body region |
+| Counter ± | `POST .../activity/{item}/progress` `{delta}` | that `resource-row` (+ header progress via OOB) |
+| Resolve open tag inline | `POST .../activity/{item}/tag` `{choice}` | re-derive → plan body |
+| Open a row's chain | `GET .../plan/chain/{item}` | → Drill fragment |
+| Open a node's sources | `GET .../plan/chain/{item}/sources/{node}` | that node (expands the picker) |
+| Pin a source | `POST .../plan/chain/{item}/pin` `{node, source}` | re-derive → Drill (+ plan via OOB) |
+| Back to plan | `GET .../plan` | → Plan fragment |
+
+`hx-target` + `hx-swap="outerHTML"` on the smallest enclosing fragment; use
+**out-of-band swaps** to keep the header progress bar and activity count in sync after a
+counter step or a re-derive.
+
+---
+
+## SEAM components used (class names in `screens.html`)
+
+All from the bound SEAM system — do not restyle raw HTML to imitate them; use the real
+DSL builders / classes.
+
+| Component | Class(es) | Notes |
+|-----------|-----------|-------|
+| Button | `.btn .btn--primary\|secondary\|ghost\|danger` (`.btn--sm`) | secondary is ink-on-paper, never a 2nd colour |
+| IconButton | `.btn .btn--icon-only` + `aria-label` | the `⇄` drill control |
+| Badge | `.badge .badge--accent\|neutral` / `.badge--{status}` | text only, never icons inside |
+| Callout | `.callout`(`.callout--info\|success\|error`) + `.callout__icon` + `.callout__body` | left-border only; glyph always present |
+| ProgressBar | `.progress`(`.progress--lg`) + `.progress__fill`(`--complete`) | 4px rows / 6px cards; full-green at 100% |
+| Tabs (pills) | `.tabs .tabs--pills` + `.tab`(`.tab--active`) | the lens switch |
+| ResourceRow | `.resource-row` + `.resource-row__main/head/name/count/source` + `.counter-btns` + `.counter-btn--neg\|pos` | the counter; tiers 1/64/1728 |
+| Card | `.card` | paper surface base |
+
+App shell: `.graph-paper` lays the signature sepia grid under everything.
+
+---
+
+## Voice & non-negotiables (from the SEAM guide)
+
+- **No emoji, ever.** (The `⭳ ⇄ ⌂ ★ ⌕` glyphs here are placeholders for **Lucide line
+  icons** — swap them for real Lucide at 2px weight in production.)
+- **Status is labelled, never colour-only** — the primary user is red-green colour-blind;
+  the only reliable axis is **blue↔yellow** (hence lapis CTA + amber warn).
+- **IBM Plex Mono** for all chrome/labels/buttons; **Inter** for body/table content.
+- Section headers: UPPERCASE, tracked, muted (`.section-label`).
+- Real Minecraft nouns + quantities; thousands separators on large counts; **never** pill
+  radius except badges and the Plan/Execute toggle.
+- Terse, builder-to-builder copy. Warnings are specific and calm — no exclamation marks.
+
+---
+
+## Notable prototype-only shortcuts (fix in the real build)
+
+- **`⇄` drill control is a sibling button** next to each `ResourceRow`, because the SEAM
+  `ResourceRow` component has no trailing-action slot. In production, either add an
+  optional trailing-action slot to `ResourceRow`, or render plan target rows with a
+  variant that includes the drill control natively.
+- **Pins are currently cosmetic** in the prototype (selecting a source updates the chip
+  but doesn't re-derive the visible rows). In production the pin must trigger the
+  re-derive described above.
+- The "2 more" low-impact sharpen questions are stubbed (count only).
+- **Execute mode** isn't built — but the plan's counter rows **are** the Execute view, so
+  the Plan↔Execute `Toggle` is a small addition over the same `ResourceRow`s.

--- a/documentation/work-documents/gathering-planner/screens.html
+++ b/documentation/work-documents/gathering-planner/screens.html
@@ -1,0 +1,364 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Gathering Planner — flattened screen reference</title>
+
+<!-- ───────────────────────────────────────────────────────────────────────
+     SEAM design-system stylesheets (bundled under ./seam/).
+     In the real app these are already served from /static/styles/.
+     This file uses ONLY SEAM classes + var(--*) tokens — no framework,
+     no inline component logic. Every block below maps to one server-rendered
+     fragment for the Kotlin HTML DSL + HTMX rewrite. See README.md.
+──────────────────────────────────────────────────────────────────────── -->
+<link rel="stylesheet" href="seam/tokens/fonts.css">
+<link rel="stylesheet" href="seam/tokens/colors.css">
+<link rel="stylesheet" href="seam/tokens/typography.css">
+<link rel="stylesheet" href="seam/tokens/spacing.css">
+<link rel="stylesheet" href="seam/css/reset.css">
+<link rel="stylesheet" href="seam/css/utilities.css">
+<link rel="stylesheet" href="seam/css/components.css">
+
+<style>
+  /* Reference-page chrome only — NOT part of the app. */
+  body { margin: 0; background: #dfded7; font-family: var(--font-body); color: var(--text-primary); }
+  .ref-wrap { max-width: 1000px; margin: 0 auto; padding: 32px 20px 100px; }
+  .ref-title { font-family: var(--font-ui); font-size: 22px; font-weight: 600; color: var(--text-primary); margin: 0 0 6px; }
+  .ref-intro { font-size: 13px; color: var(--text-muted); line-height: 1.6; max-width: 66ch; margin: 0 0 8px; }
+  .ref-intro code { font-family: var(--font-ui); font-size: 12px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 4px; padding: 1px 5px; }
+  .ref-head { font-family: var(--font-ui); font-size: 13px; font-weight: 600; letter-spacing: .03em; color: var(--text-primary); margin: 40px 0 4px; display: flex; gap: 10px; align-items: baseline; flex-wrap: wrap; }
+  .ref-head b { background: var(--accent); color: #fff; border-radius: 4px; padding: 2px 9px; font-size: 11px; flex: 0 0 auto; }
+  .ref-note { font-size: 12px; color: var(--text-muted); margin: 0 0 12px; line-height: 1.55; max-width: 70ch; }
+  .ref-note code { font-family: var(--font-ui); font-size: 11px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 4px; padding: 1px 5px; }
+  .ref-frame { border: 1px solid var(--border-strong); border-radius: 8px; overflow: hidden; box-shadow: var(--shadow-card); }
+  /* App shell paint inside each frame */
+  .app { background: var(--bg-base); }
+  .app__main { padding: var(--space-5); }
+  .app__header { display: flex; align-items: center; justify-content: space-between; padding: var(--space-3) var(--space-5); border-bottom: 1px solid var(--border); background: var(--bg-surface); }
+  .stage { max-width: 620px; margin: 0 auto; }
+  .stage--wide { max-width: 720px; }
+  .row { display: flex; align-items: center; }
+  .area-label { margin: var(--space-5) 0 var(--space-2); display: flex; align-items: center; gap: var(--space-2); }
+  .area-num { width: 22px; height: 22px; border-radius: 50%; background: var(--text-primary); color: var(--bg-surface); font-family: var(--font-ui); font-size: 11px; display: flex; align-items: center; justify-content: center; flex: 0 0 auto; }
+  .drill-row { display: flex; align-items: flex-start; gap: var(--space-2); }
+  .drill-row > .resource-row { flex: 1 1 auto; min-width: 0; }
+  .chain-node { border-bottom: 1px solid var(--border); }
+  .chain-node:last-child { border-bottom: 0; }
+  .chip { font-family: var(--font-ui); font-size: 11px; border: 1px solid var(--accent); color: var(--accent); background: var(--accent-muted); border-radius: var(--radius-sm); padding: 3px 9px; cursor: pointer; white-space: nowrap; }
+  .picker-opt { display: flex; align-items: center; gap: var(--space-2); border: 1px solid var(--border); background: var(--bg-surface); border-radius: var(--radius); padding: 8px 10px; cursor: pointer; }
+  .picker-opt--sel { border: 1.5px solid var(--accent); background: var(--accent-muted); }
+  .picker-search { display: flex; align-items: center; gap: var(--space-2); border: 1px solid var(--border); border-radius: var(--radius); background: var(--bg-surface); padding: 7px 10px; color: var(--text-disabled); font-size: var(--text-sm); }
+</style>
+</head>
+<body>
+<div class="ref-wrap">
+
+  <h1 class="ref-title">Gathering Planner — flattened screen reference</h1>
+  <p class="ref-intro">Pure static HTML using only SEAM classes and <code>var(--*)</code> tokens — the React/prototype framework has been removed so this maps directly onto the server-rendered <strong>Kotlin&nbsp;HTML&nbsp;DSL&nbsp;+&nbsp;HTMX</strong> app. Each numbered block is one render state / fragment. Interaction, persisted decisions, and HTMX swap targets are documented in <code>README.md</code>. The interactive originals are in <code>reference/</code>.</p>
+
+  <!-- =====================================================================
+       1 · IMPORT  →  fragment: GET /worlds/{id}/plan/new
+  ====================================================================== -->
+  <div class="ref-head"><b>1</b><span>Import — start a plan from a schematic</span></div>
+  <p class="ref-note">Entry point. The "Use sample" button is the demo shortcut; real flow is a file upload (<code>hx-post</code> multipart) that returns the Sharpen fragment (block 2).</p>
+  <div class="ref-frame">
+    <div class="app graph-paper">
+      <header class="app__header">
+        <div class="row" style="gap:var(--space-3);">
+          <span style="width:22px;height:22px;border-radius:5px;background:var(--accent);display:inline-block;"></span>
+          <span style="font-family:var(--font-ui);font-weight:600;font-size:15px;">SEAM</span>
+          <span style="font-family:var(--font-ui);font-size:12px;color:var(--text-muted);">/ New project</span>
+        </div>
+      </header>
+      <div class="app__main">
+        <div class="stage" style="max-width:540px;">
+          <div class="section-label" style="margin-bottom:var(--space-2);">NEW PROJECT</div>
+          <h1 style="font-family:var(--font-ui);font-weight:600;font-size:26px;margin:0 0 var(--space-2);">Plan a build</h1>
+          <p class="subtle" style="margin:0 0 var(--space-5);line-height:1.6;">Import a schematic and the path generator works out everything you need to gather — each item once, ingredients before what they build.</p>
+
+          <div class="card" style="border-style:dashed;border-color:var(--border-strong);padding:var(--space-6);text-align:center;background:var(--bg-raised);">
+            <div style="font-size:30px;color:var(--text-muted);line-height:1;">⭳</div>
+            <div style="font-family:var(--font-ui);font-size:13px;margin:var(--space-3) 0 var(--space-1);">Drop a .litematic / .schem / .nbt</div>
+            <div class="subtle" style="margin-bottom:var(--space-4);">or browse your files</div>
+            <button class="btn btn--secondary">Choose file</button>
+          </div>
+
+          <div style="text-align:center;margin:var(--space-4) 0;font-family:var(--font-ui);font-size:12px;color:var(--text-disabled);">— or try the sample —</div>
+          <div style="text-align:center;">
+            <button class="btn btn--primary">Use sample · greenhouse.litematic →</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- =====================================================================
+       2 · SHARPEN  →  fragment: POST /worlds/{id}/plan  (returns this)
+       Each answer: hx-post /plan/sharpen/{question} → re-renders this card
+       + the activity count. "See the plan" → block 3.
+  ====================================================================== -->
+  <div class="ref-head"><b>2</b><span>Sharpen — cold-start questions, ranked by plan impact</span></div>
+  <p class="ref-note">A plan already exists; these only refine it. Each question is independent and optional. Shown here AFTER answering iron = Yes and planks = Oak — note the success <code>callout</code>, the <code>badge</code> answers, and the count having dropped 24 → 22. Impact estimates ("−2,400 cobble") come from the engine; questions render in descending impact order.</p>
+  <div class="ref-frame">
+    <div class="app graph-paper">
+      <div class="app__main">
+        <div class="stage">
+          <div class="section-label" style="display:flex;gap:var(--space-2);margin-bottom:var(--space-4);">
+            <span>IMPORT</span><span style="color:var(--text-disabled);">›</span><span style="color:var(--accent);">SHARPEN</span><span style="color:var(--text-disabled);">›</span><span style="color:var(--text-disabled);">PLAN</span>
+          </div>
+          <h1 style="font-family:var(--font-ui);font-weight:600;font-size:24px;margin:0 0 var(--space-1);">Sharpen this plan</h1>
+          <p class="subtle" style="margin:0 0 var(--space-3);line-height:1.6;">A plan already exists. These questions are ranked by how much they change it — answer the ones that matter, skip the rest.</p>
+
+          <div class="cluster--xs" style="margin-bottom:var(--space-4);">
+            <span class="badge badge--neutral">greenhouse.litematic</span>
+            <span class="badge badge--neutral">1,284 blocks</span>
+            <span class="badge badge--neutral">6 targets</span>
+            <span class="badge badge--accent">⊕ 2 supplies detected</span>
+          </div>
+
+          <div class="card" style="overflow:hidden;padding:0;margin-bottom:var(--space-4);">
+            <!-- Q1 · answered -->
+            <div class="row" style="gap:var(--space-3);padding:var(--space-4);border-bottom:1px solid var(--border);">
+              <span style="font-family:var(--font-ui);font-size:11px;font-weight:500;color:var(--accent);background:var(--accent-muted);border-radius:var(--radius-sm);padding:3px 7px;white-space:nowrap;">−2,400 cobble</span>
+              <div style="flex:1;font-size:var(--text-sm);line-height:1.3;">Do you have an <b>Iron farm</b>?<div class="subtle" style="font-size:var(--text-xs);">links it, drops the whole smelting chain</div></div>
+              <span class="badge badge--accent">Farm linked ✓</span>
+            </div>
+            <!-- Q2 · answered -->
+            <div class="row" style="gap:var(--space-3);padding:var(--space-4);border-bottom:1px solid var(--border);">
+              <span style="font-family:var(--font-ui);font-size:11px;font-weight:500;color:var(--amber);background:#F2E6C9;border-radius:var(--radius-sm);padding:3px 7px;white-space:nowrap;">splits 40 chests</span>
+              <div style="flex:1;font-size:var(--text-sm);line-height:1.3;">◇ Which <b>planks</b>?<div class="subtle" style="font-size:var(--text-xs);">"any planks" needs a concrete variant</div></div>
+              <span class="badge badge--accent">Oak ✓</span>
+            </div>
+            <div style="padding:var(--space-3) var(--space-4);font-family:var(--font-ui);font-size:12px;color:var(--text-muted);">low impact · <span style="color:var(--accent);">2 more</span> — or leave them for the inline prompts</div>
+          </div>
+
+          <div class="callout callout--success" role="note" style="margin-bottom:var(--space-4);">
+            <span class="callout__icon" aria-hidden="true">✓</span>
+            <div class="callout__body">Iron farm linked — 2,400 cobblestone and 200 smelts removed from the plan.</div>
+          </div>
+
+          <div class="row" style="justify-content:space-between;gap:var(--space-3);flex-wrap:wrap;">
+            <span class="subtle">22 activities planned</span>
+            <div class="cluster--xs">
+              <button class="btn btn--ghost">Skip — decide on the way</button>
+              <button class="btn btn--primary">See the plan →</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- =====================================================================
+       3 · PLAN · LIST LENS  →  fragment: GET /worlds/{id}/plan
+       Lens tabs swap the body region only (hx-get ...?lens=list|next|sessions).
+       Each ResourceRow ± button: hx-post .../activity/{item}/progress.
+       Each ⇄ IconButton: hx-get .../chain/{item} → block 4.
+  ====================================================================== -->
+  <div class="ref-head"><b>3</b><span>Plan · List lens — geography areas, counters, per-row ⇄ drill</span></div>
+  <p class="ref-note">Default plan view. Gather rows grouped by world location; <code>resource-row</code> counters step 1/64/1728; the <strong>Supplied</strong> row (iron) has no counter; every row carries a trailing <code>⇄</code> <code>btn--icon-only</code> opening its chain. The two other lenses (Next up, Sessions) swap this same region. The warning callout holds the one open decision (planks) — resolvable inline.</p>
+  <div class="ref-frame">
+    <div class="app graph-paper">
+      <header class="app__header">
+        <div class="row" style="gap:var(--space-3);">
+          <span style="width:22px;height:22px;border-radius:5px;background:var(--accent);display:inline-block;"></span>
+          <span style="font-family:var(--font-ui);font-weight:600;font-size:15px;">SEAM</span>
+          <span style="font-family:var(--font-ui);font-size:12px;color:var(--text-muted);">/ Cherry Greenhouse</span>
+        </div>
+        <button class="btn btn--ghost btn--sm">↺ Start over</button>
+      </header>
+      <div class="app__main">
+        <div class="stage stage--wide">
+
+          <div class="row" style="align-items:flex-end;justify-content:space-between;gap:var(--space-4);flex-wrap:wrap;margin-bottom:var(--space-4);">
+            <div>
+              <div class="section-label">CONTRAPTION · PLAN</div>
+              <h1 style="font-family:var(--font-ui);font-weight:600;font-size:22px;margin:2px 0 0;">Cherry Greenhouse</h1>
+            </div>
+            <div style="min-width:200px;">
+              <div class="row" style="justify-content:space-between;font-family:var(--font-ui);font-size:12px;color:var(--text-muted);margin-bottom:4px;"><span>15% gathered</span><span>354 to go</span></div>
+              <div class="progress progress--lg" role="progressbar" aria-valuenow="64" aria-valuemin="0" aria-valuemax="418"><div class="progress__fill" style="width:15%;"></div></div>
+            </div>
+          </div>
+
+          <!-- Lens tabs (pills). hx-get swaps the region below. -->
+          <div class="tabs tabs--pills" role="tablist" style="margin-bottom:var(--space-4);">
+            <button type="button" role="tab" aria-selected="true" class="tab tab--active">List</button>
+            <button type="button" role="tab" aria-selected="false" class="tab">Next up</button>
+            <button type="button" role="tab" aria-selected="false" class="tab">Sessions</button>
+          </div>
+
+          <!-- Open decision (attention) -->
+          <div class="callout" role="note" style="margin-bottom:var(--space-4);">
+            <span class="callout__icon" aria-hidden="true">⚠</span>
+            <div class="callout__body">
+              <div class="row" style="gap:var(--space-3);flex-wrap:wrap;">
+                <span style="flex:1;min-width:200px;">1 decision before this plan is real — pick the planks for your 40 chests.</span>
+                <span class="cluster--xs">
+                  <button class="btn btn--primary btn--sm">Oak</button>
+                  <button class="btn btn--secondary btn--sm">Spruce</button>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <!-- AREA 1 -->
+          <div class="area-label"><span class="area-num">1</span><span class="section-label">Copper cliffs ↔ Iron farm · ~120m E</span></div>
+          <div class="stack--xs">
+            <div class="drill-row">
+              <div class="resource-row">
+                <div class="resource-row__main">
+                  <div class="resource-row__head"><span class="resource-row__name">Raw Copper</span><span class="resource-row__count">0 / 162</span></div>
+                  <span class="resource-row__source">Copper cliffs</span>
+                  <div class="progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="162"><div class="progress__fill" style="width:0%;"></div></div>
+                </div>
+                <div class="counter-btns">
+                  <button class="counter-btn counter-btn--neg" aria-label="minus 1728">-1728</button>
+                  <button class="counter-btn counter-btn--neg" aria-label="minus 64">-64</button>
+                  <button class="counter-btn counter-btn--neg" aria-label="minus 1">-1</button>
+                  <button class="counter-btn counter-btn--pos" aria-label="plus 1">+1</button>
+                  <button class="counter-btn counter-btn--pos" aria-label="plus 64">+64</button>
+                  <button class="counter-btn counter-btn--pos" aria-label="plus 1728">+1728</button>
+                </div>
+              </div>
+              <button class="btn btn--ghost btn--icon-only" aria-label="View how Raw Copper is sourced">⇄</button>
+            </div>
+
+            <!-- Supplied row: no counter, badge instead -->
+            <div class="drill-row">
+              <div class="card" style="flex:1;display:flex;align-items:center;gap:var(--space-3);padding:var(--space-3) var(--space-4);">
+                <span style="flex:1;font-size:var(--text-base);">Iron Ingot <span class="subtle">· Iron Farm (east platform)</span></span>
+                <span style="font-family:var(--font-ui);font-size:12px;color:var(--text-muted);">200</span>
+                <span class="badge badge--accent">Supplied</span>
+              </div>
+              <button class="btn btn--ghost btn--icon-only" aria-label="View how Iron Ingot is sourced">⇄</button>
+            </div>
+          </div>
+
+          <!-- AREA 2 -->
+          <div class="area-label"><span class="area-num">2</span><span class="section-label">Amethyst geode · -210 64 880</span></div>
+          <div class="stack--xs">
+            <div class="drill-row">
+              <div class="resource-row">
+                <div class="resource-row__main">
+                  <div class="resource-row__head"><span class="resource-row__name">Amethyst Shard</span><span class="resource-row__count">0 / 256</span></div>
+                  <span class="resource-row__source">mine the geode</span>
+                  <div class="progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="256"><div class="progress__fill" style="width:0%;"></div></div>
+                </div>
+                <div class="counter-btns">
+                  <button class="counter-btn counter-btn--neg" aria-label="minus 1728">-1728</button>
+                  <button class="counter-btn counter-btn--neg" aria-label="minus 64">-64</button>
+                  <button class="counter-btn counter-btn--neg" aria-label="minus 1">-1</button>
+                  <button class="counter-btn counter-btn--pos" aria-label="plus 1">+1</button>
+                  <button class="counter-btn counter-btn--pos" aria-label="plus 64">+64</button>
+                  <button class="counter-btn counter-btn--pos" aria-label="plus 1728">+1728</button>
+                </div>
+              </div>
+              <button class="btn btn--ghost btn--icon-only" aria-label="View how Amethyst Shard is sourced">⇄</button>
+            </div>
+          </div>
+
+          <!-- BASE -->
+          <div class="area-label"><span class="area-num">⌂</span><span class="section-label">Base — smelt &amp; craft</span></div>
+          <div class="stack--xs">
+            <div class="drill-row">
+              <div class="resource-row">
+                <div class="resource-row__main">
+                  <div class="resource-row__head"><span class="resource-row__name">Hopper</span><span class="resource-row__count">0 / 40</span></div>
+                  <span class="resource-row__source">craft · 5 iron + 1 chest each</span>
+                  <div class="progress" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="40"><div class="progress__fill" style="width:0%;"></div></div>
+                </div>
+                <div class="counter-btns">
+                  <button class="counter-btn counter-btn--neg" aria-label="minus 1728">-1728</button>
+                  <button class="counter-btn counter-btn--neg" aria-label="minus 64">-64</button>
+                  <button class="counter-btn counter-btn--neg" aria-label="minus 1">-1</button>
+                  <button class="counter-btn counter-btn--pos" aria-label="plus 1">+1</button>
+                  <button class="counter-btn counter-btn--pos" aria-label="plus 64">+64</button>
+                  <button class="counter-btn counter-btn--pos" aria-label="plus 1728">+1728</button>
+                </div>
+              </div>
+              <button class="btn btn--ghost btn--icon-only" aria-label="View how Hopper is sourced">⇄</button>
+            </div>
+          </div>
+          <p class="subtle" style="margin-top:var(--space-3);font-size:var(--text-xs);">Tap <span style="color:var(--accent);font-family:var(--font-ui);">⇄</span> on any row to see how it's sourced — and re-pin a different source at any depth.</p>
+
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- =====================================================================
+       4 · PLAN · DRILL  →  fragment: GET /worlds/{id}/plan/chain/{item}
+       The chosen chain for one target, collapsed to the picked source.
+       Node chip (multi-source): hx-get .../chain/{item}/sources/{node}
+       Pin a source: hx-post .../chain/{item}/pin {node, source}
+         → persists sourceByItem, re-derives + re-renders plan.
+  ====================================================================== -->
+  <div class="ref-head"><b>4</b><span>Plan · Drill — chosen chain, swap a node's source on demand</span></div>
+  <p class="ref-note">Reached from any row's <code>⇄</code>. Shows the target's chain collapsed to the engine-picked source per node. Forced (1-way) nodes show "· 1 way", no control. Multi-source nodes show a <code>⇄ {pick}</code> chip; tapping opens a picker that <strong>scales to fan-out</strong> — a short radio list for 2–3 sources, search&nbsp;+&nbsp;ranked top picks for high-fan-out items (e.g. ~1,000 ways to get sticks/planks). Pinning writes <code>sourceByItem</code> and re-derives. Shown here with the Any&nbsp;Planks picker open.</p>
+  <div class="ref-frame">
+    <div class="app graph-paper">
+      <div class="app__main">
+        <div class="stage stage--wide">
+          <div class="cluster--xs" style="margin-bottom:var(--space-3);">
+            <button class="btn btn--ghost btn--sm">‹ Back to plan</button>
+            <span class="section-label">Hopper · chain — if gathered alone · tap ⇄ to re-pin</span>
+          </div>
+          <div class="card" style="overflow:hidden;padding:0;">
+
+            <!-- node: Hopper (forced) -->
+            <div class="chain-node" style="padding:var(--space-3) var(--space-4) var(--space-3) var(--space-4);">
+              <div class="row" style="gap:var(--space-3);">
+                <span style="flex:1;font-size:var(--text-sm);">Hopper <span class="subtle" style="font-size:var(--text-xs);">craft · 5 iron + 1 chest</span></span>
+                <span style="font-family:var(--font-ui);font-size:11px;color:var(--text-muted);">40</span>
+                <span class="subtle" style="font-size:var(--text-xs);white-space:nowrap;">Craft (5 iron + 1 chest) · 1 way</span>
+              </div>
+            </div>
+
+            <!-- node: Iron Ingot (multi-source, collapsed) -->
+            <div class="chain-node" style="padding:var(--space-3) var(--space-4) var(--space-3) var(--space-6);">
+              <div class="row" style="gap:var(--space-3);">
+                <span style="flex:1;font-size:var(--text-sm);">Iron Ingot</span>
+                <span style="font-family:var(--font-ui);font-size:11px;color:var(--text-muted);">200</span>
+                <button class="chip">⇄ Iron Farm</button>
+              </div>
+            </div>
+
+            <!-- node: Chest (forced) -->
+            <div class="chain-node" style="padding:var(--space-3) var(--space-4) var(--space-3) var(--space-6);">
+              <div class="row" style="gap:var(--space-3);">
+                <span style="flex:1;font-size:var(--text-sm);">Chest <span class="subtle" style="font-size:var(--text-xs);">craft · 8 planks each</span></span>
+                <span style="font-family:var(--font-ui);font-size:11px;color:var(--text-muted);">40</span>
+                <span class="subtle" style="font-size:var(--text-xs);white-space:nowrap;">Craft (8 planks) · 1 way</span>
+              </div>
+            </div>
+
+            <!-- node: Any Planks (high fan-out, picker OPEN) -->
+            <div class="chain-node" style="padding:var(--space-3) var(--space-4) var(--space-3) var(--space-8);">
+              <div class="row" style="gap:var(--space-3);">
+                <span style="flex:1;font-size:var(--text-sm);">Any Planks <span class="subtle" style="font-size:var(--text-xs);">feeds 40 chests</span></span>
+                <span style="font-family:var(--font-ui);font-size:11px;color:var(--text-muted);">320</span>
+                <button class="chip">⇄ Oak Planks</button>
+              </div>
+              <div style="margin-top:var(--space-3);padding:var(--space-3);background:var(--bg-raised);border:1px solid var(--border);border-radius:var(--radius);">
+                <div class="picker-search" style="margin-bottom:var(--space-3);"><span>⌕</span><span>search all 1,000+ sources…</span></div>
+                <div class="section-label" style="margin-bottom:var(--space-2);">Ranked · top picks</div>
+                <div class="stack--xs">
+                  <div class="picker-opt picker-opt--sel"><span style="flex:1;font-size:var(--text-sm);font-weight:500;">Oak Planks → craft</span><span class="subtle" style="font-size:var(--text-xs);">best score ★</span></div>
+                  <div class="picker-opt"><span style="flex:1;font-size:var(--text-sm);font-weight:500;">Bamboo Planks → craft</span><span class="subtle" style="font-size:var(--text-xs);"></span></div>
+                  <div class="picker-opt"><span style="flex:1;font-size:var(--text-sm);font-weight:500;">Spruce Planks → craft</span><span class="subtle" style="font-size:var(--text-xs);"></span></div>
+                </div>
+                <div class="subtle" style="text-align:center;font-size:var(--text-xs);margin-top:var(--space-3);">997 more · search to narrow</div>
+              </div>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/documentation/work-documents/gathering-planner/seam/css/components.css
+++ b/documentation/work-documents/gathering-planner/seam/css/components.css
@@ -1,0 +1,486 @@
+/* ── SEAM components ────────────────────────────────────────────
+   CSS class layer the React primitives apply. BEM-ish naming mirrors the
+   production Kotlin DSL. No hardcoded hex/px — tokens only. */
+
+/* ─── App header ─── */
+.app-header {
+  height: 56px;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.app-header__inner {
+  max-width: var(--max-width);
+  height: 100%;
+  margin-inline: auto;
+  padding-inline: var(--space-5);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+.app-header__link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius);
+  padding: var(--space-2) var(--space-3);
+  cursor: pointer;
+  transition: color 120ms ease, background 120ms ease;
+}
+.app-header__link:hover { color: var(--text-primary); background: var(--bg-raised); }
+.app-header__link--active { color: var(--accent); }
+
+/* Logo lockup */
+.mc-logo { display: inline-flex; align-items: center; gap: var(--space-2); background: none; border: none; cursor: pointer; padding: 0; }
+.mc-logo__block { width: 18px; height: 18px; background: var(--accent); border-radius: 3px; box-shadow: inset -2px -2px 0 rgba(0,0,0,0.18); }
+.mc-logo__mark { font-family: var(--font-ui); font-weight: 600; font-size: var(--text-base); letter-spacing: 0.02em; color: var(--text-primary); }
+.mc-logo__dot { color: var(--accent); }
+
+/* Breadcrumb */
+.breadcrumb { display: flex; align-items: center; gap: var(--space-2); }
+.breadcrumb__item {
+  font-family: var(--font-ui); font-size: var(--text-sm); color: var(--accent);
+  background: none; border: none; padding: 0; cursor: pointer;
+}
+.breadcrumb__item:hover { color: var(--accent-hover); text-decoration: underline; }
+.breadcrumb__item--current { color: var(--text-primary); cursor: default; }
+.breadcrumb__item--current:hover { text-decoration: none; }
+.breadcrumb__sep { color: var(--text-disabled); font-family: var(--font-ui); }
+@media (max-width: 768px) { .breadcrumb { display: none; } }
+
+/* ─── Task list ─── */
+.task-list { display: flex; flex-direction: column; }
+.task-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--border);
+}
+.task-row:last-child { border-bottom: none; }
+.task-row--done { color: var(--text-disabled); }
+.task-row--done .mc-icon { opacity: 0.5; }
+.task-row--done span:not(.badge) { color: var(--text-disabled); text-decoration: line-through; }
+
+/* ─── Project detail header ─── */
+.detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+@media (max-width: 768px) {
+  .detail-header { flex-wrap: wrap; }
+}
+
+/* ─── Inline search field ─── */
+.mc-search {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-2) var(--space-3);
+  color: var(--text-muted);
+  min-width: 220px;
+}
+.mc-search:focus-within { border-color: var(--accent); box-shadow: var(--focus-ring); }
+.mc-search input:focus { outline: none; box-shadow: none; }
+
+/* ─── App shell + toast ─── */
+.mc-app { min-height: 100vh; }
+.mc-toast {
+  position: fixed;
+  bottom: var(--space-5);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--text-primary);
+  color: var(--bg-raised);
+  font-family: var(--font-ui);
+  font-size: var(--text-sm);
+  padding: var(--space-3) var(--space-4);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-pop);
+  animation: mc-fade 150ms ease;
+  z-index: 50;
+}
+
+/* ─── Page heading ─── */
+.page-heading { margin-bottom: var(--space-5); }
+.page-heading__title {
+  font-family: var(--font-ui);
+  font-weight: 600;
+  font-size: var(--text-heading);
+  color: var(--text-primary);
+}
+.page-heading__subtitle {
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  margin-top: var(--space-1);
+}
+
+/* ─── Section ─── */
+.section { margin-bottom: var(--space-6); }
+.section__head { margin-bottom: var(--space-3); }
+.section__title {
+  font-family: var(--font-ui);
+  font-weight: 600;
+  font-size: var(--text-base);
+  color: var(--text-primary);
+}
+.section__card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+}
+
+/* ─── Buttons ─── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  font-family: var(--font-ui);
+  font-size: var(--text-ui);
+  font-weight: 500;
+  line-height: 1;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius);          /* never pill */
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+  white-space: nowrap;
+  user-select: none;
+}
+.btn:disabled, .btn[aria-disabled="true"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.btn--primary {
+  background: var(--accent);
+  color: var(--on-accent);
+}
+.btn--primary:hover { background: var(--accent-hover); }
+
+/* Secondary is INK-ON-PAPER, never a second colour */
+.btn--secondary {
+  background: var(--bg-raised);
+  color: var(--text-primary);
+  border-color: var(--border);
+}
+.btn--secondary:hover { border-color: var(--border-strong); background: var(--bg-surface); }
+
+.btn--ghost {
+  background: transparent;
+  color: var(--text-muted);
+}
+.btn--ghost:hover { background: var(--bg-raised); color: var(--text-primary); }
+
+.btn--danger {
+  background: var(--red);
+  color: var(--on-accent);
+}
+.btn--danger:hover { background: #8C2A1A; }
+
+.btn--sm { padding: var(--space-1) var(--space-3); font-size: var(--text-label); }
+
+.btn:active { transform: translateY(0.5px); }
+
+/* Icon-only button */
+.btn--icon-only {
+  padding: var(--space-2);
+  width: 32px; height: 32px;
+}
+.btn--icon-only.btn--sm { width: 28px; height: 28px; padding: var(--space-1); }
+
+/* ─── Badges ─── (text-only, no icons) */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-ui);
+  font-size: var(--text-ui);
+  font-weight: 500;
+  line-height: 1;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
+}
+.badge--neutral      { background: var(--bg-raised); color: var(--text-muted); border: 1px solid var(--border); }
+.badge--accent       { background: var(--accent-muted); color: var(--accent); }
+.badge--danger       { background: var(--red-bg); color: var(--red); }
+.badge--not-started  { background: var(--bg-raised); color: var(--text-muted); border: 1px solid var(--border); }
+.badge--in-progress  { background: var(--accent-muted); color: var(--accent); }
+.badge--done         { background: var(--green-bg); color: var(--green); }
+.badge--blocked      { background: var(--red-bg); color: var(--red); }
+
+/* ─── Progress bar ─── */
+.progress {
+  width: 100%;
+  height: 4px;
+  background: var(--bg-raised);
+  border-radius: 2px;
+  overflow: hidden;
+}
+.progress--lg { height: 6px; }
+.progress__fill {
+  height: 100%;
+  background: var(--progress);
+  border-radius: 2px;
+  transition: width 200ms ease;
+}
+.progress__fill--complete { background: var(--green); }
+
+/* ─── Plan / Execute toggle ─── */
+.toggle {
+  display: inline-flex;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  padding: 2px;
+}
+.toggle__btn {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-pill);
+  padding: var(--space-1) var(--space-4);
+  width: 64px;                /* fixed — no layout shift on toggle */
+  text-align: center;
+  cursor: pointer;
+  transition: background 150ms ease-in-out, color 150ms ease-in-out;
+}
+.toggle__btn--active { background: var(--accent); color: var(--on-accent); }
+
+/* ─── Callout ─── (left-border notice, never a full-width banner) */
+.callout {
+  display: flex;
+  gap: var(--space-3);
+  background: var(--bg-raised);
+  border-left: 3px solid var(--amber);
+  border-radius: var(--radius-sm);
+  padding: var(--space-3) var(--space-4);
+}
+.callout__icon {
+  font-family: var(--font-ui);
+  color: var(--amber);
+  flex-shrink: 0;
+  line-height: var(--leading-body);
+}
+.callout__body { font-family: var(--font-body); font-size: var(--text-sm); color: var(--text-primary); }
+.callout--info    { border-left-color: var(--accent); }
+.callout--info    .callout__icon { color: var(--accent); }
+.callout--success { border-left-color: var(--green); }
+.callout--success .callout__icon { color: var(--green); }
+.callout--error   { border-left-color: var(--red); }
+.callout--error   .callout__icon { color: var(--red); }
+
+/* ─── Cards ─── */
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  box-shadow: var(--shadow-card);
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.card--interactive { cursor: pointer; }
+.card--interactive:hover { border-color: var(--border-strong); background: var(--bg-raised); }
+
+/* ─── Forms ─── */
+.form-control {
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  color: var(--text-primary);
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--space-2) var(--space-3);
+  width: 100%;
+}
+.form-control::placeholder { color: var(--text-disabled); }
+.form-control:hover { border-color: var(--border-strong); }
+.form-control:focus { outline: none; border-color: var(--accent); box-shadow: var(--focus-ring); }
+.form-control.is-invalid { border-color: var(--red); }
+.form-error, .validation-error-message {
+  font-family: var(--font-body); font-size: var(--text-xs); color: var(--red); margin-top: var(--space-1);
+}
+.form-help-text { font-family: var(--font-body); font-size: var(--text-xs); color: var(--text-muted); margin-top: var(--space-1); }
+.form-label {
+  font-family: var(--font-ui); font-size: var(--text-label); font-weight: 500;
+  letter-spacing: var(--tracking-label); text-transform: uppercase; color: var(--text-muted);
+  display: block; margin-bottom: var(--space-2);
+}
+
+/* ─── Checkbox / Radio ─── */
+.mc-check {
+  appearance: none;
+  width: 18px; height: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-raised);
+  cursor: pointer;
+  display: inline-grid;
+  place-content: center;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+.mc-check:hover { border-color: var(--border-strong); }
+.mc-check:checked { background: var(--green); border-color: var(--green); }
+.mc-check:checked::after {
+  content: "✓"; color: var(--on-accent); font-family: var(--font-ui); font-size: 12px; line-height: 1;
+}
+.mc-check--radio { border-radius: var(--radius-pill); }
+.mc-check--radio:checked { background: var(--accent); border-color: var(--accent); }
+.mc-check--radio:checked::after { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--on-accent); }
+
+/* ─── Switch ─── */
+.mc-switch {
+  appearance: none;
+  position: relative;
+  width: 38px; height: 22px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+.mc-switch::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--text-muted);
+  transition: transform 150ms ease, background 150ms ease;
+}
+.mc-switch:checked { background: var(--accent); border-color: var(--accent); }
+.mc-switch:checked::after { transform: translateX(16px); background: var(--on-accent); }
+
+/* ─── Data table ─── */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+}
+.data-table thead th {
+  font-family: var(--font-ui);
+  font-size: var(--text-label);
+  font-weight: 500;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  text-align: left;
+  padding: var(--space-3) var(--space-4);
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+}
+.data-table tbody td { padding: var(--space-2) var(--space-4); color: var(--text-primary); }
+.data-table tbody tr:nth-child(odd)  { background: var(--bg-surface); }
+.data-table tbody tr:nth-child(even) { background: var(--bg-raised); }
+
+/* ─── Tabs ─── */
+.tabs { display: flex; gap: var(--space-1); border-bottom: 1px solid var(--border); }
+.tab {
+  font-family: var(--font-ui);
+  font-size: var(--text-ui);
+  font-weight: 500;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: var(--space-3) var(--space-4);
+  margin-bottom: -1px;
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+.tab:hover { color: var(--text-primary); }
+.tab--active { color: var(--accent); border-bottom-color: var(--accent); }
+.tabs--pills { border-bottom: none; gap: var(--space-2); }
+.tabs--pills .tab { border: 1px solid var(--border); border-radius: var(--radius-pill); margin-bottom: 0; }
+.tabs--pills .tab--active { background: var(--accent); color: var(--on-accent); border-color: var(--accent); }
+
+/* ─── Modal ─── */
+.modal-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(42, 34, 24, 0.6);
+  display: grid; place-items: center;
+  padding: var(--space-5);
+  animation: mc-fade 150ms ease;
+}
+.modal {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-pop);
+  max-width: 440px; width: 100%;
+  padding: var(--space-5);
+  animation: mc-pop 150ms ease;
+}
+.modal__heading { font-family: var(--font-ui); font-weight: 600; font-size: var(--text-base); margin-bottom: var(--space-3); display: flex; align-items: center; gap: var(--space-2); }
+.modal__body { font-family: var(--font-body); font-size: var(--text-sm); color: var(--text-primary); line-height: var(--leading-body); }
+.modal__actions { display: flex; justify-content: flex-end; gap: var(--space-2); margin-top: var(--space-5); }
+
+@keyframes mc-fade { from { opacity: 0; } to { opacity: 1; } }
+@keyframes mc-pop  { from { opacity: 0; transform: scale(0.97); } to { opacity: 1; transform: scale(1); } }
+
+/* ─── Resource row (execute view) ─── */
+.resource-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--border);
+}
+.resource-row:last-child { border-bottom: none; }
+.resource-row__main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: var(--space-1); }
+.resource-row__head { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-3); }
+.resource-row__name { font-family: var(--font-body); font-size: var(--text-base); font-weight: 500; color: var(--text-primary); }
+.resource-row__count { font-family: var(--font-ui); font-size: var(--text-ui); color: var(--text-muted); white-space: nowrap; }
+.resource-row__source { font-family: var(--font-ui); font-size: var(--text-xs); color: var(--text-muted); }
+.resource-row--complete .resource-row__name { color: var(--text-disabled); text-decoration: line-through; }
+.resource-row--complete .resource-row__count { color: var(--text-disabled); }
+@media (max-width: 768px) {
+  .resource-row { flex-direction: column; align-items: stretch; min-height: 64px; }
+}
+
+/* ─── Counter buttons (resource row) ─── */
+.counter-btns { display: inline-flex; gap: var(--space-1); }
+.counter-btn {
+  font-family: var(--font-ui);
+  font-size: var(--text-label);
+  font-weight: 500;
+  min-width: 28px; height: 28px;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--bg-raised);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.counter-btn:hover { border-color: var(--border-strong); }
+.counter-btn--pos { color: var(--green); }
+.counter-btn--neg { color: var(--red); }
+@media (max-width: 768px) {
+  .counter-btn { min-width: 36px; height: 36px; }
+}

--- a/documentation/work-documents/gathering-planner/seam/css/reset.css
+++ b/documentation/work-documents/gathering-planner/seam/css/reset.css
@@ -1,0 +1,42 @@
+/* ── SEAM reset ─────────────────────────────────────────────────
+   Minimal, opinionated. Paper background, sepia ink, Inter body default. */
+
+*, *::before, *::after { box-sizing: border-box; }
+
+html, body { margin: 0; padding: 0; }
+
+body {
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: var(--font-body);
+  font-size: var(--text-base);
+  line-height: var(--leading-body);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+  font-family: var(--font-ui);
+  font-weight: 600;
+  line-height: var(--leading-tight);
+  color: var(--text-primary);
+}
+
+p { margin: 0; }
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover { color: var(--accent-hover); text-decoration: underline; }
+
+button { font-family: inherit; }
+
+ul, ol { margin: 0; padding: 0; list-style: none; }
+
+:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-radius: var(--radius-sm);
+}

--- a/documentation/work-documents/gathering-planner/seam/css/utilities.css
+++ b/documentation/work-documents/gathering-planner/seam/css/utilities.css
@@ -1,0 +1,74 @@
+/* ── SEAM layout & utility classes ──────────────────────────────
+   Prefer these for ad-hoc layout. Spacing always references tokens. */
+
+.container {
+  max-width: var(--max-width);
+  margin-inline: auto;
+  padding-inline: var(--space-5);
+  width: 100%;
+}
+
+.surface {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.divider { border-top: 1px solid var(--border); }
+
+/* Flex helpers */
+.flex { display: flex; }
+.flex-col { display: flex; flex-direction: column; }
+.items-center { align-items: center; }
+.items-start { align-items: flex-start; }
+.justify-between { justify-content: space-between; }
+.justify-center { justify-content: center; }
+.flex-1 { flex: 1; }
+.flex-wrap { flex-wrap: wrap; }
+
+/* Stacks (vertical) & clusters (horizontal) */
+.stack { display: flex; flex-direction: column; gap: var(--space-4); }
+.stack--xs { display: flex; flex-direction: column; gap: var(--space-2); }
+.cluster { display: flex; align-items: center; gap: var(--space-4); flex-wrap: wrap; }
+.cluster--xs { display: flex; align-items: center; gap: var(--space-2); flex-wrap: wrap; }
+
+/* Gap scale */
+.gap-1 { gap: var(--space-1); }
+.gap-2 { gap: var(--space-2); }
+.gap-3 { gap: var(--space-3); }
+.gap-4 { gap: var(--space-4); }
+.gap-5 { gap: var(--space-5); }
+
+/* Width */
+.w-full { width: 100%; }
+
+/* Margin / padding */
+.mt-4 { margin-top: var(--space-4); }
+.mt-5 { margin-top: var(--space-5); }
+.mb-4 { margin-bottom: var(--space-4); }
+.mb-5 { margin-bottom: var(--space-5); }
+.p-4 { padding: var(--space-4); }
+.p-5 { padding: var(--space-5); }
+
+.is-hidden { display: none !important; }
+
+/* Responsive auto-fill card grid */
+.mc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--space-4);
+}
+
+/* ─── Field-notebook graph-paper texture ───
+   The signature SEAM background motif — faint sepia rules on paper.
+   Apply to large surfaces (app shell, empty states, hero panels). */
+.graph-paper {
+  background-color: var(--bg-base);
+  background-image:
+    linear-gradient(to right,  rgba(122, 107, 71, 0.10) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(122, 107, 71, 0.10) 1px, transparent 1px);
+  background-size: 24px 24px;
+}
+.graph-paper--fine {
+  background-size: 12px 12px;
+}

--- a/documentation/work-documents/gathering-planner/seam/tokens/colors.css
+++ b/documentation/work-documents/gathering-planner/seam/tokens/colors.css
@@ -1,0 +1,48 @@
+/* ── SEAM color tokens ──────────────────────────────────────────
+   Palette: "Daylight Field Notebook" (Overworld) — a warm paper + sepia-ink
+   substrate drawn from the overworld's dirt/sand/wood, with accents borrowed
+   from overworld materials. Light theme only (no dark theme yet).
+
+   ONE HUE, ONE JOB:
+     sand/dirt/wood  → substrate (surfaces, rules, ink). Brown is NEVER an accent.
+     lapis           → ACT  (primary/CTA, links, active) + INFO (the quiet wash)
+     grass/emerald   → DONE (success, status, progress)
+     wheat-gold       → WARN
+     redstone         → DANGER
+   The primary user is red-green colour-blind: blue↔yellow is the only reliably
+   distinguishable axis. Never convey state by colour alone. */
+
+:root {
+  /* Substrate — sand / dirt / wood */
+  --bg-base:        #EBE1C8;  /* page edge / app background */
+  --bg-surface:     #F7F0DE;  /* cards, panels (paper) */
+  --bg-raised:      #FCF7EA;  /* inputs, row hover, badges */
+  --border:         #D6C6A2;  /* rule lines, dividers, borders */
+  --border-strong:  #C2AE82;  /* emphasized rule (hover/focus border) */
+
+  /* Ink — sepia */
+  --text-primary:   #2A2218;  /* body, headings */
+  --text-muted:     #7A6B47;  /* labels, metadata (faded ink) */
+  --text-disabled:  #A99B78;  /* done items, dimmed content */
+
+  /* Lapis — ACT + INFO */
+  --accent:         #2C6E9E;  /* CTA, active toggle, links */
+  --accent-hover:   #245C85;  /* CTA hover */
+  --accent-muted:   #D6E2EC;  /* info wash, badges, focus ring */
+  --on-accent:      #FCF7EA;  /* cream text/icon on an accent fill */
+
+  /* Grass — DONE */
+  --green:          #4F7A2B;  /* success / status / progress */
+  --green-bg:       #DEE8CB;  /* done badge background */
+  --progress:       #4F7A2B;  /* progress bar fill */
+
+  /* Wheat-gold — WARN */
+  --amber:          #B0791A;
+
+  /* Redstone — DANGER */
+  --red:            #A6321F;
+  --red-bg:         #F0DACF;  /* blocked badge background */
+
+  /* Focus ring (derived) */
+  --focus-ring:     0 0 0 3px var(--accent-muted);
+}

--- a/documentation/work-documents/gathering-planner/seam/tokens/fonts.css
+++ b/documentation/work-documents/gathering-planner/seam/tokens/fonts.css
@@ -1,0 +1,9 @@
+/* ── SEAM webfonts ──────────────────────────────────────────────
+   Two faces only, per spec:
+   - IBM Plex Mono  → --font-ui   (chrome, headings, badges, labels, buttons)
+   - Inter          → --font-body (body text, table cells, prose)
+   Loaded from Google Fonts. Both are the genuine specified faces (no
+   substitution). If you ship offline, self-host the .woff2 binaries and
+   replace this @import with local @font-face rules. */
+
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');

--- a/documentation/work-documents/gathering-planner/seam/tokens/spacing.css
+++ b/documentation/work-documents/gathering-planner/seam/tokens/spacing.css
@@ -1,0 +1,26 @@
+/* ── SEAM spacing, layout & radius tokens ───────────────────────
+   4px grid. Always use tokens — never raw pixel values. */
+
+:root {
+  /* Spacing — 4px grid */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 24px;
+  --space-6: 32px;
+  --space-8: 48px;
+
+  /* Layout */
+  --max-width: 1080px;
+  --breakpoint-mobile: 768px;
+
+  /* Radius — 6px everywhere; buttons are NEVER pill */
+  --radius: 6px;
+  --radius-sm: 4px;
+  --radius-pill: 999px;  /* reserved for the Plan/Execute toggle & badges only */
+
+  /* Elevation — paper, not glass. Shadows are warm + subtle. */
+  --shadow-card:  0 1px 2px rgba(42, 34, 24, 0.06);
+  --shadow-pop:   0 4px 16px rgba(42, 34, 24, 0.14);
+}

--- a/documentation/work-documents/gathering-planner/seam/tokens/typography.css
+++ b/documentation/work-documents/gathering-planner/seam/tokens/typography.css
@@ -1,0 +1,41 @@
+/* ── SEAM typography tokens ─────────────────────────────────────
+   Two fonts only. IBM Plex Mono carries the "technical notebook" voice
+   (chrome, headings, badges, labels, buttons). Inter is for legible body
+   text and dense table content. */
+
+:root {
+  --font-ui:   'IBM Plex Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+  --font-body: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+
+  /* Type scale */
+  --text-xs:      11px;   /* metadata, timestamps        (Inter 400) */
+  --text-sm:      13px;   /* table cells, secondary       (Inter 400) */
+  --text-base:    15px;   /* body text                    (Inter 400) */
+  --text-ui:      13px;   /* badges, tags, code-like      (Plex Mono 500) */
+  --text-label:   11px;   /* section headers, tracked     (Plex Mono 500) */
+  --text-heading: 20px;   /* page titles, project names   (Plex Mono 600) */
+
+  /* Section-label treatment */
+  --tracking-label: 0.08em;
+
+  /* Line heights */
+  --leading-tight: 1.25;
+  --leading-body:  1.55;
+}
+
+/* Uppercase, tracked, muted section label */
+.section-label {
+  font-family: var(--font-ui);
+  font-size: var(--text-label);
+  font-weight: 500;
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* Muted small text */
+.subtle {
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStep.kt
@@ -1,0 +1,114 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.resources.ResourceGatheringItem
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.engine.model.ItemSourceGraph
+import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.engine.plan.GatheringPlanner
+import app.mcorg.engine.plan.PlanOverrides
+import app.mcorg.engine.plan.PlanTarget
+import app.mcorg.engine.plan.SupplySource
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.minecraft.GetItemSourceGraphForVersionStep
+import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
+
+/**
+ * Input bundle for [GenerateGatheringPlanStep].
+ *
+ * @param projectId the project whose resource_gathering rows are the planning targets.
+ * @param worldId the world that owns the project — used to resolve its Minecraft version,
+ *   which drives the cached [ItemSourceGraph].
+ * @param resourceGatheringId the resource_gathering record that holds the user's
+ *   persisted [PlanOverrides] (source pins and tag-member choices).
+ */
+data class GatheringPlanInput(
+    val projectId: Int,
+    val worldId: Int,
+    val resourceGatheringId: Int
+)
+
+/**
+ * Derives a [GatheringPlan] for a project's resource gathering without persisting it.
+ *
+ * Execution order:
+ * 1. Load the world's Minecraft version string.
+ * 2. Obtain the cached [ItemSourceGraph] for that version.
+ * 3. Load all resource_gathering rows for the project.
+ * 4. Build [PlanTarget]s: amount = max(0, required − collected); skip fully-collected rows.
+ * 5. Build the [SupplySource] map: rows linked to another project become
+ *    [SupplySource.LinkedProject] terminals.
+ * 6. Load persisted [PlanOverrides] for the resource gathering record.
+ * 7. Run [GatheringPlanner.plan] and return the result.
+ *
+ * Fails with:
+ * - [AppFailure.DatabaseError.NotFound] when the world or its version graph is not found.
+ * - [AppFailure.DatabaseError.DatabaseError] on any query failure.
+ * - [AppFailure.ValidationError] when there are no positive-amount targets (all items
+ *   are already fully collected).
+ */
+object GenerateGatheringPlanStep : Step<GatheringPlanInput, AppFailure, GatheringPlan> {
+
+    private val worldVersionQuery = DatabaseSteps.query<Int, String?>(
+        sql = SafeSQL.select("SELECT version FROM world WHERE id = ?"),
+        parameterSetter = { ps, worldId -> ps.setInt(1, worldId) },
+        resultMapper = { rs -> if (rs.next()) rs.getString("version") else null }
+    )
+
+    override suspend fun process(input: GatheringPlanInput): Result<AppFailure, GatheringPlan> {
+        // 1. Resolve world version
+        val versionString = when (val r = worldVersionQuery.process(input.worldId)) {
+            is Result.Success -> r.value ?: return Result.failure(AppFailure.DatabaseError.NotFound)
+            is Result.Failure -> return r
+        }
+
+        // 2. Get (or build and cache) the item-source graph for that version
+        val graph: ItemSourceGraph = when (val r = GetItemSourceGraphForVersionStep.process(versionString)) {
+            is Result.Success -> r.value
+            is Result.Failure -> return r
+        }
+
+        // 3. Load all resource_gathering rows for this project
+        val items: List<ResourceGatheringItem> =
+            when (val r = GetAllResourceGatheringItemsStep.process(input.projectId)) {
+                is Result.Success -> r.value
+                is Result.Failure -> return r
+            }
+
+        // 4. Build targets — net of collected; skip fully-collected items
+        val targets: List<PlanTarget> = items.mapNotNull { item ->
+            val net = (item.required - item.collected).toLong()
+            if (net <= 0) null
+            else PlanTarget(Item(item.itemId, item.name), net)
+        }
+
+        if (targets.isEmpty()) {
+            return Result.failure(
+                AppFailure.customValidationError(
+                    "targets",
+                    "All items are fully collected — nothing left to plan"
+                )
+            )
+        }
+
+        // 5. Build supplied map: rows linked to another project become supply terminals
+        val supplied: Map<String, SupplySource> = items
+            .mapNotNull { item ->
+                val (solvedId, solvedName) = item.solvedByProject ?: return@mapNotNull null
+                item.itemId to SupplySource.LinkedProject(solvedId, solvedName)
+            }
+            .toMap()
+
+        // 6. Load persisted overrides
+        val overrides: PlanOverrides = when (val r = GetPlanOverridesStep.process(input.resourceGatheringId)) {
+            is Result.Success -> r.value
+            is Result.Failure -> return r
+        }
+
+        // 7. Run the engine
+        return Result.success(GatheringPlanner.plan(graph, targets, supplied, overrides))
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStepTest.kt
@@ -1,0 +1,293 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.config.CacheManager
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftTag
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.minecraft.ServerData
+import app.mcorg.domain.model.resources.ResourceQuantity
+import app.mcorg.domain.model.resources.ResourceSource
+import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.minecraft.StoreMinecraftDataStep
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [GenerateGatheringPlanStep]:
+ * - success path: targets build from resource_gathering rows, engine plan returned
+ * - world not found: fails with NotFound
+ * - empty targets (all collected): fails with ValidationError
+ * - linked project becomes a SUPPLIED terminal in the plan
+ * - unknown version (graph not ingested): fails with NotFound
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class GenerateGatheringPlanStepTest : WithUser() {
+
+    private val version = MinecraftVersion.Release(1, 99, 0)
+
+    private val log = Item("minecraft:oak_log", "Oak Log")
+    private val oakPlanks = Item("minecraft:oak_planks", "Oak Planks")
+    private val birchPlanks = Item("minecraft:birch_planks", "Birch Planks")
+    private val chest = Item("minecraft:chest", "Chest")
+    private val planksTag = MinecraftTag("#minecraft:planks", "Planks", listOf(oakPlanks, birchPlanks))
+
+    private var worldId: Int = 0
+
+    @BeforeAll
+    fun setup() {
+        CacheManager.invalidateAll()
+
+        // Store a small but realistic graph for version 1.99.0 (test-only)
+        val serverData = ServerData(
+            version = version,
+            items = listOf(log, oakPlanks, birchPlanks, chest, planksTag),
+            sources = listOf(
+                ResourceSource(
+                    type = ResourceSource.SourceType.LootTypes.BLOCK,
+                    filename = "blocks/oak_log.json",
+                    producedItems = listOf(log to ResourceQuantity.ItemQuantity(1))
+                ),
+                ResourceSource(
+                    type = ResourceSource.SourceType.RecipeTypes.CRAFTING_SHAPELESS,
+                    filename = "oak_planks.json",
+                    requiredItems = listOf(log to ResourceQuantity.ItemQuantity(1)),
+                    producedItems = listOf(oakPlanks to ResourceQuantity.ItemQuantity(4))
+                ),
+                ResourceSource(
+                    type = ResourceSource.SourceType.RecipeTypes.CRAFTING_SHAPED,
+                    filename = "chest.json",
+                    requiredItems = listOf(planksTag to ResourceQuantity.ItemQuantity(8)),
+                    producedItems = listOf(chest to ResourceQuantity.ItemQuantity(1))
+                )
+            )
+        )
+        val stored = runBlocking { StoreMinecraftDataStep.process(serverData) }
+        assertIs<Result.Success<*>>(stored)
+
+        worldId = createWorld(version)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Success path: targets build from gathering rows → engine returns a plan
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `success path - targets build from rows and engine returns a plan`() {
+        val projectId = createProject(worldId)
+        val rgId = createResourceGathering(projectId)
+        insertGatheringItem(projectId, chest.id, chest.name, required = 4, collected = 0)
+
+        val result = runBlocking {
+            GenerateGatheringPlanStep.process(
+                GatheringPlanInput(projectId, worldId, rgId)
+            )
+        }
+
+        assertIs<Result.Success<*>>(result)
+        val plan = (result as Result.Success).value
+        val chestNode = plan.nodes[chest.id]
+        assertNotNull(chestNode, "chest must be in the plan")
+        assertEquals(4L, chestNode.quantity)
+        assertEquals(PlanNodeStatus.RESOLVED, chestNode.status)
+        // planks tag is OPEN_TAG — 4 chests × 8 planks
+        val planksNode = plan.nodes[planksTag.id]
+        assertNotNull(planksNode, "#minecraft:planks must be in the plan")
+        assertEquals(32L, planksNode.quantity)
+        assertEquals(PlanNodeStatus.OPEN_TAG, planksNode.status)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Failure: world not found
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `failure - world not found returns NotFound`() {
+        val projectId = createProject(worldId)
+        val rgId = createResourceGathering(projectId)
+
+        val result = runBlocking {
+            GenerateGatheringPlanStep.process(
+                GatheringPlanInput(projectId, worldId = Int.MAX_VALUE, resourceGatheringId = rgId)
+            )
+        }
+
+        assertIs<Result.Failure<*>>(result)
+        assertTrue(
+            (result as Result.Failure).error is app.mcorg.pipeline.failure.AppFailure.DatabaseError.NotFound,
+            "Expected NotFound for unknown worldId"
+        )
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Failure: version has no ingested graph
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `failure - version with no ingested graph returns NotFound`() {
+        // Create a world with a version that has no resource_source data
+        val uningestedVersion = MinecraftVersion.fromString("0.0.1")
+        val uningestedWorldId = createWorld(uningestedVersion)
+        val projectId = createProject(uningestedWorldId)
+        val rgId = createResourceGathering(projectId)
+        insertGatheringItem(projectId, chest.id, chest.name, required = 1, collected = 0)
+
+        val result = runBlocking {
+            GenerateGatheringPlanStep.process(
+                GatheringPlanInput(projectId, uningestedWorldId, rgId)
+            )
+        }
+
+        assertIs<Result.Failure<*>>(result)
+        assertTrue(
+            (result as Result.Failure).error is app.mcorg.pipeline.failure.AppFailure.DatabaseError.NotFound,
+            "Expected NotFound when version has no ingested graph"
+        )
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Failure: empty targets (all items fully collected)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `failure - all items fully collected returns ValidationError`() {
+        val projectId = createProject(worldId)
+        val rgId = createResourceGathering(projectId)
+        // required == collected → net = 0 → no targets
+        insertGatheringItem(projectId, chest.id, chest.name, required = 4, collected = 4)
+
+        val result = runBlocking {
+            GenerateGatheringPlanStep.process(
+                GatheringPlanInput(projectId, worldId, rgId)
+            )
+        }
+
+        assertIs<Result.Failure<*>>(result)
+        assertTrue(
+            (result as Result.Failure).error is app.mcorg.pipeline.failure.AppFailure.ValidationError,
+            "Expected ValidationError when all items are fully collected"
+        )
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Supplied: item linked to another project becomes a SUPPLIED terminal
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `linked project item becomes SUPPLIED terminal in plan`() {
+        val producerProjectId = createProject(worldId)
+        val consumerProjectId = createProject(worldId)
+        val rgId = createResourceGathering(consumerProjectId)
+
+        // chest is the main target (needs planning)
+        insertGatheringItem(consumerProjectId, chest.id, chest.name, required = 2, collected = 0)
+        // oak_planks is sourced from producerProjectId
+        val rgItemId = insertGatheringItem(
+            consumerProjectId, oakPlanks.id, oakPlanks.name, required = 10, collected = 0
+        )
+        // Mark oak_planks as supplied by the producer project
+        linkResourceToProject(rgItemId, producerProjectId)
+
+        val result = runBlocking {
+            GenerateGatheringPlanStep.process(
+                GatheringPlanInput(consumerProjectId, worldId, rgId)
+            )
+        }
+
+        assertIs<Result.Success<*>>(result)
+        val plan = (result as Result.Success).value
+        val planksNode = plan.nodes[oakPlanks.id]
+        assertNotNull(planksNode, "oak_planks must be in the plan as a SUPPLIED node")
+        assertEquals(PlanNodeStatus.SUPPLIED, planksNode.status)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Fixture helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private fun createWorld(v: MinecraftVersion): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(
+                name = "GatheringPlanStep Test World (${v})",
+                description = "test",
+                version = v
+            )
+        )
+        (result as Result.Success).value
+    }
+
+    private fun createProject(worldId: Int): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, location_x, location_y, location_z, location_dimension) " +
+                    "VALUES ('GatheringPlanStep Project', ?, '', 'BUILDING', 'PLANNING', 0, 0, 0, 'OVERWORLD') RETURNING id"
+            ),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, worldId) }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun createResourceGathering(projectId: Int): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO resource_gathering (project_id, item_id, name, required, collected) " +
+                    "VALUES (?, 'minecraft:placeholder', 'Placeholder', 1, 1) RETURNING id"
+            ),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, projectId) }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun insertGatheringItem(
+        projectId: Int,
+        itemId: String,
+        name: String,
+        required: Int,
+        collected: Int
+    ): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO resource_gathering (project_id, item_id, name, required, collected) " +
+                    "VALUES (?, ?, ?, ?, ?) RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+                stmt.setString(3, name)
+                stmt.setInt(4, required)
+                stmt.setInt(5, collected)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun linkResourceToProject(resourceGatheringId: Int, solvedByProjectId: Int) {
+        runBlocking {
+            DatabaseSteps.update<Unit>(
+                sql = SafeSQL.update(
+                    "UPDATE resource_gathering SET source_type = 'project', solved_by_project_id = ? WHERE id = ?"
+                ),
+                parameterSetter = { stmt, _ ->
+                    stmt.setInt(1, solvedByProjectId)
+                    stmt.setInt(2, resourceGatheringId)
+                }
+            ).process(Unit)
+        }
+    }
+}


### PR DESCRIPTION
Phase 1 of the Gathering Planner epic ([MCO-219](https://linear.app/evegul/issue/MCO-219)) — issue **[MCO-220](https://linear.app/evegul/issue/MCO-220)**.

The keystone reconnection of the now-complete quantity-aware engine (MCO-190..197) to `mc-web`. Nothing previously called the engine from the web layer; this adds the wiring that turns a project's gathering data + persisted overrides into a `GatheringPlan`.

## What

- **`GenerateGatheringPlanStep`** (`mc-web`, `pipeline/resources/`):
  - resolves the world's `minecraft_version` and reuses the cached `ItemSourceGraph` via `GetItemSourceGraphForVersionStep` (MCO-193 infra — not rebuilt);
  - builds targets from `resource_gathering` rows net of `collected` (fully-collected rows excluded as targets);
  - maps `solved_by_project_id` rows to `SupplySource.LinkedProject`;
  - loads persisted overrides via `GetPlanOverridesStep` (`resource_gathering_plan_override`);
  - calls the engine facade `GatheringPlanner.plan(...)` → `GatheringPlan`.
- Persists the Claude Design "Gathering Planner" handoff (screens.html + README + seam CSS) under `documentation/work-documents/gathering-planner/` for the later UI phases.

**Backend only** — no UI, no migration, **no `mc-engine` changes** (pure consumer). No `preview` label needed.

## Notes / decisions

- Step tests are `@Tag("database")` (not pure unit) — the DB-backed dependencies have no injectable seam, consistent with sibling resource-step tests.
- The step takes `resourceGatheringId` explicitly (a project can have multiple gathering records); Phase 2 will decide which record the plan view uses.

## Tests

- New: 5 (`GenerateGatheringPlanStepTest`) — success, world-not-found, version-not-ingested, all-collected, linked-project→SUPPLIED.
- Suite: **541 unit / 79 database green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)