### PR TITLE
Plan backend: project-scoped overrides + per-node progress table (MCO-221, PR 2a)

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetProjectListItemStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetProjectListItemStep.kt
@@ -21,7 +21,7 @@ object GetProjectListItemStep : Step<Int, AppFailure.DatabaseError, ProjectListI
                   COUNT(DISTINCT t.id) FILTER (WHERE t.completed = false) AS tasks_remaining,
                   COUNT(DISTINCT t.id)                                      AS tasks_total,
                   COALESCE(SUM(rg.required), 0)                            AS resources_required,
-                  COALESCE(SUM(rg.collected), 0)                           AS resources_gathered,
+                  COALESCE(SUM(rgp.collected), 0)                          AS resources_gathered,
                   COUNT(DISTINCT rg.id)                                    AS item_count,
                   (
                     SELECT t2.name FROM action_task t2
@@ -32,6 +32,11 @@ object GetProjectListItemStep : Step<Int, AppFailure.DatabaseError, ProjectListI
                 FROM projects p
                 LEFT JOIN action_task t  ON t.project_id  = p.id
                 LEFT JOIN resource_gathering rg ON rg.project_id = p.id
+                -- rgp is 1:1 with rg by (project_id, item_id) (rgp is unique on that pair),
+                -- so this join adds no fan-out and SUM(rgp.collected) matches the old
+                -- SUM(rg.collected) for the normal one-row-per-item case.
+                LEFT JOIN resource_gathering_progress rgp
+                       ON rgp.project_id = rg.project_id AND rgp.item_id = rg.item_id
                 WHERE p.id = ?
                 GROUP BY p.id
             """.trimIndent()),

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetProjectListStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetProjectListStep.kt
@@ -21,7 +21,7 @@ data class GetProjectListStep(val worldId: Int) : Step<Unit, AppFailure.Database
                   COUNT(DISTINCT t.id) FILTER (WHERE t.completed = false) AS tasks_remaining,
                   COUNT(DISTINCT t.id)                                      AS tasks_total,
                   COALESCE(SUM(rg.required), 0)                            AS resources_required,
-                  COALESCE(SUM(rg.collected), 0)                           AS resources_gathered,
+                  COALESCE(SUM(rgp.collected), 0)                          AS resources_gathered,
                   COUNT(DISTINCT rg.id)                                    AS item_count,
                   (
                     SELECT t2.name FROM action_task t2
@@ -32,6 +32,11 @@ data class GetProjectListStep(val worldId: Int) : Step<Unit, AppFailure.Database
                 FROM projects p
                 LEFT JOIN action_task t  ON t.project_id  = p.id
                 LEFT JOIN resource_gathering rg ON rg.project_id = p.id
+                -- rgp is 1:1 with rg by (project_id, item_id) (rgp is unique on that pair),
+                -- so this join adds no fan-out and SUM(rgp.collected) matches the old
+                -- SUM(rg.collected) for the normal one-row-per-item case.
+                LEFT JOIN resource_gathering_progress rgp
+                       ON rgp.project_id = rg.project_id AND rgp.item_id = rg.item_id
                 WHERE p.world_id = ?
                 GROUP BY p.id
                 ORDER BY

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStep.kt
@@ -19,16 +19,14 @@ import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
 /**
  * Input bundle for [GenerateGatheringPlanStep].
  *
- * @param projectId the project whose resource_gathering rows are the planning targets.
+ * @param projectId the project whose resource_gathering rows are the planning targets
+ *   and whose persisted [PlanOverrides] (source pins and tag-member choices) are loaded.
  * @param worldId the world that owns the project — used to resolve its Minecraft version,
  *   which drives the cached [ItemSourceGraph].
- * @param resourceGatheringId the resource_gathering record that holds the user's
- *   persisted [PlanOverrides] (source pins and tag-member choices).
  */
 data class GatheringPlanInput(
     val projectId: Int,
     val worldId: Int,
-    val resourceGatheringId: Int
 )
 
 /**
@@ -41,7 +39,7 @@ data class GatheringPlanInput(
  * 4. Build [PlanTarget]s: amount = max(0, required − collected); skip fully-collected rows.
  * 5. Build the [SupplySource] map: rows linked to another project become
  *    [SupplySource.LinkedProject] terminals.
- * 6. Load persisted [PlanOverrides] for the resource gathering record.
+ * 6. Load persisted [PlanOverrides] for the project.
  * 7. Run [GatheringPlanner.plan] and return the result.
  *
  * Fails with:
@@ -102,8 +100,8 @@ object GenerateGatheringPlanStep : Step<GatheringPlanInput, AppFailure, Gatherin
             }
             .toMap()
 
-        // 6. Load persisted overrides
-        val overrides: PlanOverrides = when (val r = GetPlanOverridesStep.process(input.resourceGatheringId)) {
+        // 6. Load persisted overrides for this project
+        val overrides: PlanOverrides = when (val r = GetPlanOverridesStep.process(input.projectId)) {
             is Result.Success -> r.value
             is Result.Failure -> return r
         }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanOverrideSteps.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanOverrideSteps.kt
@@ -8,7 +8,7 @@ import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.failure.AppFailure
 
 /**
- * A single user-pinned planning choice for one item of a resource gathering.
+ * A single user-pinned planning choice for one item of a project.
  * The full plan is never persisted — the engine re-derives it from the graph,
  * the targets, and these overrides.
  */
@@ -22,7 +22,7 @@ sealed interface PlanOverride {
     data class TagMember(override val itemId: String, val memberItemId: String) : PlanOverride
 }
 
-/** Loads all of a resource gathering's overrides as engine-ready [PlanOverrides]. */
+/** Loads all of a project's overrides as engine-ready [PlanOverrides]. */
 object GetPlanOverridesStep : Step<Int, AppFailure.DatabaseError, PlanOverrides> {
 
     private val query = DatabaseSteps.query<Int, PlanOverrides>(
@@ -30,10 +30,10 @@ object GetPlanOverridesStep : Step<Int, AppFailure.DatabaseError, PlanOverrides>
             """
             SELECT item_id, source_key, tag_member
             FROM resource_gathering_plan_override
-            WHERE resource_gathering_id = ?
+            WHERE project_id = ?
             """.trimIndent()
         ),
-        parameterSetter = { ps, resourceGatheringId -> ps.setInt(1, resourceGatheringId) },
+        parameterSetter = { ps, projectId -> ps.setInt(1, projectId) },
         resultMapper = { rs ->
             val sourceByItem = mutableMapOf<String, String>()
             val tagMember = mutableMapOf<String, String>()
@@ -50,18 +50,18 @@ object GetPlanOverridesStep : Step<Int, AppFailure.DatabaseError, PlanOverrides>
         query.process(input)
 }
 
-/** Inserts or replaces the override for one item of a resource gathering. */
+/** Inserts or replaces the override for one item of a project. */
 class UpsertPlanOverrideStep(
-    private val resourceGatheringId: Int
+    private val projectId: Int
 ) : Step<PlanOverride, AppFailure.DatabaseError, Int> {
 
     override suspend fun process(input: PlanOverride): Result<AppFailure.DatabaseError, Int> {
         val step = DatabaseSteps.update<PlanOverride>(
             sql = SafeSQL.insert(
                 """
-                INSERT INTO resource_gathering_plan_override (resource_gathering_id, item_id, source_key, tag_member)
+                INSERT INTO resource_gathering_plan_override (project_id, item_id, source_key, tag_member)
                 VALUES (?, ?, ?, ?)
-                ON CONFLICT (resource_gathering_id, item_id)
+                ON CONFLICT (project_id, item_id)
                 DO UPDATE SET source_key = EXCLUDED.source_key,
                               tag_member = EXCLUDED.tag_member,
                               updated_at = CURRENT_TIMESTAMP
@@ -69,7 +69,7 @@ class UpsertPlanOverrideStep(
                 """.trimIndent()
             ),
             parameterSetter = { ps, override ->
-                ps.setInt(1, resourceGatheringId)
+                ps.setInt(1, projectId)
                 ps.setString(2, override.itemId)
                 when (override) {
                     is PlanOverride.Source -> {
@@ -87,18 +87,18 @@ class UpsertPlanOverrideStep(
     }
 }
 
-/** Removes the override for one item; the planner falls back to scorer defaults. */
+/** Removes the override for one item of a project; the planner falls back to scorer defaults. */
 class ClearPlanOverrideStep(
-    private val resourceGatheringId: Int
+    private val projectId: Int
 ) : Step<String, AppFailure.DatabaseError, Int> {
 
     override suspend fun process(input: String): Result<AppFailure.DatabaseError, Int> {
         val step = DatabaseSteps.update<String>(
             sql = SafeSQL.delete(
-                "DELETE FROM resource_gathering_plan_override WHERE resource_gathering_id = ? AND item_id = ?"
+                "DELETE FROM resource_gathering_plan_override WHERE project_id = ? AND item_id = ?"
             ),
             parameterSetter = { ps, itemId ->
-                ps.setInt(1, resourceGatheringId)
+                ps.setInt(1, projectId)
                 ps.setString(2, itemId)
             }
         )

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/SetCollectedValuePipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/SetCollectedValuePipeline.kt
@@ -2,13 +2,13 @@ package app.mcorg.pipeline.resources
 
 import app.mcorg.pipeline.Result
 import app.mcorg.domain.pipeline.Step
-import app.mcorg.pipeline.DatabaseSteps
-import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.ValidationSteps
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.resources.commonsteps.CountCollectedResourcesInProjectWithItemIdStep
 import app.mcorg.pipeline.resources.commonsteps.CountTotalResourcesRequiredInProjectWithItemIdStep
 import app.mcorg.pipeline.resources.commonsteps.GetResourceGatheringItemStep
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressByRgIdInput
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressStep
 import app.mcorg.presentation.handler.handlePipeline
 import app.mcorg.presentation.hxOutOfBands
 import app.mcorg.presentation.templated.dsl.progressBar
@@ -53,7 +53,7 @@ suspend fun ApplicationCall.handleSetCollectedValue() {
         }
     ) {
         val value = ValidateSetCollectedValueStep.run(parameters)
-        SetCollectedValueStep(resourceGatheringId).run(value)
+        UpsertProgressStep.run(UpsertProgressByRgIdInput(resourceGatheringId, value))
         GetUpdatedCollectedCountsStep.run(resourceGatheringId)
     }
 }
@@ -62,20 +62,6 @@ private object ValidateSetCollectedValueStep : Step<Parameters, AppFailure.Valid
     override suspend fun process(input: Parameters): Result<AppFailure.ValidationError, Int> {
         return ValidationSteps.requiredInt("value") { AppFailure.ValidationError(listOf(it)) }
             .process(input)
-    }
-}
-
-private data class SetCollectedValueStep(val resourceGatheringId: Int) : Step<Int, AppFailure.DatabaseError, Unit> {
-    override suspend fun process(input: Int): Result<AppFailure.DatabaseError, Unit> {
-        return DatabaseSteps.update<Int>(
-            sql = SafeSQL.update(
-                "UPDATE resource_gathering SET collected = LEAST(GREATEST(?, 0), required) WHERE id = ?"
-            ),
-            parameterSetter = { stmt, value ->
-                stmt.setInt(1, value)
-                stmt.setInt(2, resourceGatheringId)
-            }
-        ).process(input).map { }
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/UpdateItemTaskRequirementsPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/UpdateItemTaskRequirementsPipeline.kt
@@ -3,14 +3,14 @@ package app.mcorg.pipeline.resources
 import app.mcorg.domain.model.resources.ResourceGatheringItem
 import app.mcorg.pipeline.Result
 import app.mcorg.domain.pipeline.Step
-import app.mcorg.pipeline.DatabaseSteps
-import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.ValidationSteps
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.failure.ValidationFailure
 import app.mcorg.pipeline.resources.commonsteps.CountCollectedResourcesInProjectWithItemIdStep
 import app.mcorg.pipeline.resources.commonsteps.CountTotalResourcesRequiredInProjectWithItemIdStep
 import app.mcorg.pipeline.resources.commonsteps.GetResourceGatheringItemStep
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressDeltaInput
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressDeltaStep
 import app.mcorg.presentation.handler.handlePipeline
 import app.mcorg.presentation.hxOutOfBands
 import app.mcorg.presentation.templated.dsl.progressBar
@@ -61,7 +61,7 @@ suspend fun ApplicationCall.handleUpdateRequirementProgress() {
         },
     ) {
         val amount = ValidateUpdateItemTaskRequirementsInputStep.run(parameters)
-        UpdateItemTaskRequirement(resourceGatheringId).run(amount)
+        UpsertProgressDeltaStep.run(UpsertProgressDeltaInput(resourceGatheringId, amount))
         GetUpdatedTaskCountsStep.run(resourceGatheringId)
     }
 }
@@ -82,18 +82,6 @@ private object ValidateUpdateItemTaskRequirementsInputStep : Step<Parameters, Ap
             is Result.Success -> Result.success(amount.value)
             is Result.Failure -> Result.failure(AppFailure.ValidationError(listOf(amount.error)))
         }
-    }
-}
-
-private data class UpdateItemTaskRequirement(val taskId: Int) : Step<Int, AppFailure.DatabaseError, Unit> {
-    override suspend fun process(input: Int): Result<AppFailure.DatabaseError, Unit> {
-        return DatabaseSteps.update<Int>(
-            sql = SafeSQL.update("UPDATE resource_gathering SET collected = GREATEST(LEAST(collected + ?, required), 0) WHERE id = ?"),
-            parameterSetter = { statement, amount ->
-                statement.setInt(1, amount)
-                statement.setInt(2, taskId)
-            }
-        ).process(input).map {  }
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/CountCollectedResourcesInProjectWithItemIdStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/CountCollectedResourcesInProjectWithItemIdStep.kt
@@ -4,17 +4,17 @@ import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.SafeSQL
 
 val CountCollectedResourcesInProjectWithItemIdStep = DatabaseSteps.query<Int, Int>(
-    sql = SafeSQL.select("""
-                SELECT SUM(collected) FROM resource_gathering WHERE project_id = (
-                    SELECT project_id FROM resource_gathering WHERE id = ?
-                )
-            """.trimIndent()),
+    sql = SafeSQL.select(
+        """
+        SELECT COALESCE(SUM(rgp.collected), 0)
+        FROM resource_gathering_progress rgp
+        WHERE rgp.project_id = (
+            SELECT project_id FROM resource_gathering WHERE id = ?
+        )
+        """.trimIndent()
+    ),
     parameterSetter = { statement, taskId -> statement.setInt(1, taskId) },
     resultMapper = { rs ->
-        if (rs.next()) {
-            rs.getInt(1)
-        } else {
-            0
-        }
+        if (rs.next()) rs.getInt(1) else 0
     }
 )

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetAllResourceGatheringItemsStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetAllResourceGatheringItemsStep.kt
@@ -8,10 +8,13 @@ import app.mcorg.pipeline.resources.extractors.toResourceGatheringItems
 val GetAllResourceGatheringItemsStep = DatabaseSteps.query<Int, List<ResourceGatheringItem>>(
     sql = SafeSQL.select(
         """
-        SELECT rg.id, rg.project_id, rg.item_id, rg.name, rg.required, rg.collected,
+        SELECT rg.id, rg.project_id, rg.item_id, rg.name, rg.required,
+               COALESCE(rgp.collected, 0) AS collected,
                rg.source_type,
                p.id AS solved_project_id, p.name AS solved_project_name
         FROM resource_gathering rg
+        LEFT JOIN resource_gathering_progress rgp
+               ON rgp.project_id = rg.project_id AND rgp.item_id = rg.item_id
         LEFT JOIN projects p ON p.id = rg.solved_by_project_id
         WHERE rg.project_id = ?
         ORDER BY rg.required

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetProgressForProjectStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetProgressForProjectStep.kt
@@ -1,0 +1,22 @@
+package app.mcorg.pipeline.resources.commonsteps
+
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.SafeSQL
+
+/**
+ * Loads all collected-progress rows for a project as a map of itemId -> collected count.
+ * Items with no progress row are absent from the map (callers should COALESCE to 0).
+ */
+val GetProgressForProjectStep = DatabaseSteps.query<Int, Map<String, Int>>(
+    sql = SafeSQL.select(
+        "SELECT item_id, collected FROM resource_gathering_progress WHERE project_id = ?"
+    ),
+    parameterSetter = { stmt, projectId -> stmt.setInt(1, projectId) },
+    resultMapper = { rs ->
+        buildMap {
+            while (rs.next()) {
+                put(rs.getString("item_id"), rs.getInt("collected"))
+            }
+        }
+    }
+)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetResourceGatheringItemStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetResourceGatheringItemStep.kt
@@ -8,10 +8,13 @@ import app.mcorg.pipeline.resources.extractors.toResourceGatheringItem
 val GetResourceGatheringItemStep = DatabaseSteps.query<Int, ResourceGatheringItem>(
     sql = SafeSQL.select(
         """
-        SELECT rg.id, rg.project_id, rg.item_id, rg.name, rg.required, rg.collected,
+        SELECT rg.id, rg.project_id, rg.item_id, rg.name, rg.required,
+               COALESCE(rgp.collected, 0) AS collected,
                rg.source_type,
                p.id AS solved_project_id, p.name AS solved_project_name
         FROM resource_gathering rg
+        LEFT JOIN resource_gathering_progress rgp
+               ON rgp.project_id = rg.project_id AND rgp.item_id = rg.item_id
         LEFT JOIN projects p ON p.id = rg.solved_by_project_id
         WHERE rg.id = ?
         """.trimIndent()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/UpsertProgressDeltaStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/UpsertProgressDeltaStep.kt
@@ -1,0 +1,66 @@
+package app.mcorg.pipeline.resources.commonsteps
+
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+
+/**
+ * Input for incrementing or decrementing progress by a delta, identified by
+ * a resource_gathering row id.
+ *
+ * @param resourceGatheringId identifies the (project_id, item_id) pair and
+ *   the required ceiling for clamping.
+ * @param delta positive to increment, negative to decrement.
+ */
+data class UpsertProgressDeltaInput(
+    val resourceGatheringId: Int,
+    val delta: Int,
+)
+
+/**
+ * Applies a delta (positive or negative) to the progress entry identified by
+ * a resource_gathering row id. The result is clamped to [0, required].
+ *
+ * If no progress row exists yet the delta is applied from a base of 0.
+ * Matches the behaviour of the old
+ * `UPDATE resource_gathering SET collected = GREATEST(LEAST(collected + ?, required), 0)`.
+ */
+object UpsertProgressDeltaStep : Step<UpsertProgressDeltaInput, AppFailure.DatabaseError, Unit> {
+
+    override suspend fun process(input: UpsertProgressDeltaInput): Result<AppFailure.DatabaseError, Unit> {
+        return DatabaseSteps.update<UpsertProgressDeltaInput>(
+            sql = SafeSQL.with(
+                """
+                WITH rg AS (
+                    SELECT project_id, item_id, required
+                    FROM resource_gathering
+                    WHERE id = ?
+                )
+                INSERT INTO resource_gathering_progress (project_id, item_id, collected, updated_at)
+                -- First write: base is 0, so clamp(delta) is exactly clamp(0 + delta).
+                SELECT rg.project_id,
+                       rg.item_id,
+                       GREATEST(LEAST(?, rg.required), 0),
+                       CURRENT_TIMESTAMP
+                FROM rg
+                ON CONFLICT (project_id, item_id) DO UPDATE
+                    SET collected  = GREATEST(
+                            LEAST(resource_gathering_progress.collected + ?, (
+                                SELECT required FROM resource_gathering WHERE id = ?
+                            )),
+                            0
+                        ),
+                        updated_at = CURRENT_TIMESTAMP
+                """.trimIndent()
+            ),
+            parameterSetter = { stmt, inp ->
+                stmt.setInt(1, inp.resourceGatheringId)  // CTE lookup
+                stmt.setInt(2, inp.delta)                // INSERT base: clamp(delta, required)
+                stmt.setInt(3, inp.delta)                // UPDATE: existing + delta
+                stmt.setInt(4, inp.resourceGatheringId)  // UPDATE: required ceiling
+            }
+        ).process(input).map { }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/UpsertProgressStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/UpsertProgressStep.kt
@@ -1,0 +1,54 @@
+package app.mcorg.pipeline.resources.commonsteps
+
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+
+/**
+ * Input for upserting a progress entry via a resource_gathering row id.
+ *
+ * @param resourceGatheringId the resource_gathering.id that identifies both
+ *   the (project_id, item_id) pair and the required ceiling for clamping.
+ * @param value the raw collected value requested by the user (will be clamped
+ *   to [0, required] by the SQL expression, matching the old behaviour).
+ */
+data class UpsertProgressByRgIdInput(
+    val resourceGatheringId: Int,
+    val value: Int,
+)
+
+/**
+ * Upserts the collected progress for a (project_id, item_id) pair identified
+ * by a resource_gathering row id.
+ *
+ * The collected value is clamped to [0, required] so callers do not need to
+ * validate the range. Matches the behaviour of the old
+ * `UPDATE resource_gathering SET collected = LEAST(GREATEST(?,0),required)`.
+ */
+object UpsertProgressStep : Step<UpsertProgressByRgIdInput, AppFailure.DatabaseError, Unit> {
+
+    override suspend fun process(input: UpsertProgressByRgIdInput): Result<AppFailure.DatabaseError, Unit> {
+        return DatabaseSteps.update<UpsertProgressByRgIdInput>(
+            sql = SafeSQL.insert(
+                """
+                INSERT INTO resource_gathering_progress (project_id, item_id, collected, updated_at)
+                SELECT rg.project_id,
+                       rg.item_id,
+                       LEAST(GREATEST(?, 0), rg.required),
+                       CURRENT_TIMESTAMP
+                FROM resource_gathering rg
+                WHERE rg.id = ?
+                ON CONFLICT (project_id, item_id) DO UPDATE
+                    SET collected  = EXCLUDED.collected,
+                        updated_at = EXCLUDED.updated_at
+                """.trimIndent()
+            ),
+            parameterSetter = { stmt, inp ->
+                stmt.setInt(1, inp.value)
+                stmt.setInt(2, inp.resourceGatheringId)
+            }
+        ).process(input).map { }
+    }
+}

--- a/webapp/mc-web/src/main/resources/db/migration/V2_41_0__rescope_plan_overrides_to_project.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_41_0__rescope_plan_overrides_to_project.sql
@@ -1,0 +1,45 @@
+-- Re-scope resource_gathering_plan_override from per-gathering to per-project.
+-- The engine re-derives plans from graph + targets + overrides; overrides are
+-- user-pinned item choices that are project-scoped, not gathering-scoped.
+
+-- 1. Add project_id column (nullable first for backfill)
+ALTER TABLE resource_gathering_plan_override
+    ADD COLUMN project_id INTEGER REFERENCES projects(id) ON DELETE CASCADE;
+
+-- 2. Backfill project_id from resource_gathering via resource_gathering_id
+UPDATE resource_gathering_plan_override rgpo
+SET project_id = rg.project_id
+FROM resource_gathering rg
+WHERE rg.id = rgpo.resource_gathering_id;
+
+-- 3. Defensively dedupe: keep the most-recently-updated row per (project_id, item_id);
+--    remove earlier duplicates before adding the unique constraint.
+DELETE FROM resource_gathering_plan_override
+WHERE id NOT IN (
+    SELECT DISTINCT ON (project_id, item_id) id
+    FROM resource_gathering_plan_override
+    ORDER BY project_id, item_id, updated_at DESC, id DESC
+);
+
+-- 4. Drop old unique constraint, old index, and the resource_gathering_id column
+ALTER TABLE resource_gathering_plan_override
+    DROP CONSTRAINT unique_override_per_item;
+DROP INDEX idx_rgpo_gathering_id;
+ALTER TABLE resource_gathering_plan_override
+    DROP COLUMN resource_gathering_id;
+
+-- 5. Make project_id NOT NULL now that it is backfilled
+ALTER TABLE resource_gathering_plan_override
+    ALTER COLUMN project_id SET NOT NULL;
+
+-- 6. Add new unique constraint and index
+ALTER TABLE resource_gathering_plan_override
+    ADD CONSTRAINT unique_override_per_project_item UNIQUE (project_id, item_id);
+CREATE INDEX idx_rgpo_project_id ON resource_gathering_plan_override(project_id);
+
+-- 7. Update comments
+COMMENT ON TABLE resource_gathering_plan_override IS 'User-pinned planning choices per project item; plans are re-derived from these by the engine';
+COMMENT ON COLUMN resource_gathering_plan_override.project_id IS 'Project that owns this override';
+COMMENT ON COLUMN resource_gathering_plan_override.item_id IS 'Minecraft item or tag id the override applies to';
+COMMENT ON COLUMN resource_gathering_plan_override.source_key IS 'Pinned SourceNode key (type id + filename) for the item';
+COMMENT ON COLUMN resource_gathering_plan_override.tag_member IS 'Chosen member item id when item_id is a tag';

--- a/webapp/mc-web/src/main/resources/db/migration/V2_42_0__create_resource_gathering_progress.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_42_0__create_resource_gathering_progress.sql
@@ -1,0 +1,35 @@
+-- Per-node progress table: tracks how many of each item the user has collected
+-- for a project, decoupled from the resource_gathering rows.
+-- This is the foundation for per-node progress in the gathering planner (MCO-221).
+
+CREATE TABLE resource_gathering_progress (
+    id         SERIAL PRIMARY KEY,
+    project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    item_id    VARCHAR NOT NULL,
+    collected  INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT unique_progress_per_project_item UNIQUE (project_id, item_id)
+);
+
+CREATE INDEX idx_rgp_project_id ON resource_gathering_progress(project_id);
+
+COMMENT ON TABLE resource_gathering_progress IS 'Per-item collected progress for a project; keyed by (project_id, item_id)';
+COMMENT ON COLUMN resource_gathering_progress.project_id IS 'Project that owns this progress entry';
+COMMENT ON COLUMN resource_gathering_progress.item_id IS 'Minecraft item id this progress tracks';
+COMMENT ON COLUMN resource_gathering_progress.collected IS 'Number of this item collected so far';
+
+-- Backfill from resource_gathering.collected.
+-- If duplicate (project_id, item_id) rows exist in resource_gathering
+-- (which should not happen in practice given the unique item_id constraint),
+-- SUM the collected values to avoid losing data.
+INSERT INTO resource_gathering_progress (project_id, item_id, collected)
+SELECT project_id, item_id, SUM(collected)
+FROM resource_gathering
+WHERE collected > 0
+GROUP BY project_id, item_id
+ON CONFLICT (project_id, item_id) DO UPDATE
+    SET collected = EXCLUDED.collected;
+
+-- Drop collected column from resource_gathering; progress is now in the progress table
+ALTER TABLE resource_gathering DROP COLUMN collected;

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStepTest.kt
@@ -12,6 +12,8 @@ import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.minecraft.StoreMinecraftDataStep
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressByRgIdInput
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressStep
 import app.mcorg.pipeline.world.CreateWorldInput
 import app.mcorg.pipeline.world.CreateWorldStep
 import app.mcorg.test.WithUser
@@ -91,12 +93,11 @@ class GenerateGatheringPlanStepTest : WithUser() {
     @Test
     fun `success path - targets build from rows and engine returns a plan`() {
         val projectId = createProject(worldId)
-        val rgId = createResourceGathering(projectId)
-        insertGatheringItem(projectId, chest.id, chest.name, required = 4, collected = 0)
+        insertGatheringItem(projectId, chest.id, chest.name, required = 4)
 
         val result = runBlocking {
             GenerateGatheringPlanStep.process(
-                GatheringPlanInput(projectId, worldId, rgId)
+                GatheringPlanInput(projectId, worldId)
             )
         }
 
@@ -120,11 +121,10 @@ class GenerateGatheringPlanStepTest : WithUser() {
     @Test
     fun `failure - world not found returns NotFound`() {
         val projectId = createProject(worldId)
-        val rgId = createResourceGathering(projectId)
 
         val result = runBlocking {
             GenerateGatheringPlanStep.process(
-                GatheringPlanInput(projectId, worldId = Int.MAX_VALUE, resourceGatheringId = rgId)
+                GatheringPlanInput(projectId, worldId = Int.MAX_VALUE)
             )
         }
 
@@ -145,12 +145,11 @@ class GenerateGatheringPlanStepTest : WithUser() {
         val uningestedVersion = MinecraftVersion.fromString("0.0.1")
         val uningestedWorldId = createWorld(uningestedVersion)
         val projectId = createProject(uningestedWorldId)
-        val rgId = createResourceGathering(projectId)
-        insertGatheringItem(projectId, chest.id, chest.name, required = 1, collected = 0)
+        insertGatheringItem(projectId, chest.id, chest.name, required = 1)
 
         val result = runBlocking {
             GenerateGatheringPlanStep.process(
-                GatheringPlanInput(projectId, uningestedWorldId, rgId)
+                GatheringPlanInput(projectId, uningestedWorldId)
             )
         }
 
@@ -168,13 +167,13 @@ class GenerateGatheringPlanStepTest : WithUser() {
     @Test
     fun `failure - all items fully collected returns ValidationError`() {
         val projectId = createProject(worldId)
-        val rgId = createResourceGathering(projectId)
-        // required == collected → net = 0 → no targets
-        insertGatheringItem(projectId, chest.id, chest.name, required = 4, collected = 4)
+        // Insert the item, then record progress = required (fully collected)
+        val rgId = insertGatheringItem(projectId, chest.id, chest.name, required = 4)
+        setProgress(rgId, 4)
 
         val result = runBlocking {
             GenerateGatheringPlanStep.process(
-                GatheringPlanInput(projectId, worldId, rgId)
+                GatheringPlanInput(projectId, worldId)
             )
         }
 
@@ -193,20 +192,19 @@ class GenerateGatheringPlanStepTest : WithUser() {
     fun `linked project item becomes SUPPLIED terminal in plan`() {
         val producerProjectId = createProject(worldId)
         val consumerProjectId = createProject(worldId)
-        val rgId = createResourceGathering(consumerProjectId)
 
         // chest is the main target (needs planning)
-        insertGatheringItem(consumerProjectId, chest.id, chest.name, required = 2, collected = 0)
+        insertGatheringItem(consumerProjectId, chest.id, chest.name, required = 2)
         // oak_planks is sourced from producerProjectId
         val rgItemId = insertGatheringItem(
-            consumerProjectId, oakPlanks.id, oakPlanks.name, required = 10, collected = 0
+            consumerProjectId, oakPlanks.id, oakPlanks.name, required = 10
         )
         // Mark oak_planks as supplied by the producer project
         linkResourceToProject(rgItemId, producerProjectId)
 
         val result = runBlocking {
             GenerateGatheringPlanStep.process(
-                GatheringPlanInput(consumerProjectId, worldId, rgId)
+                GatheringPlanInput(consumerProjectId, worldId)
             )
         }
 
@@ -243,38 +241,32 @@ class GenerateGatheringPlanStepTest : WithUser() {
         (result as Result.Success).value
     }
 
-    private fun createResourceGathering(projectId: Int): Int = runBlocking {
-        val result = DatabaseSteps.update<Unit>(
-            sql = SafeSQL.insert(
-                "INSERT INTO resource_gathering (project_id, item_id, name, required, collected) " +
-                    "VALUES (?, 'minecraft:placeholder', 'Placeholder', 1, 1) RETURNING id"
-            ),
-            parameterSetter = { stmt, _ -> stmt.setInt(1, projectId) }
-        ).process(Unit)
-        (result as Result.Success).value
-    }
-
     private fun insertGatheringItem(
         projectId: Int,
         itemId: String,
         name: String,
         required: Int,
-        collected: Int
     ): Int = runBlocking {
         val result = DatabaseSteps.update<Unit>(
             sql = SafeSQL.insert(
-                "INSERT INTO resource_gathering (project_id, item_id, name, required, collected) " +
-                    "VALUES (?, ?, ?, ?, ?) RETURNING id"
+                "INSERT INTO resource_gathering (project_id, item_id, name, required) " +
+                    "VALUES (?, ?, ?, ?) RETURNING id"
             ),
             parameterSetter = { stmt, _ ->
                 stmt.setInt(1, projectId)
                 stmt.setString(2, itemId)
                 stmt.setString(3, name)
                 stmt.setInt(4, required)
-                stmt.setInt(5, collected)
             }
         ).process(Unit)
         (result as Result.Success).value
+    }
+
+    /** Records collected progress for a resource_gathering row via the progress table. */
+    private fun setProgress(resourceGatheringId: Int, collected: Int) {
+        runBlocking {
+            UpsertProgressStep.process(UpsertProgressByRgIdInput(resourceGatheringId, collected))
+        }
     }
 
     private fun linkResourceToProject(resourceGatheringId: Int, solvedByProjectId: Int) {

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/PlanOverrideStepsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/PlanOverrideStepsTest.kt
@@ -29,33 +29,32 @@ import kotlin.test.assertIs
 @ExtendWith(DatabaseTestExtension::class)
 class PlanOverrideStepsTest : WithUser() {
 
-    private var resourceGatheringId: Int = 0
+    private var projectId: Int = 0
 
     @BeforeAll
     fun setup() {
         val worldId = createWorld()
-        val projectId = createProject(worldId)
-        resourceGatheringId = createResourceGathering(projectId)
+        projectId = createProject(worldId)
     }
 
     @Test
     fun `overrides round-trip into engine-ready PlanOverrides`() {
-        val rgId = createResourceGathering(createProject(createWorld()))
+        val pid = createProject(createWorld())
 
         runBlocking {
             assertIs<Result.Success<*>>(
-                UpsertPlanOverrideStep(rgId).process(
+                UpsertPlanOverrideStep(pid).process(
                     PlanOverride.Source("minecraft:oak_planks", "minecraft:chest:chests/bonus_chest.json")
                 )
             )
             assertIs<Result.Success<*>>(
-                UpsertPlanOverrideStep(rgId).process(
+                UpsertPlanOverrideStep(pid).process(
                     PlanOverride.TagMember("#minecraft:planks", "minecraft:oak_planks")
                 )
             )
         }
 
-        val loaded = runBlocking { GetPlanOverridesStep.process(rgId) }
+        val loaded = runBlocking { GetPlanOverridesStep.process(pid) }
         assertIs<Result.Success<PlanOverrides>>(loaded)
         assertEquals(
             PlanOverrides(
@@ -69,34 +68,34 @@ class PlanOverrideStepsTest : WithUser() {
     @Test
     fun `upserting the same item replaces the previous choice`() {
         runBlocking {
-            UpsertPlanOverrideStep(resourceGatheringId)
+            UpsertPlanOverrideStep(projectId)
                 .process(PlanOverride.Source("minecraft:stick", "minecraft:entity:entities/witch.json"))
-            UpsertPlanOverrideStep(resourceGatheringId)
+            UpsertPlanOverrideStep(projectId)
                 .process(PlanOverride.Source("minecraft:stick", "minecraft:crafting_shaped:stick.json"))
         }
 
-        val loaded = runBlocking { GetPlanOverridesStep.process(resourceGatheringId) }
+        val loaded = runBlocking { GetPlanOverridesStep.process(projectId) }
         assertIs<Result.Success<PlanOverrides>>(loaded)
         assertEquals("minecraft:crafting_shaped:stick.json", loaded.value.sourceByItem["minecraft:stick"])
     }
 
     @Test
     fun `clearing an override removes it`() {
-        val rgId = createResourceGathering(createProject(createWorld()))
+        val pid = createProject(createWorld())
         runBlocking {
-            UpsertPlanOverrideStep(rgId)
+            UpsertPlanOverrideStep(pid)
                 .process(PlanOverride.Source("minecraft:glass", "minecraft:smelting:glass.json"))
-            ClearPlanOverrideStep(rgId).process("minecraft:glass")
+            ClearPlanOverrideStep(pid).process("minecraft:glass")
         }
 
-        val loaded = runBlocking { GetPlanOverridesStep.process(rgId) }
+        val loaded = runBlocking { GetPlanOverridesStep.process(pid) }
         assertIs<Result.Success<PlanOverrides>>(loaded)
         assertEquals(PlanOverrides.NONE, loaded.value)
     }
 
     @Test
     fun `a saved selection re-derives the identical plan`() {
-        val rgId = createResourceGathering(createProject(createWorld()))
+        val pid = createProject(createWorld())
         val graph = woodGraph()
         val targets = listOf(PlanTarget(Item("minecraft:chest", "Chest"), 4))
         val pinned = PlanOverrides(
@@ -110,11 +109,11 @@ class PlanOverrideStepsTest : WithUser() {
         )
 
         runBlocking {
-            UpsertPlanOverrideStep(rgId).process(
+            UpsertPlanOverrideStep(pid).process(
                 PlanOverride.Source("minecraft:oak_planks", "minecraft:chest:chests/bonus_chest.json")
             )
         }
-        val loaded = runBlocking { GetPlanOverridesStep.process(rgId) }
+        val loaded = runBlocking { GetPlanOverridesStep.process(pid) }
         assertIs<Result.Success<PlanOverrides>>(loaded)
 
         val rederived = GatheringPlanner.plan(graph, targets, overrides = loaded.value)
@@ -163,17 +162,6 @@ class PlanOverrideStepsTest : WithUser() {
                     "VALUES ('PlanOverride Project', ?, '', 'BUILDING', 'PLANNING', 0, 0, 0, 'OVERWORLD') RETURNING id"
             ),
             parameterSetter = { stmt, _ -> stmt.setInt(1, worldId) }
-        ).process(Unit)
-        (result as Result.Success).value
-    }
-
-    private fun createResourceGathering(projectId: Int): Int = runBlocking {
-        val result = DatabaseSteps.update<Unit>(
-            sql = SafeSQL.insert(
-                "INSERT INTO resource_gathering (project_id, item_id, name, required, collected) " +
-                    "VALUES (?, 'minecraft:chest', 'Chest', 4, 0) RETURNING id"
-            ),
-            parameterSetter = { stmt, _ -> stmt.setInt(1, projectId) }
         ).process(Unit)
         (result as Result.Success).value
     }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/ProgressStepsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/ProgressStepsTest.kt
@@ -1,0 +1,275 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
+import app.mcorg.pipeline.resources.commonsteps.GetProgressForProjectStep
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressByRgIdInput
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressDeltaInput
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressDeltaStep
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressStep
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Integration tests for progress persistence steps:
+ * - [UpsertProgressStep]: set absolute value, clamping, upsert idempotency
+ * - [UpsertProgressDeltaStep]: increment, decrement, clamping
+ * - [GetProgressForProjectStep]: load all progress for a project
+ * - Round-trip: progress is reflected via GetAllResourceGatheringItemsStep
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class ProgressStepsTest : WithUser() {
+
+    private var worldId: Int = 0
+    private var projectId: Int = 0
+
+    @BeforeAll
+    fun setup() {
+        worldId = createWorld()
+        projectId = createProject(worldId)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // UpsertProgressStep — absolute value
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `UpsertProgressStep - sets collected and is readable via GetProgressForProjectStep`() {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:iron_ingot", required = 64)
+
+        val upsert = runBlocking {
+            UpsertProgressStep.process(UpsertProgressByRgIdInput(rgId, 32))
+        }
+        assertIs<Result.Success<Unit>>(upsert)
+
+        val progress = runBlocking { GetProgressForProjectStep.process(pid) }
+        assertIs<Result.Success<Map<String, Int>>>(progress)
+        assertEquals(32, progress.value["minecraft:iron_ingot"])
+    }
+
+    @Test
+    fun `UpsertProgressStep - clamps value above required`() {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:gold_ingot", required = 10)
+
+        runBlocking { UpsertProgressStep.process(UpsertProgressByRgIdInput(rgId, 999)) }
+
+        val progress = runBlocking { GetProgressForProjectStep.process(pid) }
+        assertIs<Result.Success<Map<String, Int>>>(progress)
+        assertEquals(10, progress.value["minecraft:gold_ingot"], "should be clamped to required=10")
+    }
+
+    @Test
+    fun `UpsertProgressStep - clamps negative value to 0`() {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:diamond", required = 10)
+
+        runBlocking { UpsertProgressStep.process(UpsertProgressByRgIdInput(rgId, -5)) }
+
+        val progress = runBlocking { GetProgressForProjectStep.process(pid) }
+        assertIs<Result.Success<Map<String, Int>>>(progress)
+        assertEquals(0, progress.value.getOrDefault("minecraft:diamond", 0))
+    }
+
+    @Test
+    fun `UpsertProgressStep - second call replaces first`() {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:emerald", required = 20)
+
+        runBlocking {
+            UpsertProgressStep.process(UpsertProgressByRgIdInput(rgId, 5))
+            UpsertProgressStep.process(UpsertProgressByRgIdInput(rgId, 15))
+        }
+
+        val progress = runBlocking { GetProgressForProjectStep.process(pid) }
+        assertIs<Result.Success<Map<String, Int>>>(progress)
+        assertEquals(15, progress.value["minecraft:emerald"], "second upsert should overwrite first")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // UpsertProgressDeltaStep — delta
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `UpsertProgressDeltaStep - increments from zero`() {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:oak_log", required = 64)
+
+        runBlocking { UpsertProgressDeltaStep.process(UpsertProgressDeltaInput(rgId, 10)) }
+
+        val progress = runBlocking { GetProgressForProjectStep.process(pid) }
+        assertIs<Result.Success<Map<String, Int>>>(progress)
+        assertEquals(10, progress.value["minecraft:oak_log"])
+    }
+
+    @Test
+    fun `UpsertProgressDeltaStep - accumulates multiple increments`() {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:stone", required = 100)
+
+        runBlocking {
+            UpsertProgressDeltaStep.process(UpsertProgressDeltaInput(rgId, 30))
+            UpsertProgressDeltaStep.process(UpsertProgressDeltaInput(rgId, 25))
+        }
+
+        val progress = runBlocking { GetProgressForProjectStep.process(pid) }
+        assertIs<Result.Success<Map<String, Int>>>(progress)
+        assertEquals(55, progress.value["minecraft:stone"])
+    }
+
+    @Test
+    fun `UpsertProgressDeltaStep - decrement clamps to 0`() {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:gravel", required = 50)
+
+        runBlocking {
+            UpsertProgressStep.process(UpsertProgressByRgIdInput(rgId, 5))
+            UpsertProgressDeltaStep.process(UpsertProgressDeltaInput(rgId, -100))
+        }
+
+        val progress = runBlocking { GetProgressForProjectStep.process(pid) }
+        assertIs<Result.Success<Map<String, Int>>>(progress)
+        assertEquals(0, progress.value.getOrDefault("minecraft:gravel", 0))
+    }
+
+    @Test
+    fun `UpsertProgressDeltaStep - increment clamps to required`() {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:cobblestone", required = 20)
+
+        runBlocking {
+            UpsertProgressStep.process(UpsertProgressByRgIdInput(rgId, 18))
+            UpsertProgressDeltaStep.process(UpsertProgressDeltaInput(rgId, 10))
+        }
+
+        val progress = runBlocking { GetProgressForProjectStep.process(pid) }
+        assertIs<Result.Success<Map<String, Int>>>(progress)
+        assertEquals(20, progress.value["minecraft:cobblestone"], "should be clamped to required=20")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // GetProgressForProjectStep
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `GetProgressForProjectStep - returns empty map when no progress exists`() {
+        val pid = createProject(worldId)
+
+        val progress = runBlocking { GetProgressForProjectStep.process(pid) }
+        assertIs<Result.Success<Map<String, Int>>>(progress)
+        assertTrue(progress.value.isEmpty(), "new project should have no progress rows")
+    }
+
+    @Test
+    fun `GetProgressForProjectStep - only returns progress for the requested project`() {
+        val pid1 = createProject(worldId)
+        val pid2 = createProject(worldId)
+        val rg1 = createResourceGathering(pid1, "minecraft:sand", required = 10)
+        val rg2 = createResourceGathering(pid2, "minecraft:gravel", required = 10)
+
+        runBlocking {
+            UpsertProgressStep.process(UpsertProgressByRgIdInput(rg1, 3))
+            UpsertProgressStep.process(UpsertProgressByRgIdInput(rg2, 7))
+        }
+
+        val progress1 = runBlocking { GetProgressForProjectStep.process(pid1) }
+        assertIs<Result.Success<Map<String, Int>>>(progress1)
+        assertEquals(setOf("minecraft:sand"), progress1.value.keys)
+
+        val progress2 = runBlocking { GetProgressForProjectStep.process(pid2) }
+        assertIs<Result.Success<Map<String, Int>>>(progress2)
+        assertEquals(setOf("minecraft:gravel"), progress2.value.keys)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Round-trip — progress surfaces on the resource item read
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `progress is reflected as collected via GetAllResourceGatheringItemsStep`() {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:copper_ingot", required = 64)
+
+        runBlocking { UpsertProgressStep.process(UpsertProgressByRgIdInput(rgId, 40)) }
+
+        val items = runBlocking { GetAllResourceGatheringItemsStep.process(pid) }
+        assertIs<Result.Success<*>>(items)
+        val item = (items.value as List<*>)
+            .map { it as app.mcorg.domain.model.resources.ResourceGatheringItem }
+            .single { it.itemId == "minecraft:copper_ingot" }
+        assertEquals(40, item.collected, "collected should read through the progress table join")
+        assertEquals(64, item.required)
+    }
+
+    @Test
+    fun `item with no progress row reads collected as 0`() {
+        val pid = createProject(worldId)
+        createResourceGathering(pid, "minecraft:redstone", required = 32)
+
+        val items = runBlocking { GetAllResourceGatheringItemsStep.process(pid) }
+        assertIs<Result.Success<*>>(items)
+        val item = (items.value as List<*>)
+            .map { it as app.mcorg.domain.model.resources.ResourceGatheringItem }
+            .single { it.itemId == "minecraft:redstone" }
+        assertEquals(0, item.collected, "absent progress row should COALESCE to 0")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Fixture helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private fun createWorld(): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(
+                name = "ProgressSteps IT World",
+                description = "test",
+                version = MinecraftVersion.fromString("1.21.4"),
+            )
+        )
+        (result as Result.Success).value
+    }
+
+    private fun createProject(worldId: Int): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, location_x, location_y, location_z, location_dimension) " +
+                    "VALUES ('ProgressSteps Project', ?, '', 'BUILDING', 'PLANNING', 0, 0, 0, 'OVERWORLD') RETURNING id"
+            ),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, worldId) }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun createResourceGathering(projectId: Int, itemId: String, required: Int): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO resource_gathering (project_id, item_id, name, required) " +
+                    "VALUES (?, ?, ?, ?) RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+                stmt.setString(3, itemId.substringAfterLast(":"))
+                stmt.setInt(4, required)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/ResourceSourceStepsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/ResourceSourceStepsTest.kt
@@ -116,8 +116,8 @@ class ResourceSourceStepsTest : WithUser() {
     private fun createResourceGathering(projectId: Int): Int = runBlocking {
         val result = DatabaseSteps.update<Unit>(
             sql = SafeSQL.insert(
-                "INSERT INTO resource_gathering (project_id, item_id, name, required, collected) " +
-                        "VALUES (?, 'minecraft:iron_ingot', 'Iron Ingot', 10, 0) RETURNING id"
+                "INSERT INTO resource_gathering (project_id, item_id, name, required) " +
+                        "VALUES (?, 'minecraft:iron_ingot', 'Iron Ingot', 10) RETURNING id"
             ),
             parameterSetter = { stmt, _ -> stmt.setInt(1, projectId) }
         ).process(Unit)

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FieldLogSliceIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FieldLogSliceIT.kt
@@ -171,8 +171,8 @@ class FieldLogSliceIT : WithUser() {
     private fun createResourceGathering(projectId: Int, itemName: String, solvedByProjectId: Int? = null): Int = runBlocking {
         val result = DatabaseSteps.update<Unit>(
             sql = SafeSQL.insert(
-                "INSERT INTO resource_gathering (project_id, item_id, name, required, collected, solved_by_project_id) " +
-                        "VALUES (?, 'minecraft:test_item', ?, 64, 8, ?) RETURNING id"
+                "INSERT INTO resource_gathering (project_id, item_id, name, required, solved_by_project_id) " +
+                        "VALUES (?, 'minecraft:test_item', ?, 64, ?) RETURNING id"
             ),
             parameterSetter = { stmt, _ ->
                 stmt.setInt(1, projectId)

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/GetProjectListIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/GetProjectListIT.kt
@@ -329,8 +329,8 @@ class GetProjectListIT : WithUser() {
     private fun createResourceGathering(projectId: Int, itemName: String, solvedByProjectId: Int? = null): Int = runBlocking {
         val result = DatabaseSteps.update<Unit>(
             sql = SafeSQL.insert(
-                "INSERT INTO resource_gathering (project_id, item_id, name, required, collected, solved_by_project_id) " +
-                        "VALUES (?, 'minecraft:sticky_piston', ?, 64, 0, ?) RETURNING id"
+                "INSERT INTO resource_gathering (project_id, item_id, name, required, solved_by_project_id) " +
+                        "VALUES (?, 'minecraft:sticky_piston', ?, 64, ?) RETURNING id"
             ),
             parameterSetter = { stmt, _ ->
                 stmt.setInt(1, projectId)

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanViewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanViewIT.kt
@@ -203,8 +203,8 @@ class PlanViewIT : WithUser() {
     private fun createResourceGathering(projectId: Int, required: Int): Int = runBlocking {
         val result = DatabaseSteps.update<Unit>(
             sql = SafeSQL.insert(
-                "INSERT INTO resource_gathering (project_id, item_id, name, required, collected) " +
-                        "VALUES (?, 'minecraft:iron_ingot', 'Iron Ingot', ?, 0) RETURNING id"
+                "INSERT INTO resource_gathering (project_id, item_id, name, required) " +
+                        "VALUES (?, 'minecraft:iron_ingot', 'Iron Ingot', ?) RETURNING id"
             ),
             parameterSetter = { stmt, _ ->
                 stmt.setInt(1, projectId)

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ProjectDetailIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ProjectDetailIT.kt
@@ -6,6 +6,8 @@ import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.project.handleGetDetailContent
 import app.mcorg.pipeline.project.handleGetProject
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressByRgIdInput
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressStep
 import app.mcorg.pipeline.resources.handleSetCollectedValue
 import app.mcorg.pipeline.resources.handleUpdateRequirementProgress
 import app.mcorg.pipeline.task.handleCompleteActionTask
@@ -56,7 +58,8 @@ class ProjectDetailIT : WithUser() {
     fun setup() {
         worldId = createWorld()
         projectId = createProject(worldId)
-        resourceGatheringId = createResourceGathering(projectId, required = 10, collected = 2)
+        resourceGatheringId = createResourceGathering(projectId, required = 10)
+        seedProgress(resourceGatheringId, collected = 2)
         taskId = createTask(projectId, "Test Task")
     }
 
@@ -285,19 +288,22 @@ class ProjectDetailIT : WithUser() {
         (result as Result.Success).value
     }
 
-    private fun createResourceGathering(projectId: Int, required: Int, collected: Int): Int = runBlocking {
+    private fun createResourceGathering(projectId: Int, required: Int): Int = runBlocking {
         val result = DatabaseSteps.update<Unit>(
             sql = SafeSQL.insert(
-                "INSERT INTO resource_gathering (project_id, item_id, name, required, collected) " +
-                        "VALUES (?, 'minecraft:iron_ingot', 'Iron Ingot', ?, ?) RETURNING id"
+                "INSERT INTO resource_gathering (project_id, item_id, name, required) " +
+                        "VALUES (?, 'minecraft:iron_ingot', 'Iron Ingot', ?) RETURNING id"
             ),
             parameterSetter = { stmt, _ ->
                 stmt.setInt(1, projectId)
                 stmt.setInt(2, required)
-                stmt.setInt(3, collected)
             }
         ).process(Unit)
         (result as Result.Success).value
+    }
+
+    private fun seedProgress(resourceGatheringId: Int, collected: Int) = runBlocking {
+        UpsertProgressStep.process(UpsertProgressByRgIdInput(resourceGatheringId, collected))
     }
 
     private fun createTask(projectId: Int, name: String): Int = runBlocking {
@@ -331,9 +337,17 @@ class ProjectDetailIT : WithUser() {
 
     private fun getCollected(id: Int): Int = runBlocking {
         DatabaseSteps.query<Int, Int>(
-            sql = SafeSQL.select("SELECT collected FROM resource_gathering WHERE id = ?"),
+            sql = SafeSQL.select(
+                """
+                SELECT COALESCE(rgp.collected, 0)
+                FROM resource_gathering rg
+                LEFT JOIN resource_gathering_progress rgp
+                       ON rgp.project_id = rg.project_id AND rgp.item_id = rg.item_id
+                WHERE rg.id = ?
+                """.trimIndent()
+            ),
             parameterSetter = { stmt, inp -> stmt.setInt(1, inp) },
-            resultMapper = { rs -> if (rs.next()) rs.getInt("collected") else 0 }
+            resultMapper = { rs -> if (rs.next()) rs.getInt(1) else 0 }
         ).process(id).getOrNull() ?: 0
     }
 

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ResourceDetailPanelIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ResourceDetailPanelIT.kt
@@ -274,8 +274,8 @@ class ResourceDetailPanelIT : WithUser() {
     private fun createResourceGathering(projectId: Int): Int = runBlocking {
         val result = DatabaseSteps.update<Unit>(
             sql = SafeSQL.insert(
-                "INSERT INTO resource_gathering (project_id, item_id, name, required, collected) " +
-                        "VALUES (?, 'minecraft:iron_ingot', 'Iron Ingot', 10, 0) RETURNING id"
+                "INSERT INTO resource_gathering (project_id, item_id, name, required) " +
+                        "VALUES (?, 'minecraft:iron_ingot', 'Iron Ingot', 10) RETURNING id"
             ),
             parameterSetter = { stmt, _ -> stmt.setInt(1, projectId) }
         ).process(Unit)


### PR DESCRIPTION
PR **2a** of Gathering Planner Phase 2 ([MCO-221](https://linear.app/evegul/issue/MCO-221), epic [MCO-219](https://linear.app/evegul/issue/MCO-219)). **Behaviour-preserving data-layer refactor — no user-visible change.** The unified List-lens UI is PR 2b, on top of this.

## Migrations

- **V2_41_0** — re-scope `resource_gathering_plan_override` from `resource_gathering_id` → `project_id` (backfill via `resource_gathering`, defensive dedupe, unique `(project_id, item_id)`). Matches the engine's one-shared-DAG-per-project override model. FK `ON DELETE CASCADE` guarantees the backfill is NULL-safe.
- **V2_42_0** — create `resource_gathering_progress(project_id, item_id, collected)` unique `(project_id, item_id)`; backfill from `resource_gathering.collected` (SUM per project+item, ordered before the drop); then **drop `resource_gathering.collected`**. Progress is now per-plan-node — the single source of truth for any activity (leaves, intermediates, targets), not just defined target rows.

## Code

- Re-point every `collected` read to the progress table via `LEFT JOIN ... COALESCE(0)` — domain `ResourceGatheringItem.collected` still populated; `GetAllResourceGatheringItems`, `GetResourceGatheringItem`, `CountCollected`, `GetProjectList(+Item)`.
- The collected counter endpoint now upserts `resource_gathering_progress` (route + execute-view template **unchanged** — `item_id` resolved from the row id inside the pipeline). `UpdateItemTaskRequirements` uses a delta upsert.
- Re-scope `PlanOverrideSteps` (Get/Upsert/Clear) to `project_id`; `GenerateGatheringPlanStep` drops `resourceGatheringId`, loads overrides by `projectId`. Not yet wired into the live detail handler (PR 2b).

## Review

Reviewed by the code-reviewer agent — no blockers. Addressed: added the `GetAllResourceGatheringItemsStep` progress round-trip tests the docstring promised; documented the `rgp` 1:1 join assumption on the project-list totals (the one flagged edge case — duplicate `(project,item)` rows — is a pre-existing data anomaly, common case is byte-identical to the old `SUM(rg.collected)`).

## Tests

- New `ProgressStepsTest` (12) incl. round-trip via the resource read; `GenerateGatheringPlanStepTest` + `PlanOverrideStepsTest` re-keyed to project scope; `collected` removed from fixture inserts across the IT suite.
- Unit **541** / database **89+** green. Migrations apply cleanly (schema 2.42.0).

**Drops a column** (`resource_gathering.collected`) after backfill — flagged per the migration checkpoint rule; the model change was agreed up front. Backend-only, no `preview` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)