### PR TITLE
ci: validate Dependabot PRs; stop recurring un-mergeable Kotlin bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,12 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 10
+    ignore:
+      # Kotlin is deliberately held at the latest CodeQL-analysable 2.3.x (see the
+      # rationale in webapp/mc-bom/pom.xml). 2.4.x breaks CodeQL's Kotlin extractor
+      # (github/codeql#21938). Drop this ignore once CodeQL supports 2.4.x.
+      - dependency-name: "org.jetbrains.kotlin:*"
+        versions: [ ">=2.4.0" ]
     # Versions are centralised in mc-bom (libraries) and webapp/pom.xml (build-plugin
     # versions), so most bumps land as a single property change. Grouping keeps a family
     # that spans several artifacts (Ktor, Kotlin, the test stack) in one PR.

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -22,12 +22,10 @@ on:
       - webapp/Dockerfile
 jobs:
   compile:
-    if: github.actor != 'dependabot[bot]'
     uses: ./.github/workflows/compile.yml
 
   unit-tests:
     name: Unit Tests
-    if: github.actor != 'dependabot[bot]'
     needs: compile
     runs-on: ubuntu-latest
     defaults:
@@ -67,7 +65,6 @@ jobs:
 
   integration-tests:
     name: Integration Tests
-    if: github.actor != 'dependabot[bot]'
     needs: compile
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
## Why

While triaging the open Dependabot PRs I found two gaps:

1. **Dependabot PRs were never built or tested in CI.** `dev.yml` guarded `compile`, `unit-tests`, and `integration-tests` with `if: github.actor != 'dependabot[bot]'`, so a green tick on a dependency bump only meant CodeQL passed — the build and test suite never ran. (#320/#321 were merged after validating locally precisely because CI couldn't.)
2. **The Kotlin group bump (#319) is un-mergeable by design and recurs weekly.** Kotlin is deliberately pinned at 2.3.21 — the latest version CodeQL's Kotlin extractor supports (github/codeql#21938) — but `dependabot.yml` had no `ignore` rule, so Dependabot keeps re-proposing 2.4.x.

## Changes

- **`dev.yml`** — drop the `dependabot[bot]` guard from `compile` / `unit-tests` / `integration-tests`. These need no secrets (unit tests generate JWT keys locally; integration tests use Testcontainers), so they're safe to run for everyone. `deploy-dev` keeps its guard: it needs Neon/Fly secrets and is already gated by the `preview` label.
- **`dependabot.yml`** — ignore `org.jetbrains.kotlin:*` `>=2.4.0`. Remove once CodeQL supports 2.4.x.

## Follow-up

Closing #319 as part of this (the ignore rule replaces it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)