### PR TITLE
ci: trigger build/test pipeline on workflow file changes

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -20,6 +20,9 @@ on:
       - webapp/pom.xml
       - webapp/*/pom.xml
       - webapp/Dockerfile
+      # Workflow changes (incl. Dependabot github-actions bumps) self-test: the PR
+      # runs its own updated workflow, so a broken action bump fails CI before merge.
+      - .github/workflows/**
 jobs:
   compile:
     uses: ./.github/workflows/compile.yml


### PR DESCRIPTION
## Why

github-actions Dependabot bumps (e.g. `actions/checkout` v6→v7, #326) only edit `.github/workflows/*.yml`, which wasn't in `dev.yml`'s `paths:` filter. So the build/test pipeline never triggered for them — only CodeQL ran, leaving the bumped actions unvalidated until they hit the next real PR.

## Change

Add `.github/workflows/**` to the `paths:` filter. Because a PR runs its **own** updated workflow, this self-tests bumped actions — a broken bump (or any workflow edit) now fails compile/unit/integration *before* merge.

Cost: any workflow edit triggers a full build. Proportionate — you'd want CI to confirm a workflow change didn't break the pipeline anyway.

Follow-up to #324.

🤖 Generated with [Claude Code](https://claude.com/claude-code)