### PR TITLE
Event system: in-process bus + domain/derived events (MCO-228)

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/Application.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/Application.kt
@@ -1,5 +1,6 @@
 package app.mcorg
 
+import app.mcorg.event.configureEvents
 import app.mcorg.presentation.plugins.configureHTTP
 import app.mcorg.presentation.plugins.configureMonitoring
 import app.mcorg.presentation.plugins.configurePreviewGate
@@ -29,6 +30,7 @@ private fun defaultServer(module: Application.() -> Unit) =
     )
 
 private fun Application.module() {
+    configureEvents()
     configurePreviewGate()
     configureHTTP()
     configureMonitoring()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/event/DerivedEventConsumer.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/event/DerivedEventConsumer.kt
@@ -1,0 +1,82 @@
+package app.mcorg.event
+
+/** Resource-progress milestones, in percent, that emit a [ResourceMilestoneReached]. */
+internal val RESOURCE_MILESTONES = listOf(25, 50, 75, 100)
+
+/**
+ * The single highest milestone newly crossed when project progress moves from [previousDone] to
+ * [newDone] out of [requiredTotal], or `null` if none is crossed. A milestone is crossed when the
+ * previous percentage was strictly below it and the new percentage is at or above it.
+ *
+ * Only the highest crossed milestone fires: a jump that spans several (e.g. 0% → 80%, or 0% → 100%)
+ * reports just the top one (75, or 100), never the intermediates.
+ */
+internal fun milestoneReached(previousDone: Int, newDone: Int, requiredTotal: Int): Int? {
+    if (requiredTotal <= 0) return null
+    val previousPercent = previousDone.toDouble() / requiredTotal * 100.0
+    val newPercent = newDone.toDouble() / requiredTotal * 100.0
+    return RESOURCE_MILESTONES.lastOrNull { previousPercent < it && newPercent >= it }
+}
+
+/**
+ * Re-publishes derived events from a single domain event ([SeamEvent.data] of the source is enough —
+ * the consumer never touches the database). Derivation is one level deep: [DerivedEvent] inputs are
+ * ignored, so a re-published event can never trigger further derivation.
+ *
+ * Derivations:
+ *  - [ResourceCountUpdated] → [ResourceMilestoneReached] (per milestone crossed) and, when the
+ *    project's resources become fully satisfied, [ProjectResourcesComplete].
+ *  - [DependencyEdgeRemoved] → [ProjectUnblocked] for each newly unblocked dependent.
+ */
+class DerivedEventConsumer(private val bus: EventBus) : EventHandler {
+    override suspend fun handle(event: SeamEvent) {
+        if (event is DerivedEvent) return // one level of derivation only
+
+        when (event) {
+            is ResourceCountUpdated -> deriveFromResourceCount(event)
+            is DependencyEdgeRemoved -> deriveFromDependencyRemoval(event)
+            else -> Unit
+        }
+    }
+
+    private fun deriveFromResourceCount(event: ResourceCountUpdated) {
+        milestoneReached(event.projectPreviousDone, event.projectNewDone, event.projectRequired)?.let { milestone ->
+            bus.publish(
+                ResourceMilestoneReached(
+                    worldId = event.worldId,
+                    actorId = event.actorId,
+                    timestamp = event.timestamp,
+                    projectId = event.projectId,
+                    milestone = milestone,
+                )
+            )
+        }
+
+        val wasIncomplete = event.projectPreviousDone < event.projectRequired
+        val nowComplete = event.projectRequired > 0 && event.projectNewDone >= event.projectRequired
+        if (wasIncomplete && nowComplete) {
+            bus.publish(
+                ProjectResourcesComplete(
+                    worldId = event.worldId,
+                    actorId = event.actorId,
+                    timestamp = event.timestamp,
+                    projectId = event.projectId,
+                )
+            )
+        }
+    }
+
+    private fun deriveFromDependencyRemoval(event: DependencyEdgeRemoved) {
+        event.unblockedDependentProjectIds.forEach { dependentId ->
+            bus.publish(
+                ProjectUnblocked(
+                    worldId = event.worldId,
+                    actorId = event.actorId,
+                    timestamp = event.timestamp,
+                    projectId = dependentId,
+                    unblockedByProjectId = event.projectId,
+                )
+            )
+        }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/event/EventBus.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/event/EventBus.kt
@@ -1,0 +1,21 @@
+package app.mcorg.event
+
+/** A subscriber invoked once per published [SeamEvent]. */
+fun interface EventHandler {
+    suspend fun handle(event: SeamEvent)
+}
+
+/**
+ * In-process publish/subscribe for [SeamEvent]s. Publishing is fire-and-forget: [publish] returns
+ * immediately and fans out to every subscriber concurrently. A handler that throws is isolated —
+ * it neither propagates to the caller nor affects sibling handlers.
+ *
+ * Subscriptions are expected to be registered once at startup; there is no unsubscribe.
+ */
+interface EventBus {
+    /** Hand [event] off to all subscribers. Never blocks on or fails for handler work. */
+    fun publish(event: SeamEvent)
+
+    /** Register [handler] to receive all future events. */
+    fun subscribe(handler: EventHandler)
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/event/EventBusPlugin.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/event/EventBusPlugin.kt
@@ -1,0 +1,43 @@
+package app.mcorg.event
+
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.ApplicationStopping
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+/**
+ * Process-wide event bus. Following the codebase convention for shared infrastructure
+ * (`CacheManager`, `Database`), the bus is a singleton reachable from any handler via [eventBus]
+ * rather than threaded through DI — so it is available in unit/integration tests that bootstrap
+ * routes directly without running the full application module.
+ *
+ * The backing coroutine scope uses a `SupervisorJob` (one failed handler never cancels the scope or
+ * its siblings). In production [configureEvents] subscribes the [DerivedEventConsumer] once and
+ * cancels the scope on `ApplicationStopping`, tying the bus to the Ktor lifecycle. In tests no
+ * consumer is subscribed and publishes are harmless no-ops.
+ */
+object SeamEventBus {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default + CoroutineName("seam-event-bus"))
+    val bus = InProcessEventBus(scope)
+}
+
+/**
+ * Wires the [DerivedEventConsumer] and ties the bus's scope to the Ktor lifecycle (scope cancelled
+ * on `ApplicationStopping`). Call once from `Application.module()`.
+ */
+fun Application.configureEvents() {
+    SeamEventBus.bus.subscribe(DerivedEventConsumer(SeamEventBus.bus))
+    monitor.subscribe(ApplicationStopping) { SeamEventBus.scope.cancel("Application stopping") }
+}
+
+/** The process-wide [EventBus]. */
+val Application.eventBus: EventBus
+    get() = SeamEventBus.bus
+
+/** The process-wide [EventBus] for the current call. */
+val ApplicationCall.eventBus: EventBus
+    get() = SeamEventBus.bus

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/event/EventEnvelope.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/event/EventEnvelope.kt
@@ -1,0 +1,35 @@
+package app.mcorg.event
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.time.format.DateTimeFormatter
+
+/**
+ * Serializes a [SeamEvent] into the wire envelope shared with downstream consumers (webhook
+ * delivery — MCO-229):
+ *
+ * ```json
+ * { "event_type": "...", "world_id": 1, "timestamp": "ISO-8601", "actor": 42|null, "data": { ... } }
+ * ```
+ *
+ * `actor` is `null` for system-originated events. `data` is the event-specific payload from
+ * [SeamEvent.data]. Envelope versioning is deferred until the first schema change.
+ */
+object EventEnvelope {
+    private val json = Json
+
+    /** Build the envelope as a [JsonObject] (without serializing to a string). */
+    fun toJsonObject(event: SeamEvent): JsonObject = buildJsonObject {
+        put("event_type", event.eventType)
+        put("world_id", event.worldId)
+        put("timestamp", DateTimeFormatter.ISO_INSTANT.format(event.timestamp))
+        put("actor", event.actorId)
+        put("data", event.data())
+    }
+
+    /** Serialize the envelope to a compact JSON string. */
+    fun serialize(event: SeamEvent): String =
+        json.encodeToString(JsonObject.serializer(), toJsonObject(event))
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/event/InProcessEventBus.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/event/InProcessEventBus.kt
@@ -1,0 +1,37 @@
+package app.mcorg.event
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+import java.util.concurrent.CopyOnWriteArrayList
+
+/**
+ * [EventBus] backed by a [CoroutineScope] tied to the application lifecycle (see
+ * `Application.configureEvents`). The scope is built on a `SupervisorJob`, so one handler failing
+ * never cancels the scope or sibling handlers; each dispatch is additionally wrapped so exceptions
+ * are logged rather than lost. When the scope is cancelled at shutdown, in-flight handlers stop and
+ * further publishes become no-ops.
+ *
+ * [subscribe] uses a copy-on-write list: subscriptions happen once at startup while publishes are
+ * frequent and concurrent, so reads are lock-free.
+ */
+class InProcessEventBus(private val scope: CoroutineScope) : EventBus {
+    private val logger = LoggerFactory.getLogger(InProcessEventBus::class.java)
+    private val handlers = CopyOnWriteArrayList<EventHandler>()
+
+    override fun subscribe(handler: EventHandler) {
+        handlers.add(handler)
+    }
+
+    override fun publish(event: SeamEvent) {
+        for (handler in handlers) {
+            scope.launch {
+                try {
+                    handler.handle(event)
+                } catch (e: Exception) {
+                    logger.error("Event handler failed for {} ({})", event.eventType, event, e)
+                }
+            }
+        }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/event/SeamEvent.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/event/SeamEvent.kt
@@ -1,0 +1,237 @@
+package app.mcorg.event
+
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.domain.model.project.ProjectType
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.time.Instant
+
+/**
+ * In-process event taxonomy — the foundation layer for the webapp → Discord integration (MCO-228).
+ *
+ * Every event is world-scoped, timestamped, and attributed to an actor (or the system). Events are
+ * fire-and-forget signals emitted at the handler level after a successful pipeline result; they
+ * carry no persistence, ordering, or delivery guarantees (those live downstream — see MCO-229).
+ *
+ * Two families:
+ *  - **Domain events** — emitted by handlers after a successful mutation.
+ *  - **[DerivedEvent]s** — re-published by [DerivedEventConsumer] from a single domain event. The
+ *    consumer ignores derived events as inputs, so derivation is strictly one level deep.
+ *
+ * The wire contract for downstream consumers is the [EventEnvelope]; [eventType] and [data] define
+ * each event's stable serialized shape. Event versioning is deferred until the first schema change.
+ */
+sealed interface SeamEvent {
+    /** World the event belongs to. */
+    val worldId: Int
+
+    /** User who triggered the event, or `null` when system-originated. */
+    val actorId: Int?
+
+    /** When the event occurred. */
+    val timestamp: Instant
+
+    /** Stable snake_case wire name, e.g. `project_created`. */
+    val eventType: String
+
+    /** Event-specific payload for the envelope's `data` field. */
+    fun data(): JsonObject
+}
+
+/**
+ * Marker for events produced by [DerivedEventConsumer] rather than published directly by a handler.
+ * The consumer skips these as inputs, enforcing "one level of derivation only".
+ */
+sealed interface DerivedEvent : SeamEvent
+
+// ── Domain events ────────────────────────────────────────────────────────────
+
+/**
+ * A project's resource progress changed. Carries both the item-level delta and the project-level
+ * rollup so derived consumers can compute milestones and completion without touching the database.
+ */
+data class ResourceCountUpdated(
+    override val worldId: Int,
+    override val actorId: Int?,
+    override val timestamp: Instant,
+    val projectId: Int,
+    val itemId: String,
+    val previousDone: Int,
+    val newDone: Int,
+    val projectPreviousDone: Int,
+    val projectNewDone: Int,
+    val projectRequired: Int,
+) : SeamEvent {
+    override val eventType = "resource_count_updated"
+    override fun data() = buildJsonObject {
+        put("project_id", projectId)
+        put("item_id", itemId)
+        put("previous_done", previousDone)
+        put("new_done", newDone)
+        put("project_previous_done", projectPreviousDone)
+        put("project_new_done", projectNewDone)
+        put("project_required", projectRequired)
+    }
+}
+
+/** An action/item task was toggled complete or incomplete. */
+data class TaskToggled(
+    override val worldId: Int,
+    override val actorId: Int?,
+    override val timestamp: Instant,
+    val projectId: Int,
+    val taskId: Int,
+    val completed: Boolean,
+) : SeamEvent {
+    override val eventType = "task_toggled"
+    override fun data() = buildJsonObject {
+        put("project_id", projectId)
+        put("task_id", taskId)
+        put("completed", completed)
+    }
+}
+
+/** A new project was created. */
+data class ProjectCreated(
+    override val worldId: Int,
+    override val actorId: Int?,
+    override val timestamp: Instant,
+    val projectId: Int,
+    val name: String,
+    val type: ProjectType,
+) : SeamEvent {
+    override val eventType = "project_created"
+    override fun data() = buildJsonObject {
+        put("project_id", projectId)
+        put("name", name)
+        put("type", type.name)
+    }
+}
+
+/** A project moved between lifecycle states (PENDING → ACTIVE → DONE …). */
+data class ProjectStatusChanged(
+    override val worldId: Int,
+    override val actorId: Int?,
+    override val timestamp: Instant,
+    val projectId: Int,
+    val previousState: ProjectState,
+    val newState: ProjectState,
+) : SeamEvent {
+    override val eventType = "project_status_changed"
+    override fun data() = buildJsonObject {
+        put("project_id", projectId)
+        put("previous_state", previousState.name)
+        put("new_state", newState.name)
+    }
+}
+
+/** A production / resource-gathering path was generated for a project's target item. */
+data class ProductionPathGenerated(
+    override val worldId: Int,
+    override val actorId: Int?,
+    override val timestamp: Instant,
+    val projectId: Int,
+    val itemId: String,
+) : SeamEvent {
+    override val eventType = "production_path_generated"
+    override fun data() = buildJsonObject {
+        put("project_id", projectId)
+        put("item_id", itemId)
+    }
+}
+
+/** A dependency edge `projectId depends on dependsOnProjectId` was added. */
+data class DependencyEdgeAdded(
+    override val worldId: Int,
+    override val actorId: Int?,
+    override val timestamp: Instant,
+    val projectId: Int,
+    val dependsOnProjectId: Int,
+) : SeamEvent {
+    override val eventType = "dependency_edge_added"
+    override fun data() = buildJsonObject {
+        put("project_id", projectId)
+        put("depends_on_project_id", dependsOnProjectId)
+    }
+}
+
+/**
+ * A dependency edge was removed. [unblockedDependentProjectIds] lists projects that became unblocked
+ * as a result (computed by the publishing handler, which has database access); the derived consumer
+ * fans these out into [ProjectUnblocked] events without re-querying.
+ */
+data class DependencyEdgeRemoved(
+    override val worldId: Int,
+    override val actorId: Int?,
+    override val timestamp: Instant,
+    val projectId: Int,
+    val dependsOnProjectId: Int,
+    val unblockedDependentProjectIds: List<Int> = emptyList(),
+) : SeamEvent {
+    override val eventType = "dependency_edge_removed"
+    override fun data() = buildJsonObject {
+        put("project_id", projectId)
+        put("depends_on_project_id", dependsOnProjectId)
+    }
+}
+
+/** An idea was imported into a world (e.g. from the Discord triage feed). */
+data class IdeaImported(
+    override val worldId: Int,
+    override val actorId: Int?,
+    override val timestamp: Instant,
+    val ideaId: Int,
+    val name: String,
+) : SeamEvent {
+    override val eventType = "idea_imported"
+    override fun data() = buildJsonObject {
+        put("idea_id", ideaId)
+        put("name", name)
+    }
+}
+
+// ── Derived events ───────────────────────────────────────────────────────────
+
+/** A project crossed a resource-progress milestone (one of 25 / 50 / 75 / 100 percent). */
+data class ResourceMilestoneReached(
+    override val worldId: Int,
+    override val actorId: Int?,
+    override val timestamp: Instant,
+    val projectId: Int,
+    val milestone: Int,
+) : DerivedEvent {
+    override val eventType = "resource_milestone_reached"
+    override fun data() = buildJsonObject {
+        put("project_id", projectId)
+        put("milestone", milestone)
+    }
+}
+
+/** A project's resource requirements are fully satisfied. */
+data class ProjectResourcesComplete(
+    override val worldId: Int,
+    override val actorId: Int?,
+    override val timestamp: Instant,
+    val projectId: Int,
+) : DerivedEvent {
+    override val eventType = "project_resources_complete"
+    override fun data() = buildJsonObject {
+        put("project_id", projectId)
+    }
+}
+
+/** A project became unblocked because a dependency edge was removed. */
+data class ProjectUnblocked(
+    override val worldId: Int,
+    override val actorId: Int?,
+    override val timestamp: Instant,
+    val projectId: Int,
+    val unblockedByProjectId: Int,
+) : DerivedEvent {
+    override val eventType = "project_unblocked"
+    override fun data() = buildJsonObject {
+        put("project_id", projectId)
+        put("unblocked_by_project_id", unblockedByProjectId)
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectPipeline.kt
@@ -2,6 +2,9 @@ package app.mcorg.pipeline.project
 
 import app.mcorg.config.CacheManager
 import app.mcorg.domain.model.project.ProjectType
+import app.mcorg.event.ProjectCreated
+import app.mcorg.event.eventBus
+import java.time.Instant
 import app.mcorg.domain.model.user.Role
 import app.mcorg.pipeline.Result
 import app.mcorg.domain.pipeline.Step
@@ -38,6 +41,7 @@ suspend fun ApplicationCall.handleCreateProject() {
     val parameters = this.receiveParameters()
     val user = this.getUser()
     val worldId = this.getWorldId()
+    val bus = this.eventBus
     val isHtmx = request.headers["HX-Request"] == "true"
     val isFirstProject = parameters["first_project"] == "true"
     val view = parameters["view"]?.takeIf { it == "plan" } ?: "execute"
@@ -76,6 +80,7 @@ suspend fun ApplicationCall.handleCreateProject() {
         ValidateWorldMemberRole<CreateProjectInput>(user, Role.ADMIN, worldId).run(input)
         val projectId = CreateProjectStep(worldId).run(input)
         CacheManager.onProjectCreated(worldId, projectId)
+        bus.publish(ProjectCreated(worldId, user.id, Instant.now(), projectId, input.name, input.type))
         projectId
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -7,6 +7,8 @@ import app.mcorg.domain.model.minecraft.Item
 import app.mcorg.domain.model.minecraft.MinecraftVersion
 import app.mcorg.domain.model.minecraft.MinecraftVersionRange
 import app.mcorg.domain.model.project.ProjectType
+import app.mcorg.event.IdeaImported
+import app.mcorg.event.eventBus
 import app.mcorg.pipeline.Result
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
@@ -19,9 +21,11 @@ import app.mcorg.presentation.handler.handlePipeline
 import app.mcorg.presentation.templated.dsl.Link
 import app.mcorg.presentation.utils.clientRedirect
 import app.mcorg.presentation.utils.getIdeaId
+import app.mcorg.presentation.utils.getUser
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveParameters
 import kotlinx.serialization.json.Json
+import java.time.Instant
 
 data class IdeaForImport(
     val id: Int,
@@ -34,6 +38,8 @@ data class IdeaForImport(
 
 suspend fun ApplicationCall.handleImportIdea() {
     val ideaId = this.getIdeaId()
+    val user = this.getUser()
+    val bus = this.eventBus
 
     val worldId = (this.receiveParameters()["worldId"] ?: parameters["worldId"])?.toIntOrNull()
         ?: return run {
@@ -52,6 +58,7 @@ suspend fun ApplicationCall.handleImportIdea() {
         val validatedIdea = ValidateItemIdsStep(items).run(ideaData)
         val projectId = CreateProjectFromIdeaStep(worldId, taskId).run(validatedIdea)
         CacheManager.onProjectCreated(worldId, projectId)
+        bus.publish(IdeaImported(worldId, user.id, Instant.now(), ideaId, validatedIdea.name))
         projectId
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/UpdateProjectStatePipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/UpdateProjectStatePipeline.kt
@@ -2,6 +2,9 @@ package app.mcorg.pipeline.project
 
 import app.mcorg.domain.model.project.ProjectState
 import app.mcorg.domain.model.user.Role
+import app.mcorg.event.ProjectStatusChanged
+import app.mcorg.event.eventBus
+import java.time.Instant
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
@@ -25,6 +28,7 @@ suspend fun ApplicationCall.handleUpdateProjectState() {
     val user = this.getUser()
     val worldId = this.getWorldId()
     val projectId = this.getProjectId()
+    val bus = this.eventBus
 
     handlePipeline(
         onSuccess = { newState ->
@@ -35,7 +39,9 @@ suspend fun ApplicationCall.handleUpdateProjectState() {
         ValidateWorldMemberRole<ProjectState>(user, Role.ADMIN, worldId).run(target)
         val current = GetProjectStateStep.run(projectId)
         ValidateStateTransitionStep(current).run(target)
-        UpdateProjectStateStep(projectId).run(target)
+        val newState = UpdateProjectStateStep(projectId).run(target)
+        bus.publish(ProjectStatusChanged(worldId, user.id, Instant.now(), projectId, current, newState))
+        newState
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/SetCollectedValuePipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/SetCollectedValuePipeline.kt
@@ -1,5 +1,7 @@
 package app.mcorg.pipeline.resources
 
+import app.mcorg.event.ResourceCountUpdated
+import app.mcorg.event.eventBus
 import app.mcorg.pipeline.Result
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.ValidationSteps
@@ -15,11 +17,13 @@ import app.mcorg.presentation.templated.dsl.progressBar
 import app.mcorg.presentation.templated.dsl.resourceRow
 import app.mcorg.presentation.utils.getProjectId
 import app.mcorg.presentation.utils.getResourceGatheringId
+import app.mcorg.presentation.utils.getUser
 import app.mcorg.presentation.utils.getWorldId
 import app.mcorg.presentation.utils.respondHtml
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveParameters
+import java.time.Instant
 import kotlinx.html.div
 import kotlinx.html.id
 import kotlinx.html.stream.createHTML
@@ -29,6 +33,8 @@ suspend fun ApplicationCall.handleSetCollectedValue() {
     val worldId = this.getWorldId()
     val projectId = this.getProjectId()
     val resourceGatheringId = this.getResourceGatheringId()
+    val user = this.getUser()
+    val bus = this.eventBus
 
     handlePipeline(
         onSuccess = { progress ->
@@ -53,8 +59,19 @@ suspend fun ApplicationCall.handleSetCollectedValue() {
         }
     ) {
         val value = ValidateSetCollectedValueStep.run(parameters)
+        val before = GetUpdatedCollectedCountsStep.run(resourceGatheringId)
         UpsertProgressStep.run(UpsertProgressByRgIdInput(resourceGatheringId, value))
-        GetUpdatedCollectedCountsStep.run(resourceGatheringId)
+        val after = GetUpdatedCollectedCountsStep.run(resourceGatheringId)
+        bus.publish(
+            ResourceCountUpdated(
+                worldId = worldId, actorId = user.id, timestamp = Instant.now(),
+                projectId = projectId, itemId = after.item.itemId,
+                previousDone = before.item.collected, newDone = after.item.collected,
+                projectPreviousDone = before.totalCollected, projectNewDone = after.totalCollected,
+                projectRequired = after.totalRequired,
+            )
+        )
+        after
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/UpdateItemTaskRequirementsPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/UpdateItemTaskRequirementsPipeline.kt
@@ -1,6 +1,8 @@
 package app.mcorg.pipeline.resources
 
 import app.mcorg.domain.model.resources.ResourceGatheringItem
+import app.mcorg.event.ResourceCountUpdated
+import app.mcorg.event.eventBus
 import app.mcorg.pipeline.Result
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.ValidationSteps
@@ -17,11 +19,13 @@ import app.mcorg.presentation.templated.dsl.progressBar
 import app.mcorg.presentation.templated.dsl.resourceRow
 import app.mcorg.presentation.utils.getProjectId
 import app.mcorg.presentation.utils.getResourceGatheringId
+import app.mcorg.presentation.utils.getUser
 import app.mcorg.presentation.utils.getWorldId
 import app.mcorg.presentation.utils.respondHtml
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveParameters
+import java.time.Instant
 import kotlinx.html.div
 import kotlinx.html.id
 import kotlinx.html.stream.createHTML
@@ -37,6 +41,8 @@ suspend fun ApplicationCall.handleUpdateRequirementProgress() {
     val resourceGatheringId = this.getResourceGatheringId()
     val worldId = this.getWorldId()
     val projectId = this.getProjectId()
+    val user = this.getUser()
+    val bus = this.eventBus
 
     handlePipeline(
         onSuccess = { progress ->
@@ -61,8 +67,19 @@ suspend fun ApplicationCall.handleUpdateRequirementProgress() {
         },
     ) {
         val amount = ValidateUpdateItemTaskRequirementsInputStep.run(parameters)
+        val before = GetUpdatedTaskCountsStep.run(resourceGatheringId)
         UpsertProgressDeltaStep.run(UpsertProgressDeltaInput(resourceGatheringId, amount))
-        GetUpdatedTaskCountsStep.run(resourceGatheringId)
+        val after = GetUpdatedTaskCountsStep.run(resourceGatheringId)
+        bus.publish(
+            ResourceCountUpdated(
+                worldId = worldId, actorId = user.id, timestamp = Instant.now(),
+                projectId = projectId, itemId = after.item.itemId,
+                previousDone = before.item.collected, newDone = after.item.collected,
+                projectPreviousDone = before.totalCollected, projectNewDone = after.totalCollected,
+                projectRequired = after.totalRequired,
+            )
+        )
+        after
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/task/CompleteTaskPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/task/CompleteTaskPipeline.kt
@@ -1,6 +1,8 @@
 package app.mcorg.pipeline.task
 
 import app.mcorg.domain.model.task.ActionTask
+import app.mcorg.event.TaskToggled
+import app.mcorg.event.eventBus
 import app.mcorg.pipeline.Result
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
@@ -14,14 +16,18 @@ import app.mcorg.presentation.templated.dsl.taskRowFragment
 import app.mcorg.presentation.templated.dsl.pages.taskProgressOobFragment
 import app.mcorg.presentation.utils.getProjectId
 import app.mcorg.presentation.utils.getTaskId
+import app.mcorg.presentation.utils.getUser
 import app.mcorg.presentation.utils.getWorldId
 import app.mcorg.presentation.utils.respondHtml
 import io.ktor.server.application.ApplicationCall
+import java.time.Instant
 
 suspend fun ApplicationCall.handleCompleteActionTask() {
     val worldId = this.getWorldId()
     val projectId = this.getProjectId()
     val taskId = this.getTaskId()
+    val user = this.getUser()
+    val bus = this.eventBus
 
     handlePipeline(
         onSuccess = {
@@ -32,7 +38,9 @@ suspend fun ApplicationCall.handleCompleteActionTask() {
         },
     ) {
         ToggleTaskStep.run(taskId)
-        CheckTaskProgressStep.run(taskId)
+        val progress = CheckTaskProgressStep.run(taskId)
+        bus.publish(TaskToggled(worldId, user.id, Instant.now(), projectId, taskId, progress.first.completed))
+        progress
     }
 }
 

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/event/DerivedEventConsumerTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/event/DerivedEventConsumerTest.kt
@@ -1,0 +1,99 @@
+package app.mcorg.event
+
+import kotlinx.coroutines.runBlocking
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for derived-event logic (MCO-228): the milestone-crossing rules and the
+ * [DerivedEventConsumer]'s re-publishing, including the one-level-of-derivation guard.
+ */
+class DerivedEventConsumerTest {
+
+    // ── milestoneReached ─────────────────────────────────────────────────────
+
+    @Test
+    fun `crossing a single milestone reports that milestone`() {
+        assertEquals(25, milestoneReached(previousDone = 20, newDone = 30, requiredTotal = 100))
+    }
+
+    @Test
+    fun `a jump across several milestones reports only the highest crossed`() {
+        assertEquals(75, milestoneReached(previousDone = 0, newDone = 80, requiredTotal = 100))
+    }
+
+    @Test
+    fun `a jump straight to 100 reports only 100`() {
+        assertEquals(100, milestoneReached(previousDone = 10, newDone = 100, requiredTotal = 100))
+    }
+
+    @Test
+    fun `exactly landing on a milestone counts as crossing it`() {
+        assertEquals(50, milestoneReached(previousDone = 49, newDone = 50, requiredTotal = 100))
+    }
+
+    @Test
+    fun `no progress across a boundary reports null`() {
+        assertEquals(null, milestoneReached(previousDone = 26, newDone = 40, requiredTotal = 100))
+    }
+
+    @Test
+    fun `already complete then further update reports null`() {
+        assertEquals(null, milestoneReached(previousDone = 100, newDone = 120, requiredTotal = 100))
+    }
+
+    @Test
+    fun `zero required total reports null`() {
+        assertEquals(null, milestoneReached(previousDone = 0, newDone = 0, requiredTotal = 0))
+    }
+
+    // ── DerivedEventConsumer ─────────────────────────────────────────────────
+
+    private class RecordingBus : EventBus {
+        val published = mutableListOf<SeamEvent>()
+        override fun publish(event: SeamEvent) { published.add(event) }
+        override fun subscribe(handler: EventHandler) = Unit
+    }
+
+    private val ts = Instant.parse("2026-06-21T12:00:00Z")
+
+    @Test
+    fun `resource count update re-publishes milestone and completion`() = runBlocking {
+        val bus = RecordingBus()
+        DerivedEventConsumer(bus).handle(
+            ResourceCountUpdated(
+                worldId = 1, actorId = 7, timestamp = ts, projectId = 9, itemId = "minecraft:stone",
+                previousDone = 5, newDone = 10,
+                projectPreviousDone = 90, projectNewDone = 100, projectRequired = 100,
+            )
+        )
+        assertEquals(
+            listOf<SeamEvent>(ResourceMilestoneReached(1, 7, ts, 9, 100), ProjectResourcesComplete(1, 7, ts, 9)),
+            bus.published,
+        )
+    }
+
+    @Test
+    fun `dependency removal fans out one ProjectUnblocked per dependent`() = runBlocking {
+        val bus = RecordingBus()
+        DerivedEventConsumer(bus).handle(
+            DependencyEdgeRemoved(
+                worldId = 1, actorId = null, timestamp = ts, projectId = 4, dependsOnProjectId = 2,
+                unblockedDependentProjectIds = listOf(11, 12),
+            )
+        )
+        assertEquals(
+            listOf<SeamEvent>(ProjectUnblocked(1, null, ts, 11, 4), ProjectUnblocked(1, null, ts, 12, 4)),
+            bus.published,
+        )
+    }
+
+    @Test
+    fun `derived events are not re-derived`() = runBlocking {
+        val bus = RecordingBus()
+        DerivedEventConsumer(bus).handle(ProjectResourcesComplete(1, 7, ts, 9))
+        assertTrue(bus.published.isEmpty())
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/event/EventEnvelopeTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/event/EventEnvelopeTest.kt
@@ -1,0 +1,44 @@
+package app.mcorg.event
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import app.mcorg.domain.model.project.ProjectType
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Unit tests for the [EventEnvelope] wire contract (MCO-228). */
+class EventEnvelopeTest {
+
+    private val ts = Instant.parse("2026-06-21T12:00:00Z")
+
+    @Test
+    fun `envelope carries event_type, world_id, timestamp, actor and data`() {
+        val json = EventEnvelope.serialize(
+            ProjectCreated(worldId = 3, actorId = 42, timestamp = ts, projectId = 9, name = "Iron Farm", type = ProjectType.REDSTONE)
+        )
+        val obj = Json.parseToJsonElement(json).jsonObject
+
+        assertEquals("project_created", obj["event_type"]!!.jsonPrimitive.content)
+        assertEquals(3, obj["world_id"]!!.jsonPrimitive.content.toInt())
+        assertEquals("2026-06-21T12:00:00Z", obj["timestamp"]!!.jsonPrimitive.content)
+        assertEquals(42, obj["actor"]!!.jsonPrimitive.content.toInt())
+
+        val data = (obj["data"] as JsonObject)
+        assertEquals(9, data["project_id"]!!.jsonPrimitive.content.toInt())
+        assertEquals("Iron Farm", data["name"]!!.jsonPrimitive.content)
+        assertEquals("REDSTONE", data["type"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `system-originated event serializes actor as null`() {
+        val json = EventEnvelope.serialize(
+            IdeaImported(worldId = 1, actorId = null, timestamp = ts, ideaId = 5, name = "Auto-sorter")
+        )
+        val obj = Json.parseToJsonElement(json).jsonObject
+        assertEquals(JsonNull, obj["actor"])
+    }
+}


### PR DESCRIPTION
Foundation layer for the webapp → Discord integration (MCO-228). Self-contained in `mc-web/.../app/mcorg/event/`; no persistence, ordering, or external delivery (that's MCO-229).

## What's here

**Bus**
- `EventBus` / `InProcessEventBus` — `SupervisorJob`-backed scope tied to the Ktor lifecycle (`configureEvents`, cancelled on `ApplicationStopping`), concurrent fan-out, per-handler exception isolation + logging. Reached via the `SeamEventBus` singleton (matches the `CacheManager`/`Database` convention, so it's available in route-level ITs too).

**Events**
- `SeamEvent` sealed interface (`worldId`, `actorId?`, `timestamp`, `eventType`, `data()`) + `DerivedEvent` marker (consumer ignores derived inputs → one level of derivation).
- 8 domain events, 3 derived events.
- `EventEnvelope`: `{event_type, world_id, timestamp (ISO-8601), actor, data}` — the wire contract for MCO-229.

**Derived consumer**
- `ResourceMilestoneReached` — **project-level** progress, emits **only the highest** newly-crossed threshold of 25/50/75/100.
- `ProjectResourcesComplete`, `ProjectUnblocked`.

**Publish points** (handler level, after the successful pipeline result; steps stay pure):
`ProjectCreated`, `TaskToggled`, `ResourceCountUpdated` (delta + set handlers, clamp-safe before/after snapshots), `ProjectStatusChanged` (uses the `ProjectState` lifecycle axis), `IdeaImported`.

## Dormant (no trigger yet → MCO-238)
`DependencyEdgeAdded`/`DependencyEdgeRemoved` (no dependency add/remove endpoints) and `ProductionPathGenerated` (no per-item handler) are defined but unwired. `ProjectUnblocked` consequently can't fire until a removal endpoint exists.

## Decisions worth a look
- Project-level, highest-only milestones (confirmed with @evengul).
- `ProjectStatusChanged` modelled on `ProjectState` (PENDING→DONE), not `ProjectStage`.
- Bus as a global singleton vs. attribute DI — chosen so the many route-level ITs keep working without bootstrapping the full module.

## Tests
`app.mcorg.event.*` unit tests (milestone math incl. highest-only + completion, envelope shape, derived fan-out, no-re-derivation). Full mc-web tier green: unit 561 + database 96, 0 failures; affected handler ITs pass with the new publishes.

No `preview` label (backend-only, nothing to eyeball).

🤖 Generated with [Claude Code](https://claude.com/claude-code)