### PR TITLE
Gathering Planner — Phase 3: drill, source/tag overrides, ranked picker (MCO-222)

### DIFF
--- a/webapp/mc-engine/src/main/kotlin/app/mcorg/engine/plan/SourceRanking.kt
+++ b/webapp/mc-engine/src/main/kotlin/app/mcorg/engine/plan/SourceRanking.kt
@@ -1,0 +1,61 @@
+package app.mcorg.engine.plan
+
+import app.mcorg.domain.model.minecraft.MinecraftId
+import app.mcorg.engine.model.ItemSourceGraph
+import app.mcorg.engine.model.SourceNode
+
+/**
+ * One candidate source for an item, ranked against its siblings.
+ *
+ * @param source the candidate.
+ * @param score the [SelectionScorer] score (higher is better).
+ * @param rank position in the ranking, 0 = best.
+ */
+data class RankedSource(
+    val source: SourceNode,
+    val score: Int,
+    val rank: Int,
+)
+
+/**
+ * Read-only ranking of an item's candidate sources, for UIs that let a user
+ * re-pin a source (the drill picker). This is a thin, side-effect-free view over
+ * the **existing** [SelectionScorer] and the exact ordering [PlanSelector] uses
+ * internally — it computes nothing new and changes no scoring. It exists only
+ * because [SelectionScorer] is module-internal, so callers outside the engine
+ * cannot rank candidates themselves.
+ *
+ * The ordering mirrors `PlanSelector.rank` verbatim: descending score, then
+ * recipes ahead of non-recipes on ties, then a stable id tiebreak.
+ *
+ * Demand matters because the score includes a demand-sensitive recipe-threshold
+ * bonus; pass the demand the UI is presenting (e.g. the drill's
+ * `TargetTree.quantityIfAlone`). [supplied] and [context] default to "nothing
+ * supplied / standard context", which yields the intrinsic ranking of a source;
+ * pass the project's real supplied map to match the planner's own choice exactly.
+ */
+object SourceRanking {
+
+    fun rankSources(
+        graph: ItemSourceGraph,
+        item: MinecraftId,
+        demand: Long,
+        supplied: Map<String, SupplySource> = emptyMap(),
+        context: PlanContext = PlanContext(),
+    ): List<RankedSource> {
+        val candidates = graph.getSourcesForItem(item)
+        if (candidates.isEmpty()) return emptyList()
+
+        val scorer = SelectionScorer(graph, supplied, context)
+        val hasRecipeSibling = candidates.any { it.sourceType.isRecipe() }
+
+        return candidates
+            .map { it to scorer.score(item, it, demand, hasRecipeSibling) }
+            .sortedWith(
+                compareByDescending<Pair<SourceNode, Int>> { it.second }
+                    .thenByDescending { it.first.sourceType.isRecipe() }
+                    .thenBy { it.first.getKey() }
+            )
+            .mapIndexed { index, (source, score) -> RankedSource(source, score, index) }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -10,6 +10,7 @@ import app.mcorg.pipeline.project.commonsteps.GetViewPreferenceStep
 import app.mcorg.pipeline.resources.GatheringPlanInput
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
 import app.mcorg.pipeline.resources.buildCandidateCounts
+import app.mcorg.pipeline.resources.drillTreeFor
 import app.mcorg.pipeline.resources.getGraphForWorld
 import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
 import app.mcorg.pipeline.resources.commonsteps.GetProgressForProjectStep
@@ -89,7 +90,7 @@ suspend fun ApplicationCall.handleGetProject() {
     val drillItemId = request.queryParameters["drill"]
         ?.let { URLDecoder.decode(it, StandardCharsets.UTF_8) }
         ?.takeIf { it.isNotBlank() }
-    val drillTarget: TargetTree? = drillItemId?.let { plan?.perTarget(it) }
+    val drillTarget: TargetTree? = drillItemId?.let { plan?.drillTreeFor(it) }
     val drillCandidateCounts = if (drillTarget != null) {
         buildCandidateCounts(drillTarget, getGraphForWorld(worldId))
     } else emptyMap()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -101,7 +101,7 @@ suspend fun ApplicationCall.handleGetProject() {
             user, project, worldName, resources, tasks, lens,
             isWorldAdmin = isAdmin, plan = plan, progressMap = progressMap,
             drillTarget = drillTarget, drillCandidateCounts = drillCandidateCounts,
-            drillNodeIngredients = drillNodeIngredients,
+            drillNodeIngredients = drillNodeIngredients, drillHighlightItemId = drillItemId,
         )
     )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -1,6 +1,7 @@
 package app.mcorg.pipeline.project
 
 import app.mcorg.domain.model.user.Role
+import app.mcorg.engine.plan.TargetTree
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.project.commonsteps.GetProjectByIdStep
@@ -8,6 +9,8 @@ import app.mcorg.pipeline.project.commonsteps.GetViewPreferenceInput
 import app.mcorg.pipeline.project.commonsteps.GetViewPreferenceStep
 import app.mcorg.pipeline.resources.GatheringPlanInput
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
+import app.mcorg.pipeline.resources.buildCandidateCounts
+import app.mcorg.pipeline.resources.getGraphForWorld
 import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
 import app.mcorg.pipeline.resources.commonsteps.GetProgressForProjectStep
 import app.mcorg.pipeline.task.SearchTasksInput
@@ -22,6 +25,8 @@ import app.mcorg.presentation.utils.getWorldName
 import app.mcorg.presentation.utils.respondBadRequest
 import app.mcorg.presentation.utils.respondHtml
 import io.ktor.server.application.ApplicationCall
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
 
 suspend fun ApplicationCall.handleGetProject() {
     val user = getUser()
@@ -78,5 +83,22 @@ suspend fun ApplicationCall.handleGetProject() {
     // Load persisted progress for all items in the project (covers derived activities too)
     val progressMap = GetProgressForProjectStep.process(projectId).getOrNull() ?: emptyMap()
 
-    respondHtml(projectDetailPage(user, project, worldName, resources, tasks, lens, isWorldAdmin = isAdmin, plan = plan, progressMap = progressMap))
+    // ?drill=<item> deep-links into a target's chain so reload/share lands on the drill,
+    // not the plan. Resolves only when the plan derives and the item is an actual target;
+    // otherwise falls through to the normal lens render.
+    val drillItemId = request.queryParameters["drill"]
+        ?.let { URLDecoder.decode(it, StandardCharsets.UTF_8) }
+        ?.takeIf { it.isNotBlank() }
+    val drillTarget: TargetTree? = drillItemId?.let { plan?.perTarget(it) }
+    val drillCandidateCounts = if (drillTarget != null) {
+        buildCandidateCounts(drillTarget, getGraphForWorld(worldId))
+    } else emptyMap()
+
+    respondHtml(
+        projectDetailPage(
+            user, project, worldName, resources, tasks, lens,
+            isWorldAdmin = isAdmin, plan = plan, progressMap = progressMap,
+            drillTarget = drillTarget, drillCandidateCounts = drillCandidateCounts,
+        )
+    )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -10,6 +10,7 @@ import app.mcorg.pipeline.project.commonsteps.GetViewPreferenceStep
 import app.mcorg.pipeline.resources.GatheringPlanInput
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
 import app.mcorg.pipeline.resources.buildCandidateCounts
+import app.mcorg.pipeline.resources.buildNodeIngredients
 import app.mcorg.pipeline.resources.drillTreeFor
 import app.mcorg.pipeline.resources.getGraphForWorld
 import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
@@ -91,15 +92,16 @@ suspend fun ApplicationCall.handleGetProject() {
         ?.let { URLDecoder.decode(it, StandardCharsets.UTF_8) }
         ?.takeIf { it.isNotBlank() }
     val drillTarget: TargetTree? = drillItemId?.let { plan?.drillTreeFor(it) }
-    val drillCandidateCounts = if (drillTarget != null) {
-        buildCandidateCounts(drillTarget, getGraphForWorld(worldId))
-    } else emptyMap()
+    val drillGraph = if (drillTarget != null) getGraphForWorld(worldId) else null
+    val drillCandidateCounts = if (drillTarget != null) buildCandidateCounts(drillTarget, drillGraph) else emptyMap()
+    val drillNodeIngredients = if (drillTarget != null && plan != null) buildNodeIngredients(plan) else emptyMap()
 
     respondHtml(
         projectDetailPage(
             user, project, worldName, resources, tasks, lens,
             isWorldAdmin = isAdmin, plan = plan, progressMap = progressMap,
             drillTarget = drillTarget, drillCandidateCounts = drillCandidateCounts,
+            drillNodeIngredients = drillNodeIngredients,
         )
     )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GetWorldVersionStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GetWorldVersionStep.kt
@@ -1,0 +1,32 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+
+/**
+ * Looks up the Minecraft version string for a world by its id.
+ * Returns [AppFailure.DatabaseError.NotFound] when the world does not exist or has no version set.
+ *
+ * Extracted from [GenerateGatheringPlanStep] so handlers that need the graph independently
+ * (e.g. the drill-chain view) can obtain the version without re-running the full plan.
+ */
+object GetWorldVersionStep : Step<Int, AppFailure, String> {
+
+    private val query = DatabaseSteps.query<Int, String?>(
+        sql = SafeSQL.select("SELECT version FROM world WHERE id = ?"),
+        parameterSetter = { ps, worldId -> ps.setInt(1, worldId) },
+        resultMapper = { rs -> if (rs.next()) rs.getString("version") else null }
+    )
+
+    override suspend fun process(input: Int): Result<AppFailure, String> {
+        return when (val r = query.process(input)) {
+            is Result.Success -> r.value
+                ?.let { Result.success(it) }
+                ?: Result.failure(AppFailure.DatabaseError.NotFound)
+            is Result.Failure -> r
+        }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -27,7 +27,6 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveParameters
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
-import kotlin.math.roundToLong
 
 /**
  * GET /worlds/{worldId}/projects/{projectId}/plan/chain/{itemId}
@@ -420,20 +419,23 @@ internal fun buildCandidateCounts(
  */
 internal fun buildNodeIngredients(plan: GatheringPlan): Map<String, String> {
     fun nameOf(id: String): String = plan.nodes[id]?.item?.name ?: id
-    // Ingredients are shown per ONE output item, so normalise the per-craft amounts by the
-    // node's output count (a craft that yields N items divides its inputs across them). Drop a
-    // trailing ".0" so the common integer case reads cleanly ("5 Iron Ingot", not "5.0").
-    fun fmt(n: Double): String {
-        val r = (n * 100).roundToLong() / 100.0
-        return if (r % 1.0 == 0.0) r.toLong().toString() else r.toString()
-    }
+    fun gcd(a: Long, b: Long): Long = if (b == 0L) a else gcd(b, a % b)
     return plan.nodes.values
         .filter { it.requires.isNotEmpty() }
         .associate { node ->
-            val perCraftOutput = node.producedQuantity.coerceAtLeast(1)
-            node.item.id to node.requires
+            // Reduce inputs and the output count by their common factor so the recipe reads as
+            // a clean ratio. Recipes that yield one output drop the "→ N" ("1 Chest + 5 Iron
+            // Ingot"); multi-output recipes keep it so the ratio is exact, not a fraction
+            // ("1 Oak Log → 4" instead of "0.25 Oak Log").
+            val output = node.producedQuantity.toLong().coerceAtLeast(1)
+            val divisor = node.requires
+                .fold(output) { acc, r -> gcd(acc, r.quantityPerCraft.toLong()) }
+                .coerceAtLeast(1)
+            val inputs = node.requires
                 .sortedBy { nameOf(it.itemId) }
-                .joinToString(" + ") { "${fmt(it.quantityPerCraft.toDouble() / perCraftOutput)} ${nameOf(it.itemId)}" }
+                .joinToString(" + ") { "${it.quantityPerCraft / divisor} ${nameOf(it.itemId)}" }
+            val reducedOutput = output / divisor
+            node.item.id to if (reducedOutput > 1) "$inputs → $reducedOutput" else inputs
         }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -9,9 +9,14 @@ import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.failure.ValidationFailure
 import app.mcorg.pipeline.minecraft.GetItemSourceGraphForVersionStep
 import app.mcorg.pipeline.project.commonsteps.GetProjectByIdStep
+import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
+import app.mcorg.pipeline.resources.commonsteps.GetProgressForProjectStep
+import app.mcorg.pipeline.task.SearchTasksInput
+import app.mcorg.pipeline.task.SearchTasksStep
 import app.mcorg.presentation.handler.defaultHandleError
 import app.mcorg.presentation.templated.dsl.pages.drillChainFragment
 import app.mcorg.presentation.templated.dsl.pages.drillNotFoundFragment
+import app.mcorg.presentation.templated.dsl.pages.gatheringPlannerFragment
 import app.mcorg.presentation.templated.dsl.pages.nodePickerFragment
 import app.mcorg.presentation.templated.dsl.pages.pickerNotFoundFragment
 import app.mcorg.presentation.utils.getProjectId
@@ -108,6 +113,9 @@ suspend fun ApplicationCall.handleGetNodePicker() {
 
     // Optional search filter for high-fan-out pickers.
     val query = request.queryParameters["q"]?.takeIf { it.isNotBlank() }
+    // "list" when the picker is opened inline from the List lens — resolutions then re-render
+    // the list instead of the drill.
+    val origin = request.queryParameters["origin"]?.takeIf { it.isNotBlank() }
 
     // Re-derive plan
     val plan = deriveOrNull(projectId, worldId) ?: run {
@@ -144,6 +152,7 @@ suspend fun ApplicationCall.handleGetNodePicker() {
             activeMemberId = overrides?.tagMember?.get(nodeId),
             demand = node.quantityIfAlone,
             query = query,
+            origin = origin,
         )
     )
 }
@@ -190,7 +199,7 @@ suspend fun ApplicationCall.handlePinSource() {
         is Result.Success -> { /* continue */ }
     }
 
-    respondDrillRerender(worldId, projectId, targetItemId)
+    respondAfterOverride(worldId, projectId, targetItemId, params["origin"])
 }
 
 /**
@@ -235,7 +244,7 @@ suspend fun ApplicationCall.handleResolveTagMember() {
         is Result.Success -> { /* continue */ }
     }
 
-    respondDrillRerender(worldId, projectId, targetItemId)
+    respondAfterOverride(worldId, projectId, targetItemId, params["origin"])
 }
 
 /**
@@ -265,7 +274,7 @@ suspend fun ApplicationCall.handleClearOverride() {
         is Result.Success -> { /* continue */ }
     }
 
-    respondDrillRerender(worldId, projectId, targetItemId)
+    respondAfterOverride(worldId, projectId, targetItemId, request.queryParameters["origin"])
 }
 
 // ---------------------------------------------------------------------------
@@ -304,6 +313,36 @@ private suspend fun ApplicationCall.respondDrillRerender(
     val graph = getGraphForWorld(worldId)
     val candidateCounts = buildCandidateCounts(targetTree, graph)
     respondHtml(drillChainFragment(project, targetTree, candidateCounts))
+}
+
+/**
+ * After persisting an override, re-render whichever surface the user is on: the inline List
+ * lens when the change came from there (origin=list), otherwise the full drill chain.
+ */
+private suspend fun ApplicationCall.respondAfterOverride(
+    worldId: Int,
+    projectId: Int,
+    targetItemId: String,
+    origin: String?,
+) {
+    if (origin == "list") respondListRerender(worldId, projectId)
+    else respondDrillRerender(worldId, projectId, targetItemId)
+}
+
+/** Re-renders the List-lens fragment (#project-content) — used after an inline resolution. */
+private suspend fun ApplicationCall.respondListRerender(worldId: Int, projectId: Int) {
+    val project = when (val r = GetProjectByIdStep.process(projectId)) {
+        is Result.Success -> r.value
+        is Result.Failure -> {
+            defaultHandleError(r.error)
+            return
+        }
+    }
+    val resources = GetAllResourceGatheringItemsStep.process(projectId).getOrNull() ?: emptyList()
+    val tasks = SearchTasksStep(projectId).process(SearchTasksInput(completionStatus = "ALL")).getOrNull() ?: emptyList()
+    val plan = deriveOrNull(projectId, worldId)
+    val progressMap = GetProgressForProjectStep.process(projectId).getOrNull() ?: emptyMap()
+    respondHtml(gatheringPlannerFragment(project, resources, tasks, plan, "list", progressMap))
 }
 
 /**

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -1,18 +1,25 @@
 package app.mcorg.pipeline.resources
 
+import app.mcorg.domain.model.minecraft.MinecraftTag
 import app.mcorg.engine.model.ItemSourceGraph
+import app.mcorg.engine.plan.GatheringPlan
 import app.mcorg.engine.plan.TargetTree
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.failure.ValidationFailure
 import app.mcorg.pipeline.minecraft.GetItemSourceGraphForVersionStep
 import app.mcorg.pipeline.project.commonsteps.GetProjectByIdStep
 import app.mcorg.presentation.handler.defaultHandleError
 import app.mcorg.presentation.templated.dsl.pages.drillChainFragment
 import app.mcorg.presentation.templated.dsl.pages.drillNotFoundFragment
+import app.mcorg.presentation.templated.dsl.pages.nodePickerFragment
+import app.mcorg.presentation.templated.dsl.pages.pickerNotFoundFragment
 import app.mcorg.presentation.utils.getProjectId
 import app.mcorg.presentation.utils.getWorldId
+import app.mcorg.presentation.utils.respondBadRequest
 import app.mcorg.presentation.utils.respondHtml
 import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveParameters
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
 
@@ -79,10 +86,247 @@ suspend fun ApplicationCall.handleGetDrillChain() {
 }
 
 /**
+ * GET /worlds/{worldId}/projects/{projectId}/plan/chain/{itemId}/sources?node={encodedNodeId}
+ *
+ * Returns a picker fragment for one node in the drill chain. The picker shows all candidate
+ * sources (for a multi-source item) or all tag members (for an OPEN_TAG node).
+ *
+ * Responds with an innerHTML fragment for `#picker-{nodeSlug}`.
+ */
+suspend fun ApplicationCall.handleGetNodePicker() {
+    val worldId = getWorldId()
+    val projectId = getProjectId()
+    val rawItemId = parameters["itemId"] ?: ""
+    val targetItemId = URLDecoder.decode(rawItemId, StandardCharsets.UTF_8)
+    val rawNodeId = request.queryParameters["node"] ?: ""
+    val nodeId = URLDecoder.decode(rawNodeId, StandardCharsets.UTF_8)
+
+    if (nodeId.isBlank()) {
+        respondBadRequest("Missing required query parameter: node")
+        return
+    }
+
+    // Re-derive plan
+    val plan = deriveOrNull(projectId, worldId) ?: run {
+        respondHtml(pickerNotFoundFragment("Plan not available — try refreshing."))
+        return
+    }
+
+    val targetTree = plan.perTarget(targetItemId) ?: run {
+        respondHtml(pickerNotFoundFragment("Target '$targetItemId' not found in plan."))
+        return
+    }
+
+    val node = findNodeById(targetTree, nodeId) ?: run {
+        respondHtml(pickerNotFoundFragment("Node '$nodeId' not found in chain."))
+        return
+    }
+
+    val graph = getGraphForWorld(worldId)
+
+    // Load current overrides so we can highlight the active selection
+    val overrides = when (val r = GetPlanOverridesStep.process(projectId)) {
+        is Result.Success -> r.value
+        is Result.Failure -> null
+    }
+
+    respondHtml(
+        nodePickerFragment(
+            worldId = worldId,
+            projectId = projectId,
+            targetItemId = targetItemId,
+            node = node,
+            graph = graph,
+            activeSourceKey = overrides?.sourceByItem?.get(nodeId),
+            activeMemberId = overrides?.tagMember?.get(nodeId),
+        )
+    )
+}
+
+/**
+ * POST /worlds/{worldId}/projects/{projectId}/plan/chain/{itemId}/pin
+ *
+ * Pins a specific source for a node. Form params: `node` (item id), `sourceKey`.
+ * Re-derives the plan and re-renders the full drill chain into #project-content.
+ */
+suspend fun ApplicationCall.handlePinSource() {
+    val worldId = getWorldId()
+    val projectId = getProjectId()
+    val rawItemId = parameters["itemId"] ?: ""
+    val targetItemId = URLDecoder.decode(rawItemId, StandardCharsets.UTF_8)
+
+    val params = receiveParameters()
+    val nodeId = params["node"]
+    val sourceKey = params["sourceKey"]
+
+    if (nodeId.isNullOrBlank()) {
+        respondBadRequest(
+            buildValidationError("node", "The parameter 'node' is required."),
+            target = "#error-message",
+            swap = "innerHTML"
+        )
+        return
+    }
+    if (sourceKey.isNullOrBlank()) {
+        respondBadRequest(
+            buildValidationError("sourceKey", "The parameter 'sourceKey' is required."),
+            target = "#error-message",
+            swap = "innerHTML"
+        )
+        return
+    }
+
+    // Persist the override
+    when (val r = UpsertPlanOverrideStep(projectId).process(PlanOverride.Source(nodeId, sourceKey))) {
+        is Result.Failure -> {
+            defaultHandleError(r.error)
+            return
+        }
+        is Result.Success -> { /* continue */ }
+    }
+
+    respondDrillRerender(worldId, projectId, targetItemId)
+}
+
+/**
+ * POST /worlds/{worldId}/projects/{projectId}/plan/chain/{itemId}/tag
+ *
+ * Picks a concrete member item for a tag node. Form params: `node` (tag id), `memberItemId`.
+ * Re-derives the plan and re-renders the full drill chain into #project-content.
+ */
+suspend fun ApplicationCall.handleResolveTagMember() {
+    val worldId = getWorldId()
+    val projectId = getProjectId()
+    val rawItemId = parameters["itemId"] ?: ""
+    val targetItemId = URLDecoder.decode(rawItemId, StandardCharsets.UTF_8)
+
+    val params = receiveParameters()
+    val nodeId = params["node"]
+    val memberItemId = params["memberItemId"]
+
+    if (nodeId.isNullOrBlank()) {
+        respondBadRequest(
+            buildValidationError("node", "The parameter 'node' is required."),
+            target = "#error-message",
+            swap = "innerHTML"
+        )
+        return
+    }
+    if (memberItemId.isNullOrBlank()) {
+        respondBadRequest(
+            buildValidationError("memberItemId", "The parameter 'memberItemId' is required."),
+            target = "#error-message",
+            swap = "innerHTML"
+        )
+        return
+    }
+
+    // Persist the override
+    when (val r = UpsertPlanOverrideStep(projectId).process(PlanOverride.TagMember(nodeId, memberItemId))) {
+        is Result.Failure -> {
+            defaultHandleError(r.error)
+            return
+        }
+        is Result.Success -> { /* continue */ }
+    }
+
+    respondDrillRerender(worldId, projectId, targetItemId)
+}
+
+/**
+ * DELETE /worlds/{worldId}/projects/{projectId}/plan/chain/{itemId}/override?node={encodedNodeId}
+ *
+ * Clears the override for a node. Re-derives the plan and re-renders the full drill chain.
+ */
+suspend fun ApplicationCall.handleClearOverride() {
+    val worldId = getWorldId()
+    val projectId = getProjectId()
+    val rawItemId = parameters["itemId"] ?: ""
+    val targetItemId = URLDecoder.decode(rawItemId, StandardCharsets.UTF_8)
+
+    val rawNodeId = request.queryParameters["node"] ?: ""
+    val nodeId = URLDecoder.decode(rawNodeId, StandardCharsets.UTF_8)
+
+    if (nodeId.isBlank()) {
+        respondBadRequest("Missing required query parameter: node")
+        return
+    }
+
+    when (val r = ClearPlanOverrideStep(projectId).process(nodeId)) {
+        is Result.Failure -> {
+            defaultHandleError(r.error)
+            return
+        }
+        is Result.Success -> { /* continue */ }
+    }
+
+    respondDrillRerender(worldId, projectId, targetItemId)
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Shared re-render: re-derives the plan and responds with [drillChainFragment].
+ * Falls back to [drillNotFoundFragment] when derivation or target lookup fails.
+ */
+private suspend fun ApplicationCall.respondDrillRerender(
+    worldId: Int,
+    projectId: Int,
+    targetItemId: String,
+) {
+    val project = when (val r = GetProjectByIdStep.process(projectId)) {
+        is Result.Success -> r.value
+        is Result.Failure -> {
+            defaultHandleError(r.error)
+            return
+        }
+    }
+
+    val plan = deriveOrNull(projectId, worldId)
+    val targetTree = plan?.perTarget(targetItemId)
+
+    if (plan == null || targetTree == null) {
+        val reason = if (plan == null)
+            "Could not derive the gathering plan."
+        else
+            "'$targetItemId' is not a target in this plan."
+        respondHtml(drillNotFoundFragment(project, reason))
+        return
+    }
+
+    val graph = getGraphForWorld(worldId)
+    val candidateCounts = buildCandidateCounts(targetTree, graph)
+    respondHtml(drillChainFragment(project, targetTree, candidateCounts))
+}
+
+/**
+ * Derives the gathering plan and returns it, or null on any failure (graceful).
+ */
+private suspend fun deriveOrNull(projectId: Int, worldId: Int): GatheringPlan? =
+    when (val r = GenerateGatheringPlanStep.process(GatheringPlanInput(projectId, worldId))) {
+        is Result.Success -> r.value
+        is Result.Failure -> null
+    }
+
+/**
+ * Recursively walks a [TargetTree] looking for a node whose item id matches [nodeId].
+ * Returns the first match found in depth-first order, or null.
+ */
+internal fun findNodeById(root: TargetTree, nodeId: String): TargetTree? {
+    if (root.item.id == nodeId) return root
+    for (child in root.children) {
+        findNodeById(child, nodeId)?.let { return it }
+    }
+    return null
+}
+
+/**
  * Obtains the [ItemSourceGraph] for the world's Minecraft version.
  * Returns null when the version or graph is not found (graceful — callers treat it as empty).
  */
-private suspend fun getGraphForWorld(worldId: Int): ItemSourceGraph? {
+internal suspend fun getGraphForWorld(worldId: Int): ItemSourceGraph? {
     val versionString = GetWorldVersionStep.process(worldId).getOrNull() ?: return null
     return GetItemSourceGraphForVersionStep.process(versionString).getOrNull()
 }
@@ -92,7 +336,7 @@ private suspend fun getGraphForWorld(worldId: Int): ItemSourceGraph? {
  * for its source candidate count, building a flat map of item-id → count.
  * Items not present in the graph get 0 (treated as forced/no-chip).
  */
-private fun buildCandidateCounts(
+internal fun buildCandidateCounts(
     root: TargetTree,
     graph: ItemSourceGraph?,
 ): Map<String, Int> {
@@ -109,3 +353,7 @@ private fun buildCandidateCounts(
     walk(root)
     return result
 }
+
+/** Builds a minimal validation error HTML string for respondBadRequest. */
+private fun buildValidationError(param: String, message: String): String =
+    "<p class=\"validation-error-message\" id=\"validation-error-$param\">$message</p>"

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -70,7 +70,7 @@ suspend fun ApplicationCall.handleGetDrillChain() {
     }
 
     // Look up the target tree for this item
-    val targetTree = plan.perTarget(itemId)
+    val targetTree = plan.drillTreeFor(itemId)
     if (targetTree == null) {
         respondHtml(drillNotFoundFragment(project, "'$itemId' is not a target in this plan."))
         return
@@ -115,7 +115,7 @@ suspend fun ApplicationCall.handleGetNodePicker() {
         return
     }
 
-    val targetTree = plan.perTarget(targetItemId) ?: run {
+    val targetTree = plan.drillTreeFor(targetItemId) ?: run {
         respondHtml(pickerNotFoundFragment("Target '$targetItemId' not found in plan."))
         return
     }
@@ -290,7 +290,7 @@ private suspend fun ApplicationCall.respondDrillRerender(
     }
 
     val plan = deriveOrNull(projectId, worldId)
-    val targetTree = plan?.perTarget(targetItemId)
+    val targetTree = plan?.drillTreeFor(targetItemId)
 
     if (plan == null || targetTree == null) {
         val reason = if (plan == null)
@@ -326,6 +326,16 @@ internal fun findNodeById(root: TargetTree, nodeId: String): TargetTree? {
     }
     return null
 }
+
+/**
+ * Resolves the drill subtree for [itemId]. When the item is a defined target, that's its
+ * own per-target chain. Otherwise — a derived intermediate like planks or iron ingot — it's
+ * the item as it appears inside the first target whose chain contains it. This lets the ⇄
+ * on ANY List-lens row open a drill, not just the project's targets.
+ */
+internal fun GatheringPlan.drillTreeFor(itemId: String): TargetTree? =
+    perTarget(itemId)
+        ?: targets.firstNotNullOfOrNull { t -> perTarget(t.item.id)?.let { findNodeById(it, itemId) } }
 
 /**
  * Obtains the [ItemSourceGraph] for the world's Minecraft version.

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -106,6 +106,9 @@ suspend fun ApplicationCall.handleGetNodePicker() {
         return
     }
 
+    // Optional search filter for high-fan-out pickers.
+    val query = request.queryParameters["q"]?.takeIf { it.isNotBlank() }
+
     // Re-derive plan
     val plan = deriveOrNull(projectId, worldId) ?: run {
         respondHtml(pickerNotFoundFragment("Plan not available — try refreshing."))
@@ -139,6 +142,8 @@ suspend fun ApplicationCall.handleGetNodePicker() {
             graph = graph,
             activeSourceKey = overrides?.sourceByItem?.get(nodeId),
             activeMemberId = overrides?.tagMember?.get(nodeId),
+            demand = node.quantityIfAlone,
+            query = query,
         )
     )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -89,7 +89,7 @@ suspend fun ApplicationCall.handleGetDrillChain() {
     val candidateCounts = buildCandidateCounts(targetTree, graph)
     val nodeIngredients = buildNodeIngredients(plan)
 
-    respondHtml(drillChainFragment(project, targetTree, candidateCounts, nodeIngredients))
+    respondHtml(drillChainFragment(project, targetTree, candidateCounts, nodeIngredients, highlightItemId = itemId))
 }
 
 /**
@@ -315,7 +315,7 @@ private suspend fun ApplicationCall.respondDrillRerender(
     val graph = getGraphForWorld(worldId)
     val candidateCounts = buildCandidateCounts(targetTree, graph)
     val nodeIngredients = buildNodeIngredients(plan)
-    respondHtml(drillChainFragment(project, targetTree, candidateCounts, nodeIngredients))
+    respondHtml(drillChainFragment(project, targetTree, candidateCounts, nodeIngredients, highlightItemId = targetItemId))
 }
 
 /**
@@ -370,14 +370,14 @@ internal fun findNodeById(root: TargetTree, nodeId: String): TargetTree? {
 }
 
 /**
- * Resolves the drill subtree for [itemId]. When the item is a defined target, that's its
- * own per-target chain. Otherwise — a derived intermediate like planks or iron ingot — it's
- * the item as it appears inside the first target whose chain contains it. This lets the ⇄
- * on ANY List-lens row open a drill, not just the project's targets.
+ * Resolves the drill chain to show for [itemId]: its own per-target chain when it's a
+ * defined target, otherwise the FULL chain of the first target that contains it (so a derived
+ * intermediate like raw iron is shown in context — the chain above and below it — rather than
+ * as an isolated node). The caller highlights [itemId] within the returned tree.
  */
 internal fun GatheringPlan.drillTreeFor(itemId: String): TargetTree? =
     perTarget(itemId)
-        ?: targets.firstNotNullOfOrNull { t -> perTarget(t.item.id)?.let { findNodeById(it, itemId) } }
+        ?: targets.firstNotNullOfOrNull { t -> perTarget(t.item.id)?.takeIf { findNodeById(it, itemId) != null } }
 
 /**
  * Obtains the [ItemSourceGraph] for the world's Minecraft version.

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -1,0 +1,111 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.engine.model.ItemSourceGraph
+import app.mcorg.engine.plan.TargetTree
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.minecraft.GetItemSourceGraphForVersionStep
+import app.mcorg.pipeline.project.commonsteps.GetProjectByIdStep
+import app.mcorg.presentation.handler.defaultHandleError
+import app.mcorg.presentation.templated.dsl.pages.drillChainFragment
+import app.mcorg.presentation.templated.dsl.pages.drillNotFoundFragment
+import app.mcorg.presentation.utils.getProjectId
+import app.mcorg.presentation.utils.getWorldId
+import app.mcorg.presentation.utils.respondHtml
+import io.ktor.server.application.ApplicationCall
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * GET /worlds/{worldId}/projects/{projectId}/plan/chain/{itemId}
+ *
+ * Returns a drill-chain view fragment for one plan target. Swaps into #project-content
+ * via outerHTML, exactly like the lens fragments.
+ *
+ * Path param `{itemId}` is URL-decoded before lookup — tag ids carry a leading `#`
+ * that must be percent-encoded in URLs (`%23minecraft:planks` → `#minecraft:planks`).
+ *
+ * Graceful fallback:
+ * - Plan derivation fails (no resources, all collected, no Minecraft graph):
+ *   responds with a "no plan" info callout inside #project-content.
+ * - Item not a target in the plan: responds with an "item not found in plan" info callout.
+ */
+suspend fun ApplicationCall.handleGetDrillChain() {
+    val worldId = getWorldId()
+    val projectId = getProjectId()
+    // URL-decode itemId so that %23minecraft:planks becomes #minecraft:planks
+    val rawItemId = parameters["itemId"] ?: ""
+    val itemId = URLDecoder.decode(rawItemId, StandardCharsets.UTF_8)
+
+    // Load project for display and URLs
+    val project = when (val result = GetProjectByIdStep.process(projectId)) {
+        is Result.Success -> result.value
+        is Result.Failure -> {
+            defaultHandleError(result.error)
+            return
+        }
+    }
+
+    // Derive the gathering plan — failure is graceful (no crash)
+    val plan = when (val result = GenerateGatheringPlanStep.process(GatheringPlanInput(projectId, worldId))) {
+        is Result.Success -> result.value
+        is Result.Failure -> {
+            val reason = when (result.error) {
+                is AppFailure.ValidationError ->
+                    "No gathering plan yet — add resources or there may be nothing left to gather."
+                is AppFailure.DatabaseError.NotFound ->
+                    "No Minecraft data found for this world's version. Try again after data ingestion."
+                else -> "Could not derive the gathering plan."
+            }
+            respondHtml(drillNotFoundFragment(project, reason))
+            return
+        }
+    }
+
+    // Look up the target tree for this item
+    val targetTree = plan.perTarget(itemId)
+    if (targetTree == null) {
+        respondHtml(drillNotFoundFragment(project, "'$itemId' is not a target in this plan."))
+        return
+    }
+
+    // Obtain the graph to compute candidate counts per node
+    val graph = getGraphForWorld(worldId)
+
+    // Build candidateCounts map: item-id → number of source candidates in the graph
+    val candidateCounts = buildCandidateCounts(targetTree, graph)
+
+    respondHtml(drillChainFragment(project, targetTree, candidateCounts))
+}
+
+/**
+ * Obtains the [ItemSourceGraph] for the world's Minecraft version.
+ * Returns null when the version or graph is not found (graceful — callers treat it as empty).
+ */
+private suspend fun getGraphForWorld(worldId: Int): ItemSourceGraph? {
+    val versionString = GetWorldVersionStep.process(worldId).getOrNull() ?: return null
+    return GetItemSourceGraphForVersionStep.process(versionString).getOrNull()
+}
+
+/**
+ * Walks the [TargetTree] recursively and for each unique item queries the graph
+ * for its source candidate count, building a flat map of item-id → count.
+ * Items not present in the graph get 0 (treated as forced/no-chip).
+ */
+private fun buildCandidateCounts(
+    root: TargetTree,
+    graph: ItemSourceGraph?,
+): Map<String, Int> {
+    if (graph == null) return emptyMap()
+
+    val result = mutableMapOf<String, Int>()
+    fun walk(node: TargetTree) {
+        if (node.item.id !in result) {
+            val sources = graph.getSourcesForItem(node.item)
+            result[node.item.id] = sources.size
+        }
+        for (child in node.children) walk(child)
+    }
+    walk(root)
+    return result
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -27,6 +27,7 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveParameters
 import java.net.URLDecoder
 import java.nio.charset.StandardCharsets
+import kotlin.math.roundToLong
 
 /**
  * GET /worlds/{worldId}/projects/{projectId}/plan/chain/{itemId}
@@ -86,8 +87,9 @@ suspend fun ApplicationCall.handleGetDrillChain() {
 
     // Build candidateCounts map: item-id → number of source candidates in the graph
     val candidateCounts = buildCandidateCounts(targetTree, graph)
+    val nodeIngredients = buildNodeIngredients(plan)
 
-    respondHtml(drillChainFragment(project, targetTree, candidateCounts))
+    respondHtml(drillChainFragment(project, targetTree, candidateCounts, nodeIngredients))
 }
 
 /**
@@ -312,7 +314,8 @@ private suspend fun ApplicationCall.respondDrillRerender(
 
     val graph = getGraphForWorld(worldId)
     val candidateCounts = buildCandidateCounts(targetTree, graph)
-    respondHtml(drillChainFragment(project, targetTree, candidateCounts))
+    val nodeIngredients = buildNodeIngredients(plan)
+    respondHtml(drillChainFragment(project, targetTree, candidateCounts, nodeIngredients))
 }
 
 /**
@@ -406,6 +409,32 @@ internal fun buildCandidateCounts(
     }
     walk(root)
     return result
+}
+
+/**
+ * Per-node ingredient summary ("5 Iron Ingot + 1 Chest", "1 Deepslate Iron Ore") keyed by
+ * item id, shown in each drill node's hint so the indented children read as those inputs.
+ * Built from the engine's own [PlanNode.requires] (per-craft quantities the planner used),
+ * which is authoritative — the graph's raw input quantities can be inflated by data quirks.
+ * Empty for nodes with no inputs (terminals, supplied, open tags).
+ */
+internal fun buildNodeIngredients(plan: GatheringPlan): Map<String, String> {
+    fun nameOf(id: String): String = plan.nodes[id]?.item?.name ?: id
+    // Ingredients are shown per ONE output item, so normalise the per-craft amounts by the
+    // node's output count (a craft that yields N items divides its inputs across them). Drop a
+    // trailing ".0" so the common integer case reads cleanly ("5 Iron Ingot", not "5.0").
+    fun fmt(n: Double): String {
+        val r = (n * 100).roundToLong() / 100.0
+        return if (r % 1.0 == 0.0) r.toLong().toString() else r.toString()
+    }
+    return plan.nodes.values
+        .filter { it.requires.isNotEmpty() }
+        .associate { node ->
+            val perCraftOutput = node.producedQuantity.coerceAtLeast(1)
+            node.item.id to node.requires
+                .sortedBy { nameOf(it.itemId) }
+                .joinToString(" + ") { "${fmt(it.quantityPerCraft.toDouble() / perCraftOutput)} ${nameOf(it.itemId)}" }
+        }
 }
 
 /** Builds a minimal validation error HTML string for respondBadRequest. */

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanProgressPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanProgressPipeline.kt
@@ -10,6 +10,7 @@ import app.mcorg.pipeline.resources.commonsteps.UpsertProgressByItemInput
 import app.mcorg.pipeline.resources.commonsteps.UpsertProgressByItemStep
 import app.mcorg.presentation.handler.handlePipeline
 import app.mcorg.presentation.hxOutOfBands
+import app.mcorg.presentation.templated.dsl.pages.lootTableName
 import app.mcorg.presentation.templated.dsl.pages.overallProgressInner
 import app.mcorg.presentation.templated.dsl.pages.planActivityCount
 import app.mcorg.presentation.templated.dsl.pages.planProgressTotals
@@ -88,7 +89,8 @@ suspend fun ApplicationCall.handleUpdatePlanProgress() {
         // the swapped row, matching the initial render.
         val node = plan?.nodes?.get(input.itemId)
         val sourceLabel = node?.let {
-            listOfNotNull(it.source?.getMethodLabel(), plan.let(::buildNodeIngredients)[input.itemId])
+            val detail = plan.let(::buildNodeIngredients)[input.itemId] ?: it.source?.let(::lootTableName)
+            listOfNotNull(it.source?.getMethodLabel(), detail)
                 .joinToString(" · ")
                 .ifEmpty { null }
         }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanProgressPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanProgressPipeline.kt
@@ -84,13 +84,22 @@ suspend fun ApplicationCall.handleUpdatePlanProgress() {
         // Project-wide totals for the overall-progress OOB update
         val overallTotals: Pair<Long, Long>? = plan?.let { planProgressTotals(it, progressMap) }
 
+        // Re-derived plan lets us keep the "Smelting · 1 Raw Iron" source/ingredient label on
+        // the swapped row, matching the initial render.
+        val node = plan?.nodes?.get(input.itemId)
+        val sourceLabel = node?.let {
+            listOfNotNull(it.source?.getMethodLabel(), plan.let(::buildNodeIngredients)[input.itemId])
+                .joinToString(" · ")
+                .ifEmpty { null }
+        }
+
         PlanProgressResult(
             itemId = input.itemId,
             itemName = input.itemId.substringAfterLast(':').replace('_', ' ')
                 .replaceFirstChar { it.uppercaseChar() },
             collected = collected.toLong(),
             required = input.required,
-            sourceLabel = null, // source label not available without plan re-derive here
+            sourceLabel = sourceLabel,
             overallTotals = overallTotals,
         )
     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -9,7 +9,11 @@ import app.mcorg.pipeline.project.handleDeleteProject
 import app.mcorg.pipeline.project.handleGetProject
 import app.mcorg.pipeline.project.handleGetDetailContent
 import app.mcorg.pipeline.project.resources.handleAddResourcesFromSchematic
+import app.mcorg.pipeline.resources.handleClearOverride
 import app.mcorg.pipeline.resources.handleGetDrillChain
+import app.mcorg.pipeline.resources.handleGetNodePicker
+import app.mcorg.pipeline.resources.handlePinSource
+import app.mcorg.pipeline.resources.handleResolveTagMember
 import app.mcorg.pipeline.resources.handleUpdatePlanProgress
 import app.mcorg.pipeline.resources.handleClearResourceSource
 import app.mcorg.pipeline.resources.handleCreateResourceGatheringItem
@@ -190,8 +194,12 @@ class WorldHandler {
                             patch("/progress") {
                                 call.handleUpdatePlanProgress()
                             }
-                            get("/chain/{itemId}") {
-                                call.handleGetDrillChain()
+                            route("/chain/{itemId}") {
+                                get { call.handleGetDrillChain() }
+                                get("/sources") { call.handleGetNodePicker() }
+                                post("/pin") { call.handlePinSource() }
+                                post("/tag") { call.handleResolveTagMember() }
+                                delete("/override") { call.handleClearOverride() }
                             }
                         }
                     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -9,6 +9,7 @@ import app.mcorg.pipeline.project.handleDeleteProject
 import app.mcorg.pipeline.project.handleGetProject
 import app.mcorg.pipeline.project.handleGetDetailContent
 import app.mcorg.pipeline.project.resources.handleAddResourcesFromSchematic
+import app.mcorg.pipeline.resources.handleGetDrillChain
 import app.mcorg.pipeline.resources.handleUpdatePlanProgress
 import app.mcorg.pipeline.resources.handleClearResourceSource
 import app.mcorg.pipeline.resources.handleCreateResourceGatheringItem
@@ -188,6 +189,9 @@ class WorldHandler {
                         route("/plan") {
                             patch("/progress") {
                                 call.handleUpdatePlanProgress()
+                            }
+                            get("/chain/{itemId}") {
+                                call.handleGetDrillChain()
                             }
                         }
                     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
@@ -349,18 +349,21 @@ fun nodePickerFragment(
 private fun sourceLabel(source: SourceNode, graph: ItemSourceGraph?): String {
     val inputs = graph?.getRequiredItems(source)?.map { it.item.name }?.sorted().orEmpty()
     if (inputs.isNotEmpty()) return "from ${inputs.joinToString(" + ")}"
-    // No inputs → a loot/gather source. getName() enriches block/entity sources with their
-    // file ("Break Block: Deepslate iron ore"), but loot types fall back to the bare method
-    // ("Chest"), so every chest reads alike. Name them by their loot-table file instead
-    // ("Simple dungeon", "Ancient city") — the distinguishing info is already in `filename`.
-    val name = source.getName()
-    if (name == source.sourceType.name) {
-        val pretty = source.filename.substringAfterLast('/').substringBeforeLast('.')
-            .replace('_', ' ').trim()
-            .replaceFirstChar { it.uppercaseChar() }
-        if (pretty.isNotBlank()) return pretty
-    }
-    return name
+    return lootTableName(source) ?: source.getName()
+}
+
+/**
+ * The looting location for a loot source, from its loot-table file ("Desert pyramid",
+ * "Simple dungeon"), or null for non-loot sources. getName() enriches block/entity loot with
+ * their file already; recipes carry ingredients — only the bare-typed loot tables (chest,
+ * gift, archaeology, barter) need this, and the distinguishing info is in `filename`.
+ */
+internal fun lootTableName(source: SourceNode): String? {
+    if (!source.sourceType.isLoot() || source.getName() != source.sourceType.name) return null
+    val pretty = source.filename.substringAfterLast('/').substringBeforeLast('.')
+        .replace('_', ' ').trim()
+        .replaceFirstChar { it.uppercaseChar() }
+    return pretty.ifBlank { null }
 }
 
 /** A tag member paired with its best source + that source's score, for ranking. */

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
@@ -30,20 +30,25 @@ fun drillChainFragment(
     project: Project,
     target: TargetTree,
     candidateCounts: Map<String, Int>,
+    nodeIngredients: Map<String, String> = emptyMap(),
 ): String = createHTML().div {
     id = "project-content"
-    drillChainContent(project, target, candidateCounts)
+    drillChainContent(project, target, candidateCounts, nodeIngredients)
 }
 
 /**
  * The drill body (back-header + chain), rendered into the caller's flow. Shared by
  * [drillChainFragment] (the HTMX swap response) and the full page shell, so that a
  * `?drill=` page load renders the same drill inside #project-content.
+ *
+ * @param nodeIngredients item-id → its source's ingredient summary ("5 Iron Ingot + 1 Chest"),
+ *   shown in each node's hint so the indented children read as those exact inputs.
  */
 fun FlowContent.drillChainContent(
     project: Project,
     target: TargetTree,
     candidateCounts: Map<String, Int>,
+    nodeIngredients: Map<String, String> = emptyMap(),
 ) {
     val worldId = project.worldId
     val projectId = project.id
@@ -66,7 +71,7 @@ fun FlowContent.drillChainContent(
     }
 
     div("drill-chain") {
-        renderTargetTree(target, candidateCounts, depth = 0, worldId = worldId, projectId = projectId, encodedTargetId = encodedTargetId)
+        renderTargetTree(target, candidateCounts, nodeIngredients, depth = 0, worldId = worldId, projectId = projectId, encodedTargetId = encodedTargetId)
     }
 }
 
@@ -74,6 +79,7 @@ fun FlowContent.drillChainContent(
 private fun DIV.renderTargetTree(
     node: TargetTree,
     candidateCounts: Map<String, Int>,
+    nodeIngredients: Map<String, String>,
     depth: Int,
     worldId: Int,
     projectId: Int,
@@ -91,9 +97,13 @@ private fun DIV.renderTargetTree(
         // Item name + optional method hint for RESOLVED nodes
         span("chain-node__name") {
             +node.item.name
+            // Hint = method + ingredient summary ("Smelting · 1 Deepslate Iron Ore"), so the
+            // node states what it consumes and the indented children read as those inputs.
             val methodHint = node.source?.getMethodLabel()
-            if (methodHint != null && (node.status == PlanNodeStatus.RESOLVED || node.status == PlanNodeStatus.RAW_GATHER)) {
-                span("chain-node__method") { +"· $methodHint" }
+                ?.takeIf { node.status == PlanNodeStatus.RESOLVED || node.status == PlanNodeStatus.RAW_GATHER }
+            val hint = listOfNotNull(methodHint, nodeIngredients[node.item.id]).joinToString(" · ")
+            if (hint.isNotEmpty()) {
+                span("chain-node__method") { +"· $hint" }
             }
         }
 
@@ -147,7 +157,7 @@ private fun DIV.renderTargetTree(
 
     // Recurse into children
     for (child in node.children) {
-        renderTargetTree(child, candidateCounts, depth + 1, worldId, projectId, encodedTargetId)
+        renderTargetTree(child, candidateCounts, nodeIngredients, depth + 1, worldId, projectId, encodedTargetId)
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
@@ -1,0 +1,159 @@
+package app.mcorg.presentation.templated.dsl.pages
+
+import app.mcorg.domain.model.project.Project
+import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.TargetTree
+import kotlinx.html.*
+import kotlinx.html.stream.createHTML
+
+/**
+ * Drill-chain view fragment for one plan target.
+ *
+ * Rendered into `#project-content` via an `outerHTML` swap, exactly like the lens fragments.
+ *
+ * @param project the owning project (for URLs and titles).
+ * @param target the resolved [TargetTree] for the drill target.
+ * @param candidateCounts item-id → number of source candidates in the graph. Used to decide
+ *   whether a node is "forced" (≤ 1 candidate) or "multi-source" (≥ 2 candidates).
+ */
+fun drillChainFragment(
+    project: Project,
+    target: TargetTree,
+    candidateCounts: Map<String, Int>,
+): String = createHTML().div {
+    id = "project-content"
+
+    val worldId = project.worldId
+    val projectId = project.id
+    val listFragmentUrl = "/worlds/$worldId/projects/$projectId/detail-content?lens=list"
+    val listPageUrl = "/worlds/$worldId/projects/$projectId?lens=list"
+    val targetName = target.item.name
+
+    div("drill-header") {
+        button(classes = "btn btn--ghost btn--sm") {
+            attributes["hx-get"] = listFragmentUrl
+            attributes["hx-target"] = "#project-content"
+            attributes["hx-swap"] = "outerHTML"
+            attributes["hx-push-url"] = listPageUrl
+            +"< Back to plan"
+        }
+        span("section-label") {
+            +"$targetName · chain — if gathered alone · tap ⇄ to re-pin"
+        }
+    }
+
+    div("drill-chain") {
+        renderTargetTree(target, candidateCounts, depth = 0)
+    }
+}
+
+/** Renders a [TargetTree] node and recurses into children. */
+private fun DIV.renderTargetTree(
+    node: TargetTree,
+    candidateCounts: Map<String, Int>,
+    depth: Int,
+) {
+    val depthClass = "chain-node--depth-${depth.coerceAtMost(4)}"
+    val isForced = isForced(node, candidateCounts)
+    val isMultiSource = isMultiSource(node, candidateCounts)
+
+    div("chain-node $depthClass") {
+        // Item name + optional method hint for RESOLVED nodes
+        span("chain-node__name") {
+            +node.item.name
+            val methodHint = node.source?.getMethodLabel()
+            if (methodHint != null && (node.status == PlanNodeStatus.RESOLVED || node.status == PlanNodeStatus.RAW_GATHER)) {
+                span("chain-node__method") { +"· $methodHint" }
+            }
+        }
+
+        // Quantity if alone
+        span("chain-node__qty") { +node.quantityIfAlone.toString() }
+
+        // Source control: forced label or ⇄ chip
+        when {
+            node.status == PlanNodeStatus.SUPPLIED -> {
+                val supplyLabel = node.supply?.label ?: "Supplied"
+                span("chain-node__forced") { +"Supplied · $supplyLabel" }
+            }
+            node.status == PlanNodeStatus.BLOCKED -> {
+                span("chain-node__forced") { +"Blocked — no source" }
+            }
+            node.status == PlanNodeStatus.OPEN_TAG || isMultiSource -> {
+                // Multi-source or open tag: render ⇄ chip (Phase 1: no-op placeholder)
+                val nodeSource = node.source  // local val to enable smart cast across module boundary
+                val chipLabel = when {
+                    nodeSource != null -> nodeSource.getName()
+                    node.status == PlanNodeStatus.OPEN_TAG -> "Pick variant"
+                    else -> "Pick source"
+                }
+                button(classes = "chip") {
+                    type = ButtonType.button
+                    // Phase 1: no hx-* attributes — placeholder only
+                    +"⇄ $chipLabel"
+                }
+            }
+            isForced -> {
+                val methodLabel = node.source?.getMethodLabel() ?: "gather"
+                span("chain-node__forced") { +"$methodLabel · 1 way" }
+            }
+            else -> {
+                // Terminal with no source info (RAW_GATHER with no graph source)
+                val methodLabel = node.source?.getMethodLabel() ?: "gather"
+                span("chain-node__forced") { +"$methodLabel · 1 way" }
+            }
+        }
+    }
+
+    // Recurse into children
+    for (child in node.children) {
+        renderTargetTree(child, candidateCounts, depth + 1)
+    }
+}
+
+/**
+ * A node is "forced" (no chip) when there is at most one candidate source in the graph,
+ * OR the node is RESOLVED/RAW_GATHER and the item is a terminal (no children) with only 1 way.
+ */
+private fun isForced(node: TargetTree, candidateCounts: Map<String, Int>): Boolean {
+    if (node.status == PlanNodeStatus.OPEN_TAG || node.status == PlanNodeStatus.SUPPLIED || node.status == PlanNodeStatus.BLOCKED) {
+        return false
+    }
+    val count = candidateCounts[node.item.id] ?: 0
+    return count <= 1
+}
+
+private fun isMultiSource(node: TargetTree, candidateCounts: Map<String, Int>): Boolean {
+    if (node.status == PlanNodeStatus.OPEN_TAG) return true
+    if (node.status == PlanNodeStatus.SUPPLIED || node.status == PlanNodeStatus.BLOCKED) return false
+    val count = candidateCounts[node.item.id] ?: 0
+    return count >= 2
+}
+
+/**
+ * Graceful fallback fragment when the plan cannot be derived or the item is not a target.
+ * Renders into `#project-content` so the outerHTML swap still replaces the right element.
+ */
+fun drillNotFoundFragment(project: Project, reason: String): String = createHTML().div {
+    id = "project-content"
+
+    val worldId = project.worldId
+    val projectId = project.id
+    val listFragmentUrl = "/worlds/$worldId/projects/$projectId/detail-content?lens=list"
+    val listPageUrl = "/worlds/$worldId/projects/$projectId?lens=list"
+
+    div("drill-header") {
+        button(classes = "btn btn--ghost btn--sm") {
+            attributes["hx-get"] = listFragmentUrl
+            attributes["hx-target"] = "#project-content"
+            attributes["hx-swap"] = "outerHTML"
+            attributes["hx-push-url"] = listPageUrl
+            +"< Back to plan"
+        }
+    }
+
+    div("callout callout--info") {
+        span("callout__icon") { +"i" }
+        div("callout__body") { +reason }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
@@ -298,7 +298,7 @@ fun nodePickerFragment(
                             attributes["hx-vals"] = """{"node":"${node.item.id}","sourceKey":"${source.getKey()}"}"""
                             attributes["hx-target"] = "#project-content"
                             attributes["hx-swap"] = "outerHTML"
-                            span("picker-opt__name") { +source.getName() }
+                            span("picker-opt__name") { +sourceLabel(source, graph) }
                             pickerOptHint(source.getMethodLabel(), isBest = rs.rank == 0, isSelected = isSelected)
                         }
                     }
@@ -319,6 +319,17 @@ fun nodePickerFragment(
             }
         }
     }
+}
+
+/**
+ * A distinguishing label for a source option. [SourceNode.getName] already carries the
+ * pretty filename for block/entity sources, but for recipes and chest loot it collapses to
+ * the bare type ("Crafting"/"Smelting"/"Chest"), making siblings indistinguishable. When the
+ * graph exposes ingredients, name the source by them ("from Iron Ore", "from Block of Iron").
+ */
+private fun sourceLabel(source: SourceNode, graph: ItemSourceGraph?): String {
+    val inputs = graph?.getRequiredItems(source)?.map { it.item.name }?.sorted().orEmpty()
+    return if (inputs.isNotEmpty()) "from ${inputs.joinToString(" + ")}" else source.getName()
 }
 
 /** A tag member paired with its best source + that source's score, for ranking. */

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
@@ -297,7 +297,7 @@ fun nodePickerFragment(
         } else {
             // Source picker — candidates ranked by SelectionScorer (read-only reuse).
             val ranked = graph?.let { SourceRanking.rankSources(it, node.item, demand) } ?: emptyList()
-            val filtered = if (q.isEmpty()) ranked else ranked.filter { it.source.getName().contains(q, ignoreCase = true) }
+            val filtered = if (q.isEmpty()) ranked else ranked.filter { sourceLabel(it.source, graph).contains(q, ignoreCase = true) }
             val displayed = filtered.take(PICKER_MAX_OPTIONS)
 
             span("section-label picker__label") { +"Choose source" }
@@ -348,7 +348,19 @@ fun nodePickerFragment(
  */
 private fun sourceLabel(source: SourceNode, graph: ItemSourceGraph?): String {
     val inputs = graph?.getRequiredItems(source)?.map { it.item.name }?.sorted().orEmpty()
-    return if (inputs.isNotEmpty()) "from ${inputs.joinToString(" + ")}" else source.getName()
+    if (inputs.isNotEmpty()) return "from ${inputs.joinToString(" + ")}"
+    // No inputs → a loot/gather source. getName() enriches block/entity sources with their
+    // file ("Break Block: Deepslate iron ore"), but loot types fall back to the bare method
+    // ("Chest"), so every chest reads alike. Name them by their loot-table file instead
+    // ("Simple dungeon", "Ancient city") — the distinguishing info is already in `filename`.
+    val name = source.getName()
+    if (name == source.sourceType.name) {
+        val pretty = source.filename.substringAfterLast('/').substringBeforeLast('.')
+            .replace('_', ' ').trim()
+            .replaceFirstChar { it.uppercaseChar() }
+        if (pretty.isNotBlank()) return pretty
+    }
+    return name
 }
 
 /** A tag member paired with its best source + that source's score, for ranking. */

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
@@ -31,9 +31,10 @@ fun drillChainFragment(
     target: TargetTree,
     candidateCounts: Map<String, Int>,
     nodeIngredients: Map<String, String> = emptyMap(),
+    highlightItemId: String? = null,
 ): String = createHTML().div {
     id = "project-content"
-    drillChainContent(project, target, candidateCounts, nodeIngredients)
+    drillChainContent(project, target, candidateCounts, nodeIngredients, highlightItemId)
 }
 
 /**
@@ -49,6 +50,7 @@ fun FlowContent.drillChainContent(
     target: TargetTree,
     candidateCounts: Map<String, Int>,
     nodeIngredients: Map<String, String> = emptyMap(),
+    highlightItemId: String? = null,
 ) {
     val worldId = project.worldId
     val projectId = project.id
@@ -71,7 +73,7 @@ fun FlowContent.drillChainContent(
     }
 
     div("drill-chain") {
-        renderTargetTree(target, candidateCounts, nodeIngredients, depth = 0, worldId = worldId, projectId = projectId, encodedTargetId = encodedTargetId)
+        renderTargetTree(target, candidateCounts, nodeIngredients, highlightItemId, depth = 0, worldId = worldId, projectId = projectId, encodedTargetId = encodedTargetId)
     }
 }
 
@@ -80,12 +82,14 @@ private fun DIV.renderTargetTree(
     node: TargetTree,
     candidateCounts: Map<String, Int>,
     nodeIngredients: Map<String, String>,
+    highlightItemId: String?,
     depth: Int,
     worldId: Int,
     projectId: Int,
     encodedTargetId: String,
 ) {
     val depthClass = "chain-node--depth-${depth.coerceAtMost(4)}"
+    val highlightClass = if (node.item.id == highlightItemId) " chain-node--current" else ""
     val isForced = isForced(node, candidateCounts)
     val isMultiSource = isMultiSource(node, candidateCounts)
     val nodeSlug = node.item.id.replace(Regex("[^a-zA-Z0-9]"), "-")
@@ -93,7 +97,7 @@ private fun DIV.renderTargetTree(
     val pickerSlotId = "picker-$nodeSlug"
     val pickerUrl = "/worlds/$worldId/projects/$projectId/plan/chain/$encodedTargetId/sources?node=$encodedNodeId"
 
-    div("chain-node $depthClass") {
+    div("chain-node $depthClass$highlightClass") {
         // Item name + optional method hint for RESOLVED nodes
         span("chain-node__name") {
             +node.item.name
@@ -157,7 +161,7 @@ private fun DIV.renderTargetTree(
 
     // Recurse into children
     for (child in node.children) {
-        renderTargetTree(child, candidateCounts, nodeIngredients, depth + 1, worldId, projectId, encodedTargetId)
+        renderTargetTree(child, candidateCounts, nodeIngredients, highlightItemId, depth + 1, worldId, projectId, encodedTargetId)
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
@@ -1,10 +1,18 @@
 package app.mcorg.presentation.templated.dsl.pages
 
+import app.mcorg.domain.model.minecraft.MinecraftTag
 import app.mcorg.domain.model.project.Project
+import app.mcorg.engine.model.ItemSourceGraph
+import app.mcorg.engine.model.SourceNode
 import app.mcorg.engine.plan.PlanNodeStatus
 import app.mcorg.engine.plan.TargetTree
 import kotlinx.html.*
 import kotlinx.html.stream.createHTML
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+// High fan-out cap: when a node has more than this many candidates we only show the first N.
+private const val PICKER_MAX_OPTIONS = 30
 
 /**
  * Drill-chain view fragment for one plan target.
@@ -28,6 +36,7 @@ fun drillChainFragment(
     val listFragmentUrl = "/worlds/$worldId/projects/$projectId/detail-content?lens=list"
     val listPageUrl = "/worlds/$worldId/projects/$projectId?lens=list"
     val targetName = target.item.name
+    val encodedTargetId = encodeId(target.item.id)
 
     div("drill-header") {
         button(classes = "btn btn--ghost btn--sm") {
@@ -43,7 +52,7 @@ fun drillChainFragment(
     }
 
     div("drill-chain") {
-        renderTargetTree(target, candidateCounts, depth = 0)
+        renderTargetTree(target, candidateCounts, depth = 0, worldId = worldId, projectId = projectId, encodedTargetId = encodedTargetId)
     }
 }
 
@@ -52,10 +61,17 @@ private fun DIV.renderTargetTree(
     node: TargetTree,
     candidateCounts: Map<String, Int>,
     depth: Int,
+    worldId: Int,
+    projectId: Int,
+    encodedTargetId: String,
 ) {
     val depthClass = "chain-node--depth-${depth.coerceAtMost(4)}"
     val isForced = isForced(node, candidateCounts)
     val isMultiSource = isMultiSource(node, candidateCounts)
+    val nodeSlug = node.item.id.replace(Regex("[^a-zA-Z0-9]"), "-")
+    val encodedNodeId = encodeId(node.item.id)
+    val pickerSlotId = "picker-$nodeSlug"
+    val pickerUrl = "/worlds/$worldId/projects/$projectId/plan/chain/$encodedTargetId/sources?node=$encodedNodeId"
 
     div("chain-node $depthClass") {
         // Item name + optional method hint for RESOLVED nodes
@@ -80,8 +96,8 @@ private fun DIV.renderTargetTree(
                 span("chain-node__forced") { +"Blocked — no source" }
             }
             node.status == PlanNodeStatus.OPEN_TAG || isMultiSource -> {
-                // Multi-source or open tag: render ⇄ chip (Phase 1: no-op placeholder)
-                val nodeSource = node.source  // local val to enable smart cast across module boundary
+                // Multi-source or open tag: render ⇄ chip that loads the picker
+                val nodeSource = node.source
                 val chipLabel = when {
                     nodeSource != null -> nodeSource.getName()
                     node.status == PlanNodeStatus.OPEN_TAG -> "Pick variant"
@@ -89,7 +105,9 @@ private fun DIV.renderTargetTree(
                 }
                 button(classes = "chip") {
                     type = ButtonType.button
-                    // Phase 1: no hx-* attributes — placeholder only
+                    attributes["hx-get"] = pickerUrl
+                    attributes["hx-target"] = "#$pickerSlotId"
+                    attributes["hx-swap"] = "innerHTML"
                     +"⇄ $chipLabel"
                 }
             }
@@ -105,9 +123,17 @@ private fun DIV.renderTargetTree(
         }
     }
 
+    // Picker slot: only rendered for chip nodes; starts empty, filled by hx-get
+    if (node.status == PlanNodeStatus.OPEN_TAG || isMultiSource) {
+        div("chain-node__picker") {
+            id = pickerSlotId
+            // empty — filled by HTMX on chip click
+        }
+    }
+
     // Recurse into children
     for (child in node.children) {
-        renderTargetTree(child, candidateCounts, depth + 1)
+        renderTargetTree(child, candidateCounts, depth + 1, worldId, projectId, encodedTargetId)
     }
 }
 
@@ -157,3 +183,135 @@ fun drillNotFoundFragment(project: Project, reason: String): String = createHTML
         div("callout__body") { +reason }
     }
 }
+
+/**
+ * Picker fragment for one node — source selector or tag-member selector.
+ *
+ * Rendered into `#picker-{nodeSlug}` via innerHTML swap.
+ *
+ * For source nodes (multi-source items): shows all candidate sources sorted by getName(),
+ * capped at [PICKER_MAX_OPTIONS] with a note when truncated. Each option POSTs to the
+ * `/pin` endpoint on click.
+ *
+ * For tag nodes (OPEN_TAG): shows all member items from the tag's .content list, sorted
+ * by name, same cap. Each option POSTs to the `/tag` endpoint.
+ *
+ * When an override is currently active, a "Clear override" control is shown.
+ *
+ * @param worldId  world id
+ * @param projectId  project id
+ * @param targetItemId  the drill target's item id (URL-encoded in HTMX attrs)
+ * @param node  the TargetTree node whose picker to show
+ * @param graph  the live item-source graph (may be null — renders graceful empty state)
+ * @param activeSourceKey  the currently active source override key, if any
+ * @param activeMemberId  the currently active tag-member override id, if any
+ */
+fun nodePickerFragment(
+    worldId: Int,
+    projectId: Int,
+    targetItemId: String,
+    node: TargetTree,
+    graph: ItemSourceGraph?,
+    activeSourceKey: String?,
+    activeMemberId: String?,
+): String {
+    val encodedTargetId = encodeId(targetItemId)
+    val encodedNodeId = encodeId(node.item.id)
+    val baseUrl = "/worlds/$worldId/projects/$projectId/plan/chain/$encodedTargetId"
+    val clearUrl = "$baseUrl/override?node=$encodedNodeId"
+    val isTag = node.status == PlanNodeStatus.OPEN_TAG && node.item is MinecraftTag
+
+    return createHTML().div("picker") {
+        if (isTag) {
+            // Tag-member picker
+            val tag = node.item as MinecraftTag
+            val allMembers = tag.content.sortedBy { it.name }
+            val displayedMembers = allMembers.take(PICKER_MAX_OPTIONS)
+            val truncated = allMembers.size > PICKER_MAX_OPTIONS
+
+            span("section-label picker__label") { +"Pick a variant" }
+
+            div("stack--xs") {
+                for (member in displayedMembers) {
+                    val isSelected = member.id == activeMemberId
+                    div("picker-opt${if (isSelected) " picker-opt--sel" else ""}") {
+                        attributes["hx-post"] = "$baseUrl/tag"
+                        attributes["hx-vals"] = """{"node":"${node.item.id}","memberItemId":"${member.id}"}"""
+                        attributes["hx-target"] = "#project-content"
+                        attributes["hx-swap"] = "outerHTML"
+                        span("picker-opt__name") { +member.name }
+                        if (isSelected) {
+                            span("picker-opt__hint") { +"selected" }
+                        }
+                    }
+                }
+            }
+
+            if (truncated) {
+                p("picker__overflow-note") {
+                    +"Showing $PICKER_MAX_OPTIONS of ${allMembers.size} · ranked picks + search coming soon"
+                }
+            }
+        } else {
+            // Source picker
+            val candidates: List<SourceNode> = graph
+                ?.getSourcesForItem(node.item)
+                ?.sortedBy { it.getName() }
+                ?: emptyList()
+            val displayed = candidates.take(PICKER_MAX_OPTIONS)
+            val truncated = candidates.size > PICKER_MAX_OPTIONS
+
+            span("section-label picker__label") { +"Choose source" }
+
+            if (displayed.isEmpty()) {
+                p("picker__empty") { +"No sources available for this item." }
+            } else {
+                div("stack--xs") {
+                    for (source in displayed) {
+                        val isSelected = source.getKey() == activeSourceKey
+                        div("picker-opt${if (isSelected) " picker-opt--sel" else ""}") {
+                            attributes["hx-post"] = "$baseUrl/pin"
+                            attributes["hx-vals"] = """{"node":"${node.item.id}","sourceKey":"${source.getKey()}"}"""
+                            attributes["hx-target"] = "#project-content"
+                            attributes["hx-swap"] = "outerHTML"
+                            span("picker-opt__name") { +source.getName() }
+                            span("picker-opt__hint") { +source.getMethodLabel() }
+                        }
+                    }
+                }
+            }
+
+            if (truncated) {
+                p("picker__overflow-note") {
+                    +"Showing $PICKER_MAX_OPTIONS of ${candidates.size} · ranked picks + search coming soon"
+                }
+            }
+        }
+
+        // Clear override control — shown when an override is currently active
+        val hasOverride = activeSourceKey != null || activeMemberId != null
+        if (hasOverride) {
+            button(classes = "btn btn--ghost btn--sm picker__clear") {
+                type = ButtonType.button
+                attributes["hx-delete"] = clearUrl
+                attributes["hx-target"] = "#project-content"
+                attributes["hx-swap"] = "outerHTML"
+                +"Clear override"
+            }
+        }
+    }
+}
+
+/**
+ * Graceful fallback fragment for the picker slot when node/plan lookup fails.
+ * Rendered into `#picker-{nodeSlug}` via innerHTML.
+ */
+fun pickerNotFoundFragment(reason: String): String = createHTML().p("picker__empty") { +reason }
+
+// ---------------------------------------------------------------------------
+// Private utilities
+// ---------------------------------------------------------------------------
+
+/** URL-encodes an item or tag id for use in URL path segments. */
+private fun encodeId(id: String): String =
+    URLEncoder.encode(id, StandardCharsets.UTF_8).replace("+", "%20")

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
@@ -30,7 +30,19 @@ fun drillChainFragment(
     candidateCounts: Map<String, Int>,
 ): String = createHTML().div {
     id = "project-content"
+    drillChainContent(project, target, candidateCounts)
+}
 
+/**
+ * The drill body (back-header + chain), rendered into the caller's flow. Shared by
+ * [drillChainFragment] (the HTMX swap response) and the full page shell, so that a
+ * `?drill=` page load renders the same drill inside #project-content.
+ */
+fun FlowContent.drillChainContent(
+    project: Project,
+    target: TargetTree,
+    candidateCounts: Map<String, Int>,
+) {
     val worldId = project.worldId
     val projectId = project.id
     val listFragmentUrl = "/worlds/$worldId/projects/$projectId/detail-content?lens=list"

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
@@ -230,12 +230,17 @@ fun nodePickerFragment(
     activeMemberId: String?,
     demand: Long,
     query: String? = null,
+    origin: String? = null,
 ): String {
     val encodedTargetId = encodeId(targetItemId)
     val encodedNodeId = encodeId(node.item.id)
     val baseUrl = "/worlds/$worldId/projects/$projectId/plan/chain/$encodedTargetId"
-    val clearUrl = "$baseUrl/override?node=$encodedNodeId"
-    val sourcesUrl = "$baseUrl/sources?node=$encodedNodeId"
+    // Carry origin=list through so a resolution made inline from the List lens re-renders
+    // the list, not the drill.
+    val originQuery = if (origin != null) "&origin=$origin" else ""
+    val originJson = if (origin != null) ""","origin":"$origin"""" else ""
+    val clearUrl = "$baseUrl/override?node=$encodedNodeId$originQuery"
+    val sourcesUrl = "$baseUrl/sources?node=$encodedNodeId$originQuery"
     val pickerSlotId = "picker-${node.item.id.replace(Regex("[^a-zA-Z0-9]"), "-")}"
     val isTag = node.status == PlanNodeStatus.OPEN_TAG && node.item is MinecraftTag
     val q = query?.trim().orEmpty()
@@ -265,7 +270,7 @@ fun nodePickerFragment(
                         val isSelected = rm.member.id == activeMemberId
                         div("picker-opt${if (isSelected) " picker-opt--sel" else ""}") {
                             attributes["hx-post"] = "$baseUrl/tag"
-                            attributes["hx-vals"] = """{"node":"${node.item.id}","memberItemId":"${rm.member.id}"}"""
+                            attributes["hx-vals"] = """{"node":"${node.item.id}","memberItemId":"${rm.member.id}"$originJson}"""
                             attributes["hx-target"] = "#project-content"
                             attributes["hx-swap"] = "outerHTML"
                             span("picker-opt__name") { +rm.member.name }
@@ -295,7 +300,7 @@ fun nodePickerFragment(
                         val isSelected = source.getKey() == activeSourceKey
                         div("picker-opt${if (isSelected) " picker-opt--sel" else ""}") {
                             attributes["hx-post"] = "$baseUrl/pin"
-                            attributes["hx-vals"] = """{"node":"${node.item.id}","sourceKey":"${source.getKey()}"}"""
+                            attributes["hx-vals"] = """{"node":"${node.item.id}","sourceKey":"${source.getKey()}"$originJson}"""
                             attributes["hx-target"] = "#project-content"
                             attributes["hx-swap"] = "outerHTML"
                             span("picker-opt__name") { +sourceLabel(source, graph) }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
@@ -1,10 +1,12 @@
 package app.mcorg.presentation.templated.dsl.pages
 
+import app.mcorg.domain.model.minecraft.MinecraftId
 import app.mcorg.domain.model.minecraft.MinecraftTag
 import app.mcorg.domain.model.project.Project
 import app.mcorg.engine.model.ItemSourceGraph
 import app.mcorg.engine.model.SourceNode
 import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.SourceRanking
 import app.mcorg.engine.plan.TargetTree
 import kotlinx.html.*
 import kotlinx.html.stream.createHTML
@@ -226,60 +228,70 @@ fun nodePickerFragment(
     graph: ItemSourceGraph?,
     activeSourceKey: String?,
     activeMemberId: String?,
+    demand: Long,
+    query: String? = null,
 ): String {
     val encodedTargetId = encodeId(targetItemId)
     val encodedNodeId = encodeId(node.item.id)
     val baseUrl = "/worlds/$worldId/projects/$projectId/plan/chain/$encodedTargetId"
     val clearUrl = "$baseUrl/override?node=$encodedNodeId"
+    val sourcesUrl = "$baseUrl/sources?node=$encodedNodeId"
+    val pickerSlotId = "picker-${node.item.id.replace(Regex("[^a-zA-Z0-9]"), "-")}"
     val isTag = node.status == PlanNodeStatus.OPEN_TAG && node.item is MinecraftTag
+    val q = query?.trim().orEmpty()
 
     return createHTML().div("picker") {
         if (isTag) {
-            // Tag-member picker
+            // Tag-member picker — members ranked by the score of their best source.
             val tag = node.item as MinecraftTag
-            val allMembers = tag.content.sortedBy { it.name }
-            val displayedMembers = allMembers.take(PICKER_MAX_OPTIONS)
-            val truncated = allMembers.size > PICKER_MAX_OPTIONS
+            val ranked = tag.content
+                .map { member ->
+                    val best = graph?.let { SourceRanking.rankSources(it, member, demand).firstOrNull() }
+                    RankedMember(member, best?.source, best?.score ?: Int.MIN_VALUE)
+                }
+                .sortedWith(compareByDescending<RankedMember> { it.score }.thenBy { it.member.name })
+            val topId = ranked.firstOrNull()?.member?.id
+            val filtered = if (q.isEmpty()) ranked else ranked.filter { it.member.name.contains(q, ignoreCase = true) }
+            val displayed = filtered.take(PICKER_MAX_OPTIONS)
 
             span("section-label picker__label") { +"Pick a variant" }
+            if (ranked.size > PICKER_MAX_OPTIONS) pickerSearch(sourcesUrl, pickerSlotId, q)
 
-            div("stack--xs") {
-                for (member in displayedMembers) {
-                    val isSelected = member.id == activeMemberId
-                    div("picker-opt${if (isSelected) " picker-opt--sel" else ""}") {
-                        attributes["hx-post"] = "$baseUrl/tag"
-                        attributes["hx-vals"] = """{"node":"${node.item.id}","memberItemId":"${member.id}"}"""
-                        attributes["hx-target"] = "#project-content"
-                        attributes["hx-swap"] = "outerHTML"
-                        span("picker-opt__name") { +member.name }
-                        if (isSelected) {
-                            span("picker-opt__hint") { +"selected" }
+            if (displayed.isEmpty()) {
+                p("picker__empty") { +(if (q.isEmpty()) "No variants available." else "No variants match \"$q\".") }
+            } else {
+                div("stack--xs") {
+                    for (rm in displayed) {
+                        val isSelected = rm.member.id == activeMemberId
+                        div("picker-opt${if (isSelected) " picker-opt--sel" else ""}") {
+                            attributes["hx-post"] = "$baseUrl/tag"
+                            attributes["hx-vals"] = """{"node":"${node.item.id}","memberItemId":"${rm.member.id}"}"""
+                            attributes["hx-target"] = "#project-content"
+                            attributes["hx-swap"] = "outerHTML"
+                            span("picker-opt__name") { +rm.member.name }
+                            pickerOptHint(rm.bestSource?.getMethodLabel(), isBest = rm.member.id == topId, isSelected = isSelected)
                         }
                     }
                 }
             }
-
-            if (truncated) {
-                p("picker__overflow-note") {
-                    +"Showing $PICKER_MAX_OPTIONS of ${allMembers.size} · ranked picks + search coming soon"
-                }
-            }
+            overflowNote(displayed.size, filtered.size, q)
         } else {
-            // Source picker
-            val candidates: List<SourceNode> = graph
-                ?.getSourcesForItem(node.item)
-                ?.sortedBy { it.getName() }
-                ?: emptyList()
-            val displayed = candidates.take(PICKER_MAX_OPTIONS)
-            val truncated = candidates.size > PICKER_MAX_OPTIONS
+            // Source picker — candidates ranked by SelectionScorer (read-only reuse).
+            val ranked = graph?.let { SourceRanking.rankSources(it, node.item, demand) } ?: emptyList()
+            val filtered = if (q.isEmpty()) ranked else ranked.filter { it.source.getName().contains(q, ignoreCase = true) }
+            val displayed = filtered.take(PICKER_MAX_OPTIONS)
 
             span("section-label picker__label") { +"Choose source" }
+            if (ranked.size > PICKER_MAX_OPTIONS) pickerSearch(sourcesUrl, pickerSlotId, q)
 
             if (displayed.isEmpty()) {
-                p("picker__empty") { +"No sources available for this item." }
+                p("picker__empty") {
+                    +(if (ranked.isEmpty()) "No sources available for this item." else "No sources match \"$q\".")
+                }
             } else {
                 div("stack--xs") {
-                    for (source in displayed) {
+                    for (rs in displayed) {
+                        val source = rs.source
                         val isSelected = source.getKey() == activeSourceKey
                         div("picker-opt${if (isSelected) " picker-opt--sel" else ""}") {
                             attributes["hx-post"] = "$baseUrl/pin"
@@ -287,17 +299,12 @@ fun nodePickerFragment(
                             attributes["hx-target"] = "#project-content"
                             attributes["hx-swap"] = "outerHTML"
                             span("picker-opt__name") { +source.getName() }
-                            span("picker-opt__hint") { +source.getMethodLabel() }
+                            pickerOptHint(source.getMethodLabel(), isBest = rs.rank == 0, isSelected = isSelected)
                         }
                     }
                 }
             }
-
-            if (truncated) {
-                p("picker__overflow-note") {
-                    +"Showing $PICKER_MAX_OPTIONS of ${candidates.size} · ranked picks + search coming soon"
-                }
-            }
+            overflowNote(displayed.size, filtered.size, q)
         }
 
         // Clear override control — shown when an override is currently active
@@ -310,6 +317,44 @@ fun nodePickerFragment(
                 attributes["hx-swap"] = "outerHTML"
                 +"Clear override"
             }
+        }
+    }
+}
+
+/** A tag member paired with its best source + that source's score, for ranking. */
+private data class RankedMember(val member: MinecraftId, val bestSource: SourceNode?, val score: Int)
+
+/** The per-option hint line: method label, a "best score ★" marker, and/or "selected". */
+private fun FlowContent.pickerOptHint(methodLabel: String?, isBest: Boolean, isSelected: Boolean) {
+    val parts = listOfNotNull(
+        methodLabel,
+        if (isBest) "best score ★" else null,
+        if (isSelected) "selected" else null,
+    )
+    if (parts.isNotEmpty()) span("picker-opt__hint") { +parts.joinToString(" · ") }
+}
+
+/** A search box that re-fetches the picker filtered by name (high fan-out nodes only). */
+private fun FlowContent.pickerSearch(sourcesUrl: String, pickerSlotId: String, q: String) {
+    div("picker-search") {
+        input(type = InputType.search, classes = "form-control picker-search__input") {
+            name = "q"
+            placeholder = "Search…"
+            value = q
+            attributes["hx-get"] = sourcesUrl
+            attributes["hx-trigger"] = "keyup changed delay:300ms"
+            attributes["hx-target"] = "#$pickerSlotId"
+            attributes["hx-swap"] = "innerHTML"
+            attributes["hx-vals"] = "js:{q: this.value}"
+        }
+    }
+}
+
+/** "Showing N of M" note when the (filtered) list is capped. */
+private fun FlowContent.overflowNote(shown: Int, matching: Int, q: String) {
+    if (matching > shown) {
+        p("picker__overflow-note") {
+            +("Showing $shown of $matching" + if (q.isEmpty()) " · search to narrow" else "")
         }
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -779,6 +779,7 @@ fun gatheringPlannerFragment(
     lens: String = "list",
     progressMap: Map<String, Int> = emptyMap(),
 ): String = createHTML().div {
+    id = "project-content"
     gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap)
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -49,6 +49,7 @@ fun projectDetailPage(
     progressMap: Map<String, Int> = emptyMap(),
     drillTarget: TargetTree? = null,
     drillCandidateCounts: Map<String, Int> = emptyMap(),
+    drillNodeIngredients: Map<String, String> = emptyMap(),
 ): String = pageShell(
     pageTitle = "Seam — ${project.name}",
     user = user,
@@ -109,7 +110,7 @@ fun projectDetailPage(
                 id = "project-content"
                 if (drillTarget != null) {
                     // ?drill=<item> deep-links straight into a target's chain (reload/share-safe).
-                    drillChainContent(project, drillTarget, drillCandidateCounts)
+                    drillChainContent(project, drillTarget, drillCandidateCounts, drillNodeIngredients)
                 } else {
                     gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap)
                 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -33,6 +33,8 @@ import app.mcorg.presentation.templated.dsl.tabStrip
 import app.mcorg.presentation.templated.dsl.taskList
 import kotlinx.html.*
 import kotlinx.html.stream.createHTML
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
 fun projectDetailPage(
     user: TokenProfile,
@@ -58,6 +60,7 @@ fun projectDetailPage(
         "/static/styles/components/resource-search.css",
         "/static/styles/components/resource-panel.css",
         "/static/styles/components/callout.css",
+        "/static/styles/components/drill.css",
         "/static/styles/pages/project-detail.css",
     ),
     scripts = listOf(
@@ -410,29 +413,32 @@ private fun FlowContent.planActivityRow(
     progressMap: Map<String, Int> = emptyMap(),
 ) {
     when (activity.status) {
-        PlanNodeStatus.SUPPLIED -> suppliedActivityRow(activity)
-        PlanNodeStatus.OPEN_TAG -> openTagActivityRow(activity)
-        PlanNodeStatus.BLOCKED -> blockedActivityRow(activity)
+        PlanNodeStatus.SUPPLIED -> suppliedActivityRow(worldId, projectId, activity)
+        PlanNodeStatus.OPEN_TAG -> openTagActivityRow(worldId, projectId, activity)
+        PlanNodeStatus.BLOCKED -> blockedActivityRow(worldId, projectId, activity)
         PlanNodeStatus.RESOLVED, PlanNodeStatus.RAW_GATHER ->
             counterActivityRow(worldId, projectId, activity, progressMap)
     }
 }
 
 /** SUPPLIED row: badge + supply label, no counter. */
-private fun FlowContent.suppliedActivityRow(activity: Activity) {
+private fun FlowContent.suppliedActivityRow(worldId: Int, projectId: Int, activity: Activity) {
     val supplyLabel = activity.supply?.label ?: "Supplied"
+    val encodedItemId = URLEncoder.encode(activity.item.id, StandardCharsets.UTF_8)
     div("resource-row") {
         id = "plan-activity-${activity.item.id.replace(":", "-")}"
         div("resource-row__desktop") {
             div("resource-row__name") { +activity.item.name }
             span("badge badge--accent") { +"Supplied" }
             span("resource-row__source") { +"from $supplyLabel" }
+            drillButton(worldId, projectId, encodedItemId)
         }
     }
 }
 
 /** OPEN_TAG row: amber callout, indicates variant pick needed. */
-private fun FlowContent.openTagActivityRow(activity: Activity) {
+private fun FlowContent.openTagActivityRow(worldId: Int, projectId: Int, activity: Activity) {
+    val encodedItemId = URLEncoder.encode(activity.item.id, StandardCharsets.UTF_8)
     div("callout callout--warning") {
         id = "plan-activity-${activity.item.id.replace(":", "-")}"
         span("callout__icon") { +"!" }
@@ -440,11 +446,13 @@ private fun FlowContent.openTagActivityRow(activity: Activity) {
             span { +activity.item.name }
             +" — Pick a variant (open tag)"
         }
+        drillButton(worldId, projectId, encodedItemId)
     }
 }
 
 /** BLOCKED row: warning callout. */
-private fun FlowContent.blockedActivityRow(activity: Activity) {
+private fun FlowContent.blockedActivityRow(worldId: Int, projectId: Int, activity: Activity) {
+    val encodedItemId = URLEncoder.encode(activity.item.id, StandardCharsets.UTF_8)
     div("callout callout--warning") {
         id = "plan-activity-${activity.item.id.replace(":", "-")}"
         span("callout__icon") { +"!" }
@@ -453,6 +461,7 @@ private fun FlowContent.blockedActivityRow(activity: Activity) {
             +activity.item.name
             +" — no feasible source found"
         }
+        drillButton(worldId, projectId, encodedItemId)
     }
 }
 
@@ -473,6 +482,7 @@ fun FlowContent.counterActivityRow(
     val current = (progressMap[activity.item.id] ?: 0).toLong().coerceIn(0, required)
     val percent = if (required > 0) (current * 100 / required).toInt() else 0
     val sourceLabel = activity.source?.getMethodLabel()
+    val encodedItemId = URLEncoder.encode(activity.item.id, StandardCharsets.UTF_8)
 
     div("resource-row") {
         id = rowId
@@ -501,6 +511,8 @@ fun FlowContent.counterActivityRow(
                 span("resource-row__source") { +sourceLabel }
             }
 
+            drillButton(worldId, projectId, encodedItemId)
+
             div("resource-row__counters") {
                 intArrayOf(-1728, -64, -1, 1, 64, 1728).forEach { amount ->
                     button(classes = "btn btn--ghost btn--sm resource-row__counter-btn") {
@@ -515,6 +527,24 @@ fun FlowContent.counterActivityRow(
                 }
             }
         }
+    }
+}
+
+/**
+ * The ⇄ drill button that navigates to the chain drill view for an activity's item.
+ * [encodedItemId] must be URL-encoded (e.g. `%23minecraft:planks` for tag ids with `#`).
+ */
+private fun FlowContent.drillButton(worldId: Int, projectId: Int, encodedItemId: String) {
+    val drillUrl = "/worlds/$worldId/projects/$projectId/plan/chain/$encodedItemId"
+    val pushUrl = "/worlds/$worldId/projects/$projectId?drill=$encodedItemId"
+    button(classes = "btn btn--ghost btn--sm") {
+        type = ButtonType.button
+        attributes["hx-get"] = drillUrl
+        attributes["hx-target"] = "#project-content"
+        attributes["hx-swap"] = "outerHTML"
+        attributes["hx-push-url"] = pushUrl
+        attributes["aria-label"] = "View source chain"
+        +"⇄"
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -447,6 +447,7 @@ private fun FlowContent.suppliedActivityRow(worldId: Int, projectId: Int, activi
 /** OPEN_TAG row: amber callout, indicates variant pick needed. */
 private fun FlowContent.openTagActivityRow(worldId: Int, projectId: Int, activity: Activity) {
     val encodedItemId = URLEncoder.encode(activity.item.id, StandardCharsets.UTF_8)
+    val pickerSlotId = "picker-${activity.item.id.replace(Regex("[^a-zA-Z0-9]"), "-")}"
     div("callout callout--warning") {
         id = "plan-activity-${activity.item.id.replace(":", "-")}"
         span("callout__icon") { +"!" }
@@ -454,8 +455,20 @@ private fun FlowContent.openTagActivityRow(worldId: Int, projectId: Int, activit
             span { +activity.item.name }
             +" — Pick a variant (open tag)"
         }
+        // Resolve inline: drops the tag-member picker below this row; a pick re-renders the
+        // List lens (origin=list) so the resolved tag leaves "Needs attention".
+        button(classes = "btn btn--primary btn--sm") {
+            type = ButtonType.button
+            attributes["hx-get"] =
+                "/worlds/$worldId/projects/$projectId/plan/chain/$encodedItemId/sources?node=$encodedItemId&origin=list"
+            attributes["hx-target"] = "#$pickerSlotId"
+            attributes["hx-swap"] = "innerHTML"
+            +"Pick variant"
+        }
+        // ⇄ still opens the full drill to explore/re-pin the whole chain.
         drillButton(worldId, projectId, encodedItemId)
     }
+    div("chain-node__picker") { id = pickerSlotId }
 }
 
 /** BLOCKED row: warning callout. */

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -33,6 +33,7 @@ import app.mcorg.presentation.templated.dsl.tabStrip
 import app.mcorg.presentation.templated.dsl.taskList
 import kotlinx.html.*
 import kotlinx.html.stream.createHTML
+import app.mcorg.engine.plan.TargetTree
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
@@ -46,6 +47,8 @@ fun projectDetailPage(
     isWorldAdmin: Boolean = false,
     plan: GatheringPlan? = null,
     progressMap: Map<String, Int> = emptyMap(),
+    drillTarget: TargetTree? = null,
+    drillCandidateCounts: Map<String, Int> = emptyMap(),
 ): String = pageShell(
     pageTitle = "Seam — ${project.name}",
     user = user,
@@ -104,7 +107,12 @@ fun projectDetailPage(
 
             div {
                 id = "project-content"
-                gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap)
+                if (drillTarget != null) {
+                    // ?drill=<item> deep-links straight into a target's chain (reload/share-safe).
+                    drillChainContent(project, drillTarget, drillCandidateCounts)
+                } else {
+                    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap)
+                }
             }
         }
     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -508,9 +508,11 @@ fun FlowContent.counterActivityRow(
     val required = activity.quantity
     val current = (progressMap[activity.item.id] ?: 0).toLong().coerceIn(0, required)
     val percent = if (required > 0) (current * 100 / required).toInt() else 0
-    // Method + ingredients ("Smelting · 1 Raw Iron") so the row states how the item is made
-    // and what it consumes — the chain relationships, visible without drilling.
-    val sourceLabel = listOfNotNull(activity.source?.getMethodLabel(), nodeIngredients[activity.item.id])
+    // Method + detail: ingredients for recipes ("Smelting · 1 Raw Iron"), or the loot location
+    // for a pinned loot source ("Chest Loot · Desert pyramid") — the relationship/source,
+    // visible without drilling.
+    val detail = nodeIngredients[activity.item.id] ?: activity.source?.let { lootTableName(it) }
+    val sourceLabel = listOfNotNull(activity.source?.getMethodLabel(), detail)
         .joinToString(" · ")
         .ifEmpty { null }
     val encodedItemId = URLEncoder.encode(activity.item.id, StandardCharsets.UTF_8)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -34,6 +34,7 @@ import app.mcorg.presentation.templated.dsl.taskList
 import kotlinx.html.*
 import kotlinx.html.stream.createHTML
 import app.mcorg.engine.plan.TargetTree
+import app.mcorg.pipeline.resources.buildNodeIngredients
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
@@ -50,6 +51,7 @@ fun projectDetailPage(
     drillTarget: TargetTree? = null,
     drillCandidateCounts: Map<String, Int> = emptyMap(),
     drillNodeIngredients: Map<String, String> = emptyMap(),
+    drillHighlightItemId: String? = null,
 ): String = pageShell(
     pageTitle = "Seam — ${project.name}",
     user = user,
@@ -110,7 +112,7 @@ fun projectDetailPage(
                 id = "project-content"
                 if (drillTarget != null) {
                     // ?drill=<item> deep-links straight into a target's chain (reload/share-safe).
-                    drillChainContent(project, drillTarget, drillCandidateCounts, drillNodeIngredients)
+                    drillChainContent(project, drillTarget, drillCandidateCounts, drillNodeIngredients, drillHighlightItemId)
                 } else {
                     gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap)
                 }
@@ -395,6 +397,7 @@ fun FlowContent.gatheringPlanSections(
 
     val byGroup = plan.activityList.groupBy { it.group }
     val groupOrder = ActivityGroup.values()
+    val nodeIngredients = buildNodeIngredients(plan)
 
     div {
         id = "gathering-plan-sections"
@@ -406,7 +409,7 @@ fun FlowContent.gatheringPlanSections(
                 span("section-label") { +groupLabel(group) }
                 div("resource-list") {
                     activities.forEach { activity ->
-                        planActivityRow(project.worldId, project.id, activity, progressMap)
+                        planActivityRow(project.worldId, project.id, activity, progressMap, nodeIngredients)
                     }
                 }
             }
@@ -420,13 +423,14 @@ private fun FlowContent.planActivityRow(
     projectId: Int,
     activity: Activity,
     progressMap: Map<String, Int> = emptyMap(),
+    nodeIngredients: Map<String, String> = emptyMap(),
 ) {
     when (activity.status) {
         PlanNodeStatus.SUPPLIED -> suppliedActivityRow(worldId, projectId, activity)
         PlanNodeStatus.OPEN_TAG -> openTagActivityRow(worldId, projectId, activity)
         PlanNodeStatus.BLOCKED -> blockedActivityRow(worldId, projectId, activity)
         PlanNodeStatus.RESOLVED, PlanNodeStatus.RAW_GATHER ->
-            counterActivityRow(worldId, projectId, activity, progressMap)
+            counterActivityRow(worldId, projectId, activity, progressMap, nodeIngredients)
     }
 }
 
@@ -497,13 +501,18 @@ fun FlowContent.counterActivityRow(
     projectId: Int,
     activity: Activity,
     progressMap: Map<String, Int> = emptyMap(),
+    nodeIngredients: Map<String, String> = emptyMap(),
 ) {
     val itemSlug = activity.item.id.replace(":", "-")
     val rowId = "plan-activity-$itemSlug"
     val required = activity.quantity
     val current = (progressMap[activity.item.id] ?: 0).toLong().coerceIn(0, required)
     val percent = if (required > 0) (current * 100 / required).toInt() else 0
-    val sourceLabel = activity.source?.getMethodLabel()
+    // Method + ingredients ("Smelting · 1 Raw Iron") so the row states how the item is made
+    // and what it consumes — the chain relationships, visible without drilling.
+    val sourceLabel = listOfNotNull(activity.source?.getMethodLabel(), nodeIngredients[activity.item.id])
+        .joinToString(" · ")
+        .ifEmpty { null }
     val encodedItemId = URLEncoder.encode(activity.item.id, StandardCharsets.UTF_8)
 
     div("resource-row") {

--- a/webapp/mc-web/src/main/resources/static/styles/components/drill.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/drill.css
@@ -154,6 +154,16 @@
     white-space: nowrap;
 }
 
+/* Search box for high-fan-out pickers */
+.picker-search {
+    margin-bottom: var(--space-2);
+}
+
+.picker-search__input {
+    width: 100%;
+    font-size: var(--text-sm);
+}
+
 /* Truncation note when candidates exceed the cap */
 .picker__overflow-note {
     font-size: var(--text-xs);

--- a/webapp/mc-web/src/main/resources/static/styles/components/drill.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/drill.css
@@ -1,0 +1,101 @@
+/* ==========================================================================
+   DRILL VIEW — chain view for a single plan target
+   ========================================================================== */
+
+/* Back header row + hint label */
+.drill-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+    margin-bottom: var(--space-3);
+}
+
+/* Chain container card */
+.drill-chain {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+/* One row per item in the chain */
+.chain-node {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-surface);
+}
+
+.chain-node:last-child {
+    border-bottom: none;
+}
+
+/* Depth indentation — each level adds one unit of padding-left */
+.chain-node--depth-0 { padding-left: var(--space-4); }
+.chain-node--depth-1 { padding-left: var(--space-6); }
+.chain-node--depth-2 { padding-left: var(--space-8); }
+.chain-node--depth-3 { padding-left: calc(var(--space-8) + var(--space-4)); }
+.chain-node--depth-4 { padding-left: calc(var(--space-8) + var(--space-6)); }
+
+/* Item name + method hint */
+.chain-node__name {
+    flex: 1;
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+}
+
+.chain-node__method {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    margin-left: var(--space-2);
+}
+
+/* Quantity number */
+.chain-node__qty {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+/* "· 1 way" forced-source label */
+.chain-node__forced {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+/* ⇄ source chip — placeholder button (no-op in Phase 1) */
+.chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: 2px var(--space-3);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-raised);
+    color: var(--accent);
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    cursor: default;          /* Phase 1: no-op */
+    white-space: nowrap;
+    flex-shrink: 0;
+    transition: background var(--transition-base);
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+    .chain-node {
+        flex-wrap: wrap;
+        gap: var(--space-2);
+    }
+
+    .chain-node__name {
+        flex-basis: 100%;
+    }
+}

--- a/webapp/mc-web/src/main/resources/static/styles/components/drill.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/drill.css
@@ -69,7 +69,12 @@
     flex-shrink: 0;
 }
 
-/* ⇄ source chip — placeholder button (no-op in Phase 1) */
+/* Picker slot below a chain-node row — starts empty, fills on chip click */
+.chain-node__picker {
+    /* no default styles — content injected by HTMX */
+}
+
+/* ⇄ source chip — interactive button */
 .chip {
     display: inline-flex;
     align-items: center;
@@ -82,10 +87,90 @@
     font-family: var(--font-ui);
     font-size: var(--text-xs);
     font-weight: 500;
-    cursor: default;          /* Phase 1: no-op */
+    cursor: pointer;
     white-space: nowrap;
     flex-shrink: 0;
     transition: background var(--transition-base);
+}
+
+.chip:hover {
+    background: var(--accent-muted);
+    border-color: var(--accent);
+}
+
+/* ==========================================================================
+   PICKER — source / tag-member selector panel
+   ========================================================================== */
+
+.picker {
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-raised);
+}
+
+.picker__label {
+    display: block;
+    margin-bottom: var(--space-2);
+}
+
+/* One selectable option row */
+.picker-opt {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-surface);
+    cursor: pointer;
+    transition: background var(--transition-base), border-color var(--transition-base);
+}
+
+.picker-opt:hover {
+    background: var(--accent-muted);
+    border-color: var(--accent);
+}
+
+/* Currently selected option */
+.picker-opt--sel {
+    background: var(--accent-muted);
+    border-color: var(--accent);
+}
+
+.picker-opt--sel .picker-opt__name {
+    font-weight: 600;
+    color: var(--accent);
+}
+
+.picker-opt__name {
+    flex: 1;
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+}
+
+.picker-opt__hint {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
+/* Truncation note when candidates exceed the cap */
+.picker__overflow-note {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    margin-top: var(--space-2);
+    text-align: center;
+}
+
+/* Empty state / fallback text */
+.picker__empty {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+/* "Clear override" button */
+.picker__clear {
+    margin-top: var(--space-2);
 }
 
 /* Mobile */
@@ -97,5 +182,9 @@
 
     .chain-node__name {
         flex-basis: 100%;
+    }
+
+    .picker {
+        padding: var(--space-2) var(--space-3);
     }
 }

--- a/webapp/mc-web/src/main/resources/static/styles/components/drill.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/drill.css
@@ -32,6 +32,12 @@
     border-bottom: none;
 }
 
+/* The node the user drilled into — emphasised so it's findable in its chain. */
+.chain-node--current {
+    background: var(--accent-muted);
+    box-shadow: inset 3px 0 0 var(--accent);
+}
+
 /* Depth indentation — each level adds one unit of padding-left */
 .chain-node--depth-0 { padding-left: var(--space-4); }
 .chain-node--depth-1 { padding-left: var(--space-6); }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/DrillTreeResolutionTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/DrillTreeResolutionTest.kt
@@ -67,4 +67,42 @@ class DrillTreeResolutionTest {
     fun `returns null for an item not in the plan at all`() {
         assertNull(hopperPlan().drillTreeFor("minecraft:diamond"))
     }
+
+    // ── buildNodeIngredients ──────────────────────────────────────────────────
+
+    private fun craftPlan(): GatheringPlan = GatheringPlan(
+        nodes = mapOf(
+            // produces 2 hoppers per craft, consuming 10 iron + 2 chest → 5 iron + 1 chest each
+            "minecraft:hopper" to PlanNode(
+                item = Item("minecraft:hopper", "Hopper"),
+                quantity = 2, crafts = 1, leftover = 0, status = PlanNodeStatus.RESOLVED, producedQuantity = 2,
+                requires = listOf(PlanRequirement("minecraft:iron_ingot", 10), PlanRequirement("minecraft:chest", 2)),
+            ),
+            // produces 8 planks per craft from 2 logs → 0.25 log each
+            "minecraft:oak_planks" to PlanNode(
+                item = Item("minecraft:oak_planks", "Oak Planks"),
+                quantity = 8, crafts = 1, leftover = 0, status = PlanNodeStatus.RESOLVED, producedQuantity = 8,
+                requires = listOf(PlanRequirement("minecraft:oak_log", 2)),
+            ),
+            "minecraft:iron_ingot" to PlanNode(Item("minecraft:iron_ingot", "Iron Ingot"), 10, 10, 0, PlanNodeStatus.RAW_GATHER),
+            "minecraft:chest" to PlanNode(Item("minecraft:chest", "Chest"), 2, 2, 0, PlanNodeStatus.RAW_GATHER),
+            "minecraft:oak_log" to PlanNode(Item("minecraft:oak_log", "Oak Log"), 2, 2, 0, PlanNodeStatus.RAW_GATHER),
+        ),
+        targets = listOf(PlanTarget(Item("minecraft:hopper", "Hopper"), 2)),
+    )
+
+    @Test
+    fun `ingredients normalise per output and sort by name`() {
+        assertEquals("1 Chest + 5 Iron Ingot", buildNodeIngredients(craftPlan())["minecraft:hopper"])
+    }
+
+    @Test
+    fun `ingredients keep a clean decimal for sub-one ratios`() {
+        assertEquals("0.25 Oak Log", buildNodeIngredients(craftPlan())["minecraft:oak_planks"])
+    }
+
+    @Test
+    fun `terminals have no ingredient entry`() {
+        assertNull(buildNodeIngredients(craftPlan())["minecraft:iron_ingot"])
+    }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/DrillTreeResolutionTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/DrillTreeResolutionTest.kt
@@ -101,8 +101,9 @@ class DrillTreeResolutionTest {
     }
 
     @Test
-    fun `ingredients keep a clean decimal for sub-one ratios`() {
-        assertEquals("0.25 Oak Log", buildNodeIngredients(craftPlan())["minecraft:oak_planks"])
+    fun `multi-output recipes read as a reduced ratio, not a fraction`() {
+        // 2 logs → 8 planks reduces to 1 log → 4 planks.
+        assertEquals("1 Oak Log → 4", buildNodeIngredients(craftPlan())["minecraft:oak_planks"])
     }
 
     @Test

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/DrillTreeResolutionTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/DrillTreeResolutionTest.kt
@@ -7,6 +7,7 @@ import app.mcorg.engine.plan.PlanNodeStatus
 import app.mcorg.engine.plan.PlanRequirement
 import app.mcorg.engine.plan.PlanTarget
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import org.junit.jupiter.api.Test
 
@@ -52,15 +53,18 @@ class DrillTreeResolutionTest {
     }
 
     @Test
-    fun `resolves a derived intermediate as a subtree of its target`() {
+    fun `derived intermediate resolves to the full chain of its target, containing the item`() {
         val tree = hopperPlan().drillTreeFor("minecraft:oak_planks")
-        assertEquals("minecraft:oak_planks", tree?.item?.id, "Derived planks should resolve via the hopper chain")
+        // Full containing chain (rooted at the target), not the isolated planks subtree.
+        assertEquals("minecraft:hopper", tree?.item?.id)
+        assertNotNull(tree?.let { findNodeById(it, "minecraft:oak_planks") }, "planks present within the chain")
     }
 
     @Test
-    fun `resolves a deeper derived node`() {
+    fun `deeper derived node resolves to its target chain`() {
         val tree = hopperPlan().drillTreeFor("minecraft:iron_ingot")
-        assertEquals("minecraft:iron_ingot", tree?.item?.id)
+        assertEquals("minecraft:hopper", tree?.item?.id)
+        assertNotNull(tree?.let { findNodeById(it, "minecraft:iron_ingot") })
     }
 
     @Test

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/DrillTreeResolutionTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/DrillTreeResolutionTest.kt
@@ -1,0 +1,70 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.engine.plan.PlanNode
+import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.PlanRequirement
+import app.mcorg.engine.plan.PlanTarget
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * [drillTreeFor] must resolve a drill subtree for ANY item in the plan — both the
+ * project's defined targets and derived intermediates (which `perTarget` alone rejects).
+ * Regression for "'#minecraft:planks' is not a target in this plan".
+ */
+class DrillTreeResolutionTest {
+
+    // hopper (target) -> chest -> planks ; hopper -> iron_ingot
+    private fun hopperPlan(): GatheringPlan {
+        val nodes = mapOf(
+            "minecraft:hopper" to PlanNode(
+                item = Item("minecraft:hopper", "Hopper"),
+                quantity = 1, crafts = 1, leftover = 0, status = PlanNodeStatus.RESOLVED,
+                requires = listOf(
+                    PlanRequirement("minecraft:chest", 1),
+                    PlanRequirement("minecraft:iron_ingot", 5),
+                ),
+            ),
+            "minecraft:chest" to PlanNode(
+                item = Item("minecraft:chest", "Chest"),
+                quantity = 1, crafts = 1, leftover = 0, status = PlanNodeStatus.RESOLVED,
+                requires = listOf(PlanRequirement("minecraft:oak_planks", 8)),
+            ),
+            "minecraft:oak_planks" to PlanNode(
+                item = Item("minecraft:oak_planks", "Oak Planks"),
+                quantity = 8, crafts = 2, leftover = 0, status = PlanNodeStatus.RAW_GATHER,
+            ),
+            "minecraft:iron_ingot" to PlanNode(
+                item = Item("minecraft:iron_ingot", "Iron Ingot"),
+                quantity = 5, crafts = 5, leftover = 0, status = PlanNodeStatus.RAW_GATHER,
+            ),
+        )
+        return GatheringPlan(nodes = nodes, targets = listOf(PlanTarget(Item("minecraft:hopper", "Hopper"), 1)))
+    }
+
+    @Test
+    fun `resolves the defined target directly`() {
+        val tree = hopperPlan().drillTreeFor("minecraft:hopper")
+        assertEquals("minecraft:hopper", tree?.item?.id)
+    }
+
+    @Test
+    fun `resolves a derived intermediate as a subtree of its target`() {
+        val tree = hopperPlan().drillTreeFor("minecraft:oak_planks")
+        assertEquals("minecraft:oak_planks", tree?.item?.id, "Derived planks should resolve via the hopper chain")
+    }
+
+    @Test
+    fun `resolves a deeper derived node`() {
+        val tree = hopperPlan().drillTreeFor("minecraft:iron_ingot")
+        assertEquals("minecraft:iron_ingot", tree?.item?.id)
+    }
+
+    @Test
+    fun `returns null for an item not in the plan at all`() {
+        assertNull(hopperPlan().drillTreeFor("minecraft:diamond"))
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanChainIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanChainIT.kt
@@ -4,7 +4,11 @@ import app.mcorg.domain.model.minecraft.MinecraftVersion
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.resources.handleClearOverride
 import app.mcorg.pipeline.resources.handleGetDrillChain
+import app.mcorg.pipeline.resources.handleGetNodePicker
+import app.mcorg.pipeline.resources.handlePinSource
+import app.mcorg.pipeline.resources.handleResolveTagMember
 import app.mcorg.pipeline.resources.handleUpdatePlanProgress
 import app.mcorg.pipeline.world.CreateWorldInput
 import app.mcorg.pipeline.world.CreateWorldStep
@@ -14,10 +18,16 @@ import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.delete
+import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.get
+import io.ktor.client.request.post
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.server.routing.delete
 import io.ktor.server.routing.get
+import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
@@ -29,18 +39,22 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 /**
- * Integration tests for GET /worlds/{worldId}/projects/{projectId}/plan/chain/{itemId}.
+ * Integration tests for the plan chain drill endpoints:
  *
- * The Testcontainers DB has no ingested Minecraft graph, so a real perTarget plan cannot
- * be derived. These tests cover:
- * - Route exists and auth is enforced
- * - Graceful fallback when the plan cannot be derived (no resources → ValidationError)
- * - Graceful fallback when the item is not a target (plan unavailable → same fallback)
+ *   GET  /plan/chain/{itemId}              — drill view (Phase 1, unchanged)
+ *   GET  /plan/chain/{itemId}/sources      — node picker
+ *   POST /plan/chain/{itemId}/pin          — pin source override
+ *   POST /plan/chain/{itemId}/tag          — resolve tag member override
+ *   DELETE /plan/chain/{itemId}/override   — clear override
  *
- * Rich plan rendering (with candidate counts, chip/forced labels, depth) is covered
- * by the DrillViewTest unit test.
+ * The Testcontainers DB has no ingested Minecraft graph, so real plan derivation
+ * fails gracefully. The override persistence tests assert DB state directly via
+ * query helpers — the re-render may fall back to the not-found fragment but the
+ * DB row change is the real behaviour under test.
  */
 @Tag("database")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -54,15 +68,17 @@ class PlanChainIT : WithUser() {
     fun setup() {
         worldId = createWorld()
         projectId = createProject(worldId)
+        // Add a resource row so param plugins resolve (project exists)
+        createResourceGathering(projectId)
     }
 
     // -------------------------------------------------------------------------
-    // Auth
+    // Auth — GET chain
     // -------------------------------------------------------------------------
 
     @Test
     fun `GET chain without auth returns redirect`() = testApplication {
-        setupRoutes()
+        setupAllRoutes()
 
         val unauthClient = createClient { followRedirects = false }
         val response = unauthClient.get(
@@ -78,7 +94,7 @@ class PlanChainIT : WithUser() {
 
     @Test
     fun `GET chain responds 200 with fallback fragment when plan cannot be derived`() = testApplication {
-        setupRoutes()
+        setupAllRoutes()
 
         val response = client.get(
             "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot"
@@ -100,7 +116,7 @@ class PlanChainIT : WithUser() {
     fun `GET chain with an item that has no resources defined returns graceful fragment`() = testApplication {
         // Empty project: no resource_gathering rows → ValidationError from GenerateGatheringPlanStep
         val emptyProjectId = createProject(worldId)
-        setupRoutes()
+        setupAllRoutes()
 
         val response = client.get(
             "/worlds/$worldId/projects/$emptyProjectId/plan/chain/minecraft:oak_log"
@@ -117,7 +133,7 @@ class PlanChainIT : WithUser() {
 
     @Test
     fun `GET chain with URL-encoded tag id responds 200 with graceful fallback`() = testApplication {
-        setupRoutes()
+        setupAllRoutes()
 
         // Tag ids have a '#' prefix — must be percent-encoded in the URL
         val response = client.get(
@@ -133,7 +149,7 @@ class PlanChainIT : WithUser() {
 
     @Test
     fun `GET chain back-to-plan link points to list lens`() = testApplication {
-        setupRoutes()
+        setupAllRoutes()
 
         val response = client.get(
             "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot"
@@ -148,10 +164,307 @@ class PlanChainIT : WithUser() {
     }
 
     // -------------------------------------------------------------------------
-    // Routing helpers
+    // GET /sources — node picker
     // -------------------------------------------------------------------------
 
-    private fun ApplicationTestBuilder.setupRoutes() {
+    @Test
+    fun `GET sources without auth returns redirect`() = testApplication {
+        setupAllRoutes()
+
+        val unauthClient = createClient { followRedirects = false }
+        val response = unauthClient.get(
+            "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot/sources?node=minecraft:iron_ingot"
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+    }
+
+    @Test
+    fun `GET sources without node param returns 400`() = testApplication {
+        setupAllRoutes()
+
+        val response = client.get(
+            "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot/sources"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `GET sources with missing plan returns graceful picker fragment`() = testApplication {
+        setupAllRoutes()
+
+        // No graph — plan derivation fails; picker falls back gracefully
+        val response = client.get(
+            "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot/sources?node=minecraft:iron_ingot"
+        ) {
+            addAuthCookie(this)
+        }
+
+        // Returns 200 with a graceful fallback picker fragment (plan not available)
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        // Must return some HTML (graceful — not a crash)
+        assertContains(body, "picker")
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /pin — source override persistence
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `POST pin without auth returns redirect`() = testApplication {
+        setupAllRoutes()
+
+        val unauthClient = createClient { followRedirects = false }
+        val response = unauthClient.submitForm(
+            url = "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot/pin",
+            formParameters = Parameters.build {
+                append("node", "minecraft:iron_ingot")
+                append("sourceKey", "minecraft:block:blocks/iron_ore.json")
+            }
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+    }
+
+    @Test
+    fun `POST pin with missing node param returns 400`() = testApplication {
+        setupAllRoutes()
+
+        val response = client.submitForm(
+            url = "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot/pin",
+            formParameters = Parameters.build {
+                append("sourceKey", "minecraft:block:blocks/iron_ore.json")
+            }
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `POST pin with missing sourceKey param returns 400`() = testApplication {
+        setupAllRoutes()
+
+        val response = client.submitForm(
+            url = "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot/pin",
+            formParameters = Parameters.build {
+                append("node", "minecraft:iron_ingot")
+            }
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `POST pin persists source override row in DB`() = testApplication {
+        val pid = createProject(worldId)
+        createResourceGathering(pid)
+        setupAllRoutes()
+
+        val nodeId = "minecraft:iron_ingot"
+        val sourceKey = "minecraft:block:blocks/iron_ore.json"
+
+        val response = client.submitForm(
+            url = "/worlds/$worldId/projects/$pid/plan/chain/minecraft:iron_ingot/pin",
+            formParameters = Parameters.build {
+                append("node", nodeId)
+                append("sourceKey", sourceKey)
+            }
+        ) {
+            addAuthCookie(this)
+        }
+
+        // Re-render returns 200 (may be fallback fragment since no graph)
+        assertEquals(HttpStatusCode.OK, response.status)
+        // DB row persisted
+        val override = getOverrideRow(pid, nodeId)
+        assertNotNull(override, "Expected override row in DB after POST /pin")
+        assertEquals(sourceKey, override.sourceKey)
+        assertNull(override.tagMember)
+    }
+
+    @Test
+    fun `POST pin re-render response is HTML fragment`() = testApplication {
+        val pid = createProject(worldId)
+        createResourceGathering(pid)
+        setupAllRoutes()
+
+        val response = client.submitForm(
+            url = "/worlds/$worldId/projects/$pid/plan/chain/minecraft:iron_ingot/pin",
+            formParameters = Parameters.build {
+                append("node", "minecraft:iron_ingot")
+                append("sourceKey", "minecraft:block:blocks/iron_ore.json")
+            }
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        // Always renders into #project-content
+        assertContains(response.bodyAsText(), "project-content")
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /tag — tag member override persistence
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `POST tag without auth returns redirect`() = testApplication {
+        setupAllRoutes()
+
+        val unauthClient = createClient { followRedirects = false }
+        val response = unauthClient.submitForm(
+            url = "/worlds/$worldId/projects/$projectId/plan/chain/%23minecraft:planks/tag",
+            formParameters = Parameters.build {
+                append("node", "#minecraft:planks")
+                append("memberItemId", "minecraft:oak_planks")
+            }
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+    }
+
+    @Test
+    fun `POST tag with missing node param returns 400`() = testApplication {
+        setupAllRoutes()
+
+        val response = client.submitForm(
+            url = "/worlds/$worldId/projects/$projectId/plan/chain/%23minecraft:planks/tag",
+            formParameters = Parameters.build {
+                append("memberItemId", "minecraft:oak_planks")
+            }
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `POST tag with missing memberItemId param returns 400`() = testApplication {
+        setupAllRoutes()
+
+        val response = client.submitForm(
+            url = "/worlds/$worldId/projects/$projectId/plan/chain/%23minecraft:planks/tag",
+            formParameters = Parameters.build {
+                append("node", "#minecraft:planks")
+            }
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `POST tag persists tag member override row in DB`() = testApplication {
+        val pid = createProject(worldId)
+        createResourceGathering(pid)
+        setupAllRoutes()
+
+        val tagId = "#minecraft:planks"
+        val memberId = "minecraft:oak_planks"
+
+        val response = client.submitForm(
+            url = "/worlds/$worldId/projects/$pid/plan/chain/minecraft:iron_ingot/tag",
+            formParameters = Parameters.build {
+                append("node", tagId)
+                append("memberItemId", memberId)
+            }
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        // DB row persisted
+        val override = getOverrideRow(pid, tagId)
+        assertNotNull(override, "Expected override row in DB after POST /tag")
+        assertEquals(memberId, override.tagMember)
+        assertNull(override.sourceKey)
+    }
+
+    // -------------------------------------------------------------------------
+    // DELETE /override — clear override
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `DELETE override without auth returns redirect`() = testApplication {
+        setupAllRoutes()
+
+        val unauthClient = createClient { followRedirects = false }
+        val response = unauthClient.delete(
+            "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot/override?node=minecraft:iron_ingot"
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+    }
+
+    @Test
+    fun `DELETE override without node param returns 400`() = testApplication {
+        setupAllRoutes()
+
+        val response = client.delete(
+            "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot/override"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `DELETE override clears previously pinned source from DB`() = testApplication {
+        val pid = createProject(worldId)
+        createResourceGathering(pid)
+        setupAllRoutes()
+
+        val nodeId = "minecraft:iron_ingot"
+        val sourceKey = "minecraft:block:blocks/iron_ore.json"
+
+        // First pin a source
+        seedOverrideSource(pid, nodeId, sourceKey)
+        assertNotNull(getOverrideRow(pid, nodeId), "Seed failed — override row should exist before DELETE")
+
+        // Now clear it
+        val response = client.delete(
+            "/worlds/$worldId/projects/$pid/plan/chain/minecraft:iron_ingot/override?node=$nodeId"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        // Row removed from DB
+        assertNull(getOverrideRow(pid, nodeId), "Override row should be cleared after DELETE /override")
+    }
+
+    @Test
+    fun `DELETE override re-render response is HTML fragment`() = testApplication {
+        val pid = createProject(worldId)
+        createResourceGathering(pid)
+        setupAllRoutes()
+
+        val response = client.delete(
+            "/worlds/$worldId/projects/$pid/plan/chain/minecraft:iron_ingot/override?node=minecraft:iron_ingot"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertContains(response.bodyAsText(), "project-content")
+    }
+
+    // -------------------------------------------------------------------------
+    // Route helper — sets up all chain sub-routes
+    // -------------------------------------------------------------------------
+
+    private fun ApplicationTestBuilder.setupAllRoutes() {
         routing {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
@@ -159,7 +472,13 @@ class PlanChainIT : WithUser() {
                 install(UpdateActiveWorldPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)
-                    get("/plan/chain/{itemId}") { call.handleGetDrillChain() }
+                    route("/plan/chain/{itemId}") {
+                        get { call.handleGetDrillChain() }
+                        get("/sources") { call.handleGetNodePicker() }
+                        post("/pin") { call.handlePinSource() }
+                        post("/tag") { call.handleResolveTagMember() }
+                        delete("/override") { call.handleClearOverride() }
+                    }
                 }
             }
         }
@@ -189,5 +508,54 @@ class PlanChainIT : WithUser() {
             parameterSetter = { stmt, _ -> stmt.setInt(1, worldId) }
         ).process(Unit)
         (result as Result.Success).value
+    }
+
+    private fun createResourceGathering(projectId: Int): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO resource_gathering (project_id, item_id, name, required) " +
+                        "VALUES (?, 'minecraft:iron_ingot', 'Iron Ingot', 10) RETURNING id"
+            ),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, projectId) }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun seedOverrideSource(projectId: Int, itemId: String, sourceKey: String) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                """
+                INSERT INTO resource_gathering_plan_override (project_id, item_id, source_key, tag_member)
+                VALUES (?, ?, ?, NULL)
+                ON CONFLICT (project_id, item_id)
+                DO UPDATE SET source_key = EXCLUDED.source_key, tag_member = NULL, updated_at = CURRENT_TIMESTAMP
+                """.trimIndent()
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+                stmt.setString(3, sourceKey)
+            }
+        ).process(Unit)
+    }
+
+    private data class OverrideRow(val sourceKey: String?, val tagMember: String?)
+
+    private fun getOverrideRow(projectId: Int, itemId: String): OverrideRow? = runBlocking {
+        DatabaseSteps.query<Pair<Int, String>, OverrideRow?>(
+            sql = SafeSQL.select(
+                "SELECT source_key, tag_member FROM resource_gathering_plan_override WHERE project_id = ? AND item_id = ?"
+            ),
+            parameterSetter = { stmt, inp ->
+                stmt.setInt(1, inp.first)
+                stmt.setString(2, inp.second)
+            },
+            resultMapper = { rs ->
+                if (rs.next()) OverrideRow(
+                    sourceKey = rs.getString("source_key"),
+                    tagMember = rs.getString("tag_member")
+                ) else null
+            }
+        ).process(Pair(projectId, itemId)).getOrNull()
     }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanChainIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanChainIT.kt
@@ -1,0 +1,193 @@
+package app.mcorg.presentation.handler.project
+
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.resources.handleGetDrillChain
+import app.mcorg.pipeline.resources.handleUpdatePlanProgress
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.ProjectParamPlugin
+import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
+import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+/**
+ * Integration tests for GET /worlds/{worldId}/projects/{projectId}/plan/chain/{itemId}.
+ *
+ * The Testcontainers DB has no ingested Minecraft graph, so a real perTarget plan cannot
+ * be derived. These tests cover:
+ * - Route exists and auth is enforced
+ * - Graceful fallback when the plan cannot be derived (no resources → ValidationError)
+ * - Graceful fallback when the item is not a target (plan unavailable → same fallback)
+ *
+ * Rich plan rendering (with candidate counts, chip/forced labels, depth) is covered
+ * by the DrillViewTest unit test.
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class PlanChainIT : WithUser() {
+
+    private var worldId: Int = 0
+    private var projectId: Int = 0
+
+    @BeforeAll
+    fun setup() {
+        worldId = createWorld()
+        projectId = createProject(worldId)
+    }
+
+    // -------------------------------------------------------------------------
+    // Auth
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `GET chain without auth returns redirect`() = testApplication {
+        setupRoutes()
+
+        val unauthClient = createClient { followRedirects = false }
+        val response = unauthClient.get(
+            "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot"
+        )
+
+        assertEquals(HttpStatusCode.Found, response.status)
+    }
+
+    // -------------------------------------------------------------------------
+    // Graceful fallback — no Minecraft graph in Testcontainers DB
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `GET chain responds 200 with fallback fragment when plan cannot be derived`() = testApplication {
+        setupRoutes()
+
+        val response = client.get(
+            "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        // Fragment always replaces #project-content
+        assertContains(body, "project-content")
+        // Back-to-plan button is always rendered
+        assertContains(body, "Back to plan")
+        // Fallback callout is rendered (plan derivation failed — no graph)
+        assertContains(body, "callout")
+    }
+
+    @Test
+    fun `GET chain with an item that has no resources defined returns graceful fragment`() = testApplication {
+        // Empty project: no resource_gathering rows → ValidationError from GenerateGatheringPlanStep
+        val emptyProjectId = createProject(worldId)
+        setupRoutes()
+
+        val response = client.get(
+            "/worlds/$worldId/projects/$emptyProjectId/plan/chain/minecraft:oak_log"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertContains(body, "project-content")
+        assertContains(body, "Back to plan")
+        assertContains(body, "callout")
+    }
+
+    @Test
+    fun `GET chain with URL-encoded tag id responds 200 with graceful fallback`() = testApplication {
+        setupRoutes()
+
+        // Tag ids have a '#' prefix — must be percent-encoded in the URL
+        val response = client.get(
+            "/worlds/$worldId/projects/$projectId/plan/chain/%23minecraft:planks"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertContains(body, "project-content")
+    }
+
+    @Test
+    fun `GET chain back-to-plan link points to list lens`() = testApplication {
+        setupRoutes()
+
+        val response = client.get(
+            "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        // Back button targets the list lens fragment
+        assertContains(body, "detail-content?lens=list")
+    }
+
+    // -------------------------------------------------------------------------
+    // Routing helpers
+    // -------------------------------------------------------------------------
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(UpdateActiveWorldPlugin)
+                route("/projects/{projectId}") {
+                    install(ProjectParamPlugin)
+                    get("/plan/chain/{itemId}") { call.handleGetDrillChain() }
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // DB fixture helpers
+    // -------------------------------------------------------------------------
+
+    private fun createWorld(): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(
+                name = "PlanChain IT World",
+                description = "test",
+                version = MinecraftVersion.fromString("1.21.4")
+            )
+        )
+        (result as Result.Success).value
+    }
+
+    private fun createProject(worldId: Int): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, location_x, location_y, location_z, location_dimension) " +
+                        "VALUES ('PC IT Project', ?, '', 'BUILDING', 'PLANNING', 0, 0, 0, 'OVERWORLD') RETURNING id"
+            ),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, worldId) }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
@@ -601,6 +601,29 @@ class DrillViewTest {
     }
 
     @Test
+    fun `source picker names chest-loot sources by their loot table, not a bare Chest`() {
+        // Two chest-loot sources for iron ingot — distinguishable by their loot-table file.
+        val ironIngot = item("iron_ingot", "Iron Ingot")
+        val builder = ItemSourceGraph.builder()
+        val ingotNode = builder.addItemNode(ironIngot)
+        listOf("chests/simple_dungeon.json", "chests/ancient_city.json").forEach { file ->
+            val src = builder.addSourceNode(ResourceSource.SourceType.LootTypes.CHEST, file)
+            builder.addSourceToItemEdge(src, ingotNode)
+        }
+        val graph = builder.build()
+
+        val node = TargetTree(ironIngot, 200, 200, PlanNodeStatus.RESOLVED, mine)
+        val html = nodePickerFragment(
+            worldId = 1, projectId = 2, targetItemId = "minecraft:iron_ingot",
+            node = node, graph = graph, activeSourceKey = null, activeMemberId = null,
+            demand = node.quantityIfAlone,
+        )
+
+        assertContains(html, "Simple dungeon")
+        assertContains(html, "Ancient city")
+    }
+
+    @Test
     fun `source picker shows clear button when override is active`() {
         val ironIngotItem = item("iron_ingot", "Iron Ingot")
         val node = TargetTree(

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
@@ -504,6 +504,31 @@ class DrillViewTest {
     }
 
     @Test
+    fun `source picker labels recipe sources by their ingredients`() {
+        // smeltSource consumes iron_ore (an ItemToSource edge in ironGraph), so its option
+        // is named "from Iron Ore" rather than the indistinguishable bare "Smelting".
+        val node = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:iron_ingot",
+            node = node,
+            graph = ironGraph(),
+            activeSourceKey = null,
+            activeMemberId = null,
+            demand = node.quantityIfAlone,
+        )
+
+        assertContains(html, "from Iron Ore")
+    }
+
+    @Test
     fun `source picker shows clear button when override is active`() {
         val ironIngotItem = item("iron_ingot", "Iron Ingot")
         val node = TargetTree(

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
@@ -1,0 +1,318 @@
+package app.mcorg.presentation.templated.dsl.pages
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.resources.ResourceSource
+import app.mcorg.engine.model.SourceNode
+import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.TargetTree
+import app.mcorg.domain.model.project.Project
+import app.mcorg.domain.model.project.ProjectStage
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.domain.model.project.ProjectType
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit tests for [drillChainFragment].
+ *
+ * Verifies:
+ * - The fragment wraps in #project-content for HTMX outerHTML swap
+ * - Back-to-plan button targets the list lens
+ * - Depth indentation via chain-node--depth-N classes
+ * - Forced (1-way) nodes render a "· 1 way" label and no chip
+ * - Multi-source nodes render a ⇄ chip (no-op placeholder)
+ * - OPEN_TAG nodes render a ⇄ chip
+ * - Fallback fragment renders gracefully with a callout
+ */
+class DrillViewTest {
+
+    private val mine = SourceNode(ResourceSource.SourceType.LootTypes.BLOCK, "blocks/iron_ore.json")
+    private val craft = SourceNode(ResourceSource.SourceType.RecipeTypes.CRAFTING_SHAPED, "iron_pickaxe.json")
+
+    private fun item(id: String, name: String) = Item("minecraft:$id", name)
+
+    private fun testProject(worldId: Int = 1, projectId: Int = 2) = Project(
+        id = projectId,
+        worldId = worldId,
+        name = "Test Project",
+        description = "",
+        type = ProjectType.BUILDING,
+        stage = ProjectStage.PLANNING,
+        state = ProjectState.ACTIVE,
+        location = null,
+        tasksTotal = 0,
+        tasksCompleted = 0,
+        importedFromIdea = null,
+        createdAt = ZonedDateTime.now(),
+        updatedAt = ZonedDateTime.now()
+    )
+
+    // -------------------------------------------------------------------------
+    // Fragment structure
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `fragment wraps in project-content div for outerHTML swap`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 64,
+            craftsIfAlone = 64,
+            status = PlanNodeStatus.RAW_GATHER,
+            source = mine,
+        )
+        val html = drillChainFragment(testProject(), tree, emptyMap())
+
+        assertTrue(html.contains("id=\"project-content\""),
+            "Expected id='project-content' in: $html")
+    }
+
+    @Test
+    fun `fragment contains back-to-plan button linking to list lens fragment`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 64,
+            craftsIfAlone = 64,
+            status = PlanNodeStatus.RAW_GATHER,
+            source = mine,
+        )
+        val html = drillChainFragment(testProject(worldId = 3, projectId = 7), tree, emptyMap())
+
+        assertContains(html, "detail-content?lens=list")
+        assertContains(html, "Back to plan")
+    }
+
+    @Test
+    fun `target item name appears in section label`() {
+        val tree = TargetTree(
+            item = item("iron_pickaxe", "Iron Pickaxe"),
+            quantityIfAlone = 2,
+            craftsIfAlone = 2,
+            status = PlanNodeStatus.RESOLVED,
+            source = craft,
+        )
+        val html = drillChainFragment(testProject(), tree, emptyMap())
+
+        assertContains(html, "Iron Pickaxe")
+        assertContains(html, "chain")
+    }
+
+    // -------------------------------------------------------------------------
+    // Depth indentation
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `root node has depth-0 class and child has depth-1 class`() {
+        val child = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RAW_GATHER,
+            source = mine,
+        )
+        val root = TargetTree(
+            item = item("iron_pickaxe", "Iron Pickaxe"),
+            quantityIfAlone = 2,
+            craftsIfAlone = 2,
+            status = PlanNodeStatus.RESOLVED,
+            source = craft,
+            children = listOf(child),
+        )
+        val html = drillChainFragment(testProject(), root, emptyMap())
+
+        assertContains(html, "chain-node--depth-0")
+        assertContains(html, "chain-node--depth-1")
+    }
+
+    @Test
+    fun `nodes deeper than 4 cap at depth-4`() {
+        fun deepTree(depth: Int): TargetTree {
+            return if (depth == 0) {
+                TargetTree(
+                    item = item("leaf", "Leaf"),
+                    quantityIfAlone = 1,
+                    craftsIfAlone = 1,
+                    status = PlanNodeStatus.RAW_GATHER,
+                    source = mine,
+                )
+            } else {
+                TargetTree(
+                    item = item("node_$depth", "Node $depth"),
+                    quantityIfAlone = 1L,
+                    craftsIfAlone = 1L,
+                    status = PlanNodeStatus.RESOLVED,
+                    source = craft,
+                    children = listOf(deepTree(depth - 1)),
+                )
+            }
+        }
+
+        val root = deepTree(6) // 7 levels deep
+        val html = drillChainFragment(testProject(), root, emptyMap())
+
+        assertContains(html, "chain-node--depth-4") // capped at 4
+        assertFalse(html.contains("chain-node--depth-5"), "Depth should cap at 4 but got depth-5 in: $html")
+    }
+
+    // -------------------------------------------------------------------------
+    // 1-way (forced) nodes
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `forced node (1 candidate) renders 1 way label and no chip`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 64,
+            craftsIfAlone = 64,
+            status = PlanNodeStatus.RAW_GATHER,
+            source = mine,
+        )
+        // 1 candidate → forced
+        val candidateCounts = mapOf("minecraft:iron_ingot" to 1)
+        val html = drillChainFragment(testProject(), tree, candidateCounts)
+
+        assertContains(html, "1 way")
+        assertFalse(html.contains("class=\"chip\""), "Should not render chip for forced node, but got: $html")
+    }
+
+    @Test
+    fun `node with 0 candidates renders 1 way label`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 64,
+            craftsIfAlone = 64,
+            status = PlanNodeStatus.RAW_GATHER,
+            source = mine,
+        )
+        val candidateCounts = mapOf("minecraft:iron_ingot" to 0)
+        val html = drillChainFragment(testProject(), tree, candidateCounts)
+
+        assertContains(html, "1 way")
+    }
+
+    // -------------------------------------------------------------------------
+    // Multi-source nodes (⇄ chip)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `multi-source node (2+ candidates) renders chip with source name`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        // 3 candidates → multi-source chip
+        val candidateCounts = mapOf("minecraft:iron_ingot" to 3)
+        val html = drillChainFragment(testProject(), tree, candidateCounts)
+
+        assertContains(html, "class=\"chip\"")
+        assertContains(html, "⇄")
+        assertFalse(html.contains("1 way"), "Should not show '1 way' for multi-source node, got: $html")
+    }
+
+    @Test
+    fun `multi-source node chip contains current source method name`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine, // mine = BLOCK → getName() = "Break Block: Iron ore"
+        )
+        val candidateCounts = mapOf("minecraft:iron_ingot" to 2)
+        val html = drillChainFragment(testProject(), tree, candidateCounts)
+
+        assertContains(html, "⇄")
+        // The chip label comes from getName() which includes "Break Block"
+        assertContains(html, "Break Block")
+    }
+
+    // -------------------------------------------------------------------------
+    // OPEN_TAG nodes (⇄ chip — pick variant)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `OPEN_TAG node renders chip with pick variant label`() {
+        val tree = TargetTree(
+            item = item("planks", "Any Planks"),
+            quantityIfAlone = 320,
+            craftsIfAlone = 320,
+            status = PlanNodeStatus.OPEN_TAG,
+            source = null,
+        )
+        val html = drillChainFragment(testProject(), tree, emptyMap())
+
+        assertContains(html, "class=\"chip\"")
+        assertContains(html, "⇄")
+        assertContains(html, "Pick variant")
+    }
+
+    // -------------------------------------------------------------------------
+    // SUPPLIED / BLOCKED nodes
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `SUPPLIED node renders supply label with no chip`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 64,
+            craftsIfAlone = 64,
+            status = PlanNodeStatus.SUPPLIED,
+        )
+        val html = drillChainFragment(testProject(), tree, emptyMap())
+
+        assertContains(html, "Supplied")
+        assertFalse(html.contains("class=\"chip\""), "SUPPLIED node should not have a chip, got: $html")
+    }
+
+    @Test
+    fun `BLOCKED node renders blocked label with no chip`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 64,
+            craftsIfAlone = 64,
+            status = PlanNodeStatus.BLOCKED,
+        )
+        val html = drillChainFragment(testProject(), tree, emptyMap())
+
+        assertContains(html, "Blocked")
+        assertFalse(html.contains("class=\"chip\""), "BLOCKED node should not have a chip, got: $html")
+    }
+
+    // -------------------------------------------------------------------------
+    // Quantity
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `quantityIfAlone appears in node row`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 1728,
+            craftsIfAlone = 1728,
+            status = PlanNodeStatus.RAW_GATHER,
+            source = mine,
+        )
+        val html = drillChainFragment(testProject(), tree, emptyMap())
+
+        assertContains(html, "1728")
+    }
+
+    // -------------------------------------------------------------------------
+    // Fallback fragment
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `drillNotFoundFragment renders project-content with callout and back button`() {
+        val html = drillNotFoundFragment(testProject(worldId = 5, projectId = 10), "Item not found in plan.")
+
+        assertTrue(html.contains("id=\"project-content\""),
+            "Expected id='project-content' in fallback: $html")
+        assertContains(html, "Back to plan")
+        assertContains(html, "callout")
+        assertContains(html, "Item not found in plan.")
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
@@ -315,6 +315,29 @@ class DrillViewTest {
         assertContains(html, "/worlds/3/projects/7?lens=list")
     }
 
+    @Test
+    fun `drill marks the highlighted node as current and shows ingredient hints`() {
+        val tree = TargetTree(
+            item = item("hopper", "Hopper"),
+            quantityIfAlone = 40,
+            craftsIfAlone = 40,
+            status = PlanNodeStatus.RESOLVED,
+            source = craft,
+            children = listOf(
+                TargetTree(item("iron_ingot", "Iron Ingot"), 200, 200, PlanNodeStatus.RAW_GATHER, mine),
+            ),
+        )
+        val html = drillChainFragment(
+            testProject(), tree,
+            candidateCounts = mapOf("minecraft:iron_ingot" to 1),
+            nodeIngredients = mapOf("minecraft:hopper" to "1 Chest + 5 Iron Ingot"),
+            highlightItemId = "minecraft:iron_ingot",
+        )
+
+        assertContains(html, "chain-node--current")
+        assertContains(html, "1 Chest + 5 Iron Ingot") // ingredient hint rendered
+    }
+
     // -------------------------------------------------------------------------
     // OPEN_TAG nodes (⇄ chip — pick variant)
     // -------------------------------------------------------------------------

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
@@ -439,6 +439,7 @@ class DrillViewTest {
             graph = graph,
             activeSourceKey = null,
             activeMemberId = null,
+            demand = node.quantityIfAlone,
         )
 
         // "Choose source" label
@@ -471,10 +472,35 @@ class DrillViewTest {
             graph = graph,
             activeSourceKey = activeKey,
             activeMemberId = null,
+            demand = node.quantityIfAlone,
         )
 
         // Selected option has the --sel modifier class
         assertContains(html, "picker-opt--sel")
+    }
+
+    @Test
+    fun `source picker marks the top-ranked candidate with best score star`() {
+        val node = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:iron_ingot",
+            node = node,
+            graph = ironGraph(),
+            activeSourceKey = null,
+            activeMemberId = null,
+            demand = node.quantityIfAlone,
+        )
+
+        // Exactly the rank-0 candidate carries the marker.
+        assertContains(html, "best score ★")
     }
 
     @Test
@@ -497,6 +523,7 @@ class DrillViewTest {
             graph = graph,
             activeSourceKey = mine.getKey(),
             activeMemberId = null,
+            demand = node.quantityIfAlone,
         )
 
         assertContains(html, "Clear override")
@@ -524,6 +551,7 @@ class DrillViewTest {
             graph = graph,
             activeSourceKey = null,
             activeMemberId = null,
+            demand = node.quantityIfAlone,
         )
 
         assertFalse(html.contains("Clear override"), "Clear button should not appear when no override active")
@@ -548,6 +576,7 @@ class DrillViewTest {
             graph = null,
             activeSourceKey = null,
             activeMemberId = null,
+            demand = node.quantityIfAlone,
         )
 
         assertContains(html, "No sources available")
@@ -581,11 +610,13 @@ class DrillViewTest {
             graph = graph,
             activeSourceKey = null,
             activeMemberId = null,
+            demand = node.quantityIfAlone,
         )
 
-        // Truncation note present
+        // Truncation note present, with a search box for high fan-out
         assertContains(html, "Showing 30 of 35")
-        assertContains(html, "ranked picks + search coming soon")
+        assertContains(html, "search to narrow")
+        assertContains(html, "picker-search")
     }
 
     // -------------------------------------------------------------------------
@@ -614,6 +645,7 @@ class DrillViewTest {
             graph = null,
             activeSourceKey = null,
             activeMemberId = null,
+            demand = node.quantityIfAlone,
         )
 
         assertContains(html, "Pick a variant")
@@ -645,6 +677,7 @@ class DrillViewTest {
             graph = null,
             activeSourceKey = null,
             activeMemberId = "minecraft:oak_planks",
+            demand = node.quantityIfAlone,
         )
 
         assertContains(html, "picker-opt--sel")
@@ -672,6 +705,7 @@ class DrillViewTest {
             graph = null,
             activeSourceKey = null,
             activeMemberId = null,
+            demand = node.quantityIfAlone,
         )
 
         assertContains(html, "Showing 30 of 35")
@@ -698,6 +732,7 @@ class DrillViewTest {
             graph = null,
             activeSourceKey = null,
             activeMemberId = "minecraft:oak_planks",
+            demand = node.quantityIfAlone,
         )
 
         assertContains(html, "Clear override")

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
@@ -1,7 +1,9 @@
 package app.mcorg.presentation.templated.dsl.pages
 
 import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftTag
 import app.mcorg.domain.model.resources.ResourceSource
+import app.mcorg.engine.model.ItemSourceGraph
 import app.mcorg.engine.model.SourceNode
 import app.mcorg.engine.plan.PlanNodeStatus
 import app.mcorg.engine.plan.TargetTree
@@ -16,21 +18,29 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * Unit tests for [drillChainFragment].
+ * Unit tests for [drillChainFragment], [drillNotFoundFragment], and [nodePickerFragment].
  *
  * Verifies:
  * - The fragment wraps in #project-content for HTMX outerHTML swap
  * - Back-to-plan button targets the list lens
  * - Depth indentation via chain-node--depth-N classes
  * - Forced (1-way) nodes render a "· 1 way" label and no chip
- * - Multi-source nodes render a ⇄ chip (no-op placeholder)
+ * - Multi-source nodes render a ⇄ chip wired to the sources endpoint
  * - OPEN_TAG nodes render a ⇄ chip
+ * - The chip links to the /sources?node= endpoint
+ * - A picker slot div is emitted for chip nodes
+ * - nodePickerFragment: source picker renders options with hx-post to /pin
+ * - nodePickerFragment: tag picker renders members with hx-post to /tag
+ * - nodePickerFragment: selected option has picker-opt--sel
+ * - nodePickerFragment: >30 cap shows "Showing 30 of N" note
+ * - nodePickerFragment: clear control appears when override is active
  * - Fallback fragment renders gracefully with a callout
  */
 class DrillViewTest {
 
     private val mine = SourceNode(ResourceSource.SourceType.LootTypes.BLOCK, "blocks/iron_ore.json")
     private val craft = SourceNode(ResourceSource.SourceType.RecipeTypes.CRAFTING_SHAPED, "iron_pickaxe.json")
+    private val smelt = SourceNode(ResourceSource.SourceType.RecipeTypes.SMELTING, "smelting/iron_ingot.json")
 
     private fun item(id: String, name: String) = Item("minecraft:$id", name)
 
@@ -49,6 +59,23 @@ class DrillViewTest {
         createdAt = ZonedDateTime.now(),
         updatedAt = ZonedDateTime.now()
     )
+
+    /** Build a tiny ItemSourceGraph with two sources for iron ingot. */
+    private fun ironGraph(): ItemSourceGraph {
+        val ironIngot = item("iron_ingot", "Iron Ingot")
+        val ironOre = item("iron_ore", "Iron Ore")
+        val builder = ItemSourceGraph.builder()
+
+        val mineSource = builder.addSourceNode(ResourceSource.SourceType.LootTypes.BLOCK, "blocks/iron_ore.json")
+        builder.addSourceToItemEdge(mineSource, builder.addItemNode(ironIngot))
+        builder.addSourceToItemEdge(mineSource, builder.addItemNode(ironOre))
+
+        val smeltSource = builder.addSourceNode(ResourceSource.SourceType.RecipeTypes.SMELTING, "smelting/iron_ingot.json")
+        builder.addSourceToItemEdge(smeltSource, builder.addItemNode(ironIngot))
+        builder.addItemToSourceEdge(builder.addItemNode(ironOre), smeltSource)
+
+        return builder.build()
+    }
 
     // -------------------------------------------------------------------------
     // Fragment structure
@@ -231,6 +258,40 @@ class DrillViewTest {
         assertContains(html, "Break Block")
     }
 
+    @Test
+    fun `multi-source chip has hx-get wired to sources endpoint`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val candidateCounts = mapOf("minecraft:iron_ingot" to 2)
+        val html = drillChainFragment(testProject(worldId = 5, projectId = 9), tree, candidateCounts)
+
+        // Chip must hx-get the /sources endpoint
+        assertContains(html, "/sources?node=")
+        assertContains(html, "hx-get")
+    }
+
+    @Test
+    fun `multi-source chip has a picker slot div with correct id`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val candidateCounts = mapOf("minecraft:iron_ingot" to 2)
+        val html = drillChainFragment(testProject(), tree, candidateCounts)
+
+        // Picker slot id = "picker-{slug}" where slug = id with every non-alphanumeric → '-'
+        // (so "minecraft:iron_ingot" → "minecraft-iron-ingot"; also neutralises '#' in tag ids).
+        assertContains(html, "picker-minecraft-iron-ingot")
+    }
+
     // -------------------------------------------------------------------------
     // OPEN_TAG nodes (⇄ chip — pick variant)
     // -------------------------------------------------------------------------
@@ -249,6 +310,21 @@ class DrillViewTest {
         assertContains(html, "class=\"chip\"")
         assertContains(html, "⇄")
         assertContains(html, "Pick variant")
+    }
+
+    @Test
+    fun `OPEN_TAG chip has hx-get wired to sources endpoint`() {
+        val tree = TargetTree(
+            item = item("planks", "Any Planks"),
+            quantityIfAlone = 320,
+            craftsIfAlone = 320,
+            status = PlanNodeStatus.OPEN_TAG,
+            source = null,
+        )
+        val html = drillChainFragment(testProject(worldId = 3, projectId = 8), tree, emptyMap())
+
+        assertContains(html, "hx-get")
+        assertContains(html, "/sources?node=")
     }
 
     // -------------------------------------------------------------------------
@@ -314,5 +390,295 @@ class DrillViewTest {
         assertContains(html, "Back to plan")
         assertContains(html, "callout")
         assertContains(html, "Item not found in plan.")
+    }
+
+    // -------------------------------------------------------------------------
+    // nodePickerFragment — source picker
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `source picker renders options with hx-post to pin endpoint`() {
+        val ironIngotItem = item("iron_ingot", "Iron Ingot")
+        val node = TargetTree(
+            item = ironIngotItem,
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val graph = ironGraph()
+
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:iron_ingot",
+            node = node,
+            graph = graph,
+            activeSourceKey = null,
+            activeMemberId = null,
+        )
+
+        // "Choose source" label
+        assertContains(html, "Choose source")
+        // hx-post to /pin endpoint
+        assertContains(html, "hx-post")
+        assertContains(html, "/pin")
+        // contains source names from graph
+        assertContains(html, "Break Block")
+    }
+
+    @Test
+    fun `source picker marks active source as selected`() {
+        val ironIngotItem = item("iron_ingot", "Iron Ingot")
+        val node = TargetTree(
+            item = ironIngotItem,
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val graph = ironGraph()
+        val activeKey = mine.getKey() // "minecraft:block:blocks/iron_ore.json"
+
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:iron_ingot",
+            node = node,
+            graph = graph,
+            activeSourceKey = activeKey,
+            activeMemberId = null,
+        )
+
+        // Selected option has the --sel modifier class
+        assertContains(html, "picker-opt--sel")
+    }
+
+    @Test
+    fun `source picker shows clear button when override is active`() {
+        val ironIngotItem = item("iron_ingot", "Iron Ingot")
+        val node = TargetTree(
+            item = ironIngotItem,
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val graph = ironGraph()
+
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:iron_ingot",
+            node = node,
+            graph = graph,
+            activeSourceKey = mine.getKey(),
+            activeMemberId = null,
+        )
+
+        assertContains(html, "Clear override")
+        assertContains(html, "/override")
+        assertContains(html, "hx-delete")
+    }
+
+    @Test
+    fun `source picker does not show clear button when no override is active`() {
+        val ironIngotItem = item("iron_ingot", "Iron Ingot")
+        val node = TargetTree(
+            item = ironIngotItem,
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val graph = ironGraph()
+
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:iron_ingot",
+            node = node,
+            graph = graph,
+            activeSourceKey = null,
+            activeMemberId = null,
+        )
+
+        assertFalse(html.contains("Clear override"), "Clear button should not appear when no override active")
+    }
+
+    @Test
+    fun `source picker with empty graph shows no-sources message`() {
+        val ironIngotItem = item("iron_ingot", "Iron Ingot")
+        val node = TargetTree(
+            item = ironIngotItem,
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        // No graph (null) → no candidates
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:iron_ingot",
+            node = node,
+            graph = null,
+            activeSourceKey = null,
+            activeMemberId = null,
+        )
+
+        assertContains(html, "No sources available")
+    }
+
+    @Test
+    fun `source picker with more than 30 candidates shows truncation note`() {
+        // Build a graph with 35 sources for one item
+        val ironIngotItem = item("iron_ingot", "Iron Ingot")
+        val builder = ItemSourceGraph.builder()
+        val itemNode = builder.addItemNode(ironIngotItem)
+        for (i in 1..35) {
+            val src = builder.addSourceNode(ResourceSource.SourceType.LootTypes.BLOCK, "blocks/ore_$i.json")
+            builder.addSourceToItemEdge(src, itemNode)
+        }
+        val graph = builder.build()
+
+        val node = TargetTree(
+            item = ironIngotItem,
+            quantityIfAlone = 100,
+            craftsIfAlone = 100,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:iron_ingot",
+            node = node,
+            graph = graph,
+            activeSourceKey = null,
+            activeMemberId = null,
+        )
+
+        // Truncation note present
+        assertContains(html, "Showing 30 of 35")
+        assertContains(html, "ranked picks + search coming soon")
+    }
+
+    // -------------------------------------------------------------------------
+    // nodePickerFragment — tag member picker
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `tag picker renders member options with hx-post to tag endpoint`() {
+        val oakPlanks = Item("minecraft:oak_planks", "Oak Planks")
+        val sprucePlanks = Item("minecraft:spruce_planks", "Spruce Planks")
+        val tag = MinecraftTag("#minecraft:planks", "Any Planks", listOf(oakPlanks, sprucePlanks))
+
+        val node = TargetTree(
+            item = tag,
+            quantityIfAlone = 320,
+            craftsIfAlone = 320,
+            status = PlanNodeStatus.OPEN_TAG,
+            source = null,
+        )
+
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:chest",
+            node = node,
+            graph = null,
+            activeSourceKey = null,
+            activeMemberId = null,
+        )
+
+        assertContains(html, "Pick a variant")
+        assertContains(html, "hx-post")
+        assertContains(html, "/tag")
+        assertContains(html, "Oak Planks")
+        assertContains(html, "Spruce Planks")
+    }
+
+    @Test
+    fun `tag picker marks active member as selected`() {
+        val oakPlanks = Item("minecraft:oak_planks", "Oak Planks")
+        val sprucePlanks = Item("minecraft:spruce_planks", "Spruce Planks")
+        val tag = MinecraftTag("#minecraft:planks", "Any Planks", listOf(oakPlanks, sprucePlanks))
+
+        val node = TargetTree(
+            item = tag,
+            quantityIfAlone = 320,
+            craftsIfAlone = 320,
+            status = PlanNodeStatus.OPEN_TAG,
+            source = null,
+        )
+
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:chest",
+            node = node,
+            graph = null,
+            activeSourceKey = null,
+            activeMemberId = "minecraft:oak_planks",
+        )
+
+        assertContains(html, "picker-opt--sel")
+        assertContains(html, "selected")
+    }
+
+    @Test
+    fun `tag picker with more than 30 members shows truncation note`() {
+        val members = (1..35).map { Item("minecraft:planks_$it", "Planks $it") }
+        val tag = MinecraftTag("#minecraft:planks", "Any Planks", members)
+
+        val node = TargetTree(
+            item = tag,
+            quantityIfAlone = 320,
+            craftsIfAlone = 320,
+            status = PlanNodeStatus.OPEN_TAG,
+            source = null,
+        )
+
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:chest",
+            node = node,
+            graph = null,
+            activeSourceKey = null,
+            activeMemberId = null,
+        )
+
+        assertContains(html, "Showing 30 of 35")
+    }
+
+    @Test
+    fun `tag picker shows clear button when member override is active`() {
+        val oakPlanks = Item("minecraft:oak_planks", "Oak Planks")
+        val tag = MinecraftTag("#minecraft:planks", "Any Planks", listOf(oakPlanks))
+
+        val node = TargetTree(
+            item = tag,
+            quantityIfAlone = 320,
+            craftsIfAlone = 320,
+            status = PlanNodeStatus.OPEN_TAG,
+            source = null,
+        )
+
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:chest",
+            node = node,
+            graph = null,
+            activeSourceKey = null,
+            activeMemberId = "minecraft:oak_planks",
+        )
+
+        assertContains(html, "Clear override")
+        assertContains(html, "hx-delete")
+        assertContains(html, "/override")
     }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
@@ -529,6 +529,55 @@ class DrillViewTest {
     }
 
     @Test
+    fun `picker threads origin=list into option posts and clear url`() {
+        val node = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:iron_ingot",
+            node = node,
+            graph = ironGraph(),
+            activeSourceKey = mine.getKey(), // forces the clear control to render
+            activeMemberId = null,
+            demand = node.quantityIfAlone,
+            origin = "list",
+        )
+
+        // hx-vals JSON quotes are HTML-escaped to &quot; in the rendered attribute.
+        assertContains(html, "origin&quot;:&quot;list&quot;") // carried in the pin hx-vals
+        assertContains(html, "origin=list")                  // carried on the clear url
+    }
+
+    @Test
+    fun `picker omits origin when not provided`() {
+        val node = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:iron_ingot",
+            node = node,
+            graph = ironGraph(),
+            activeSourceKey = null,
+            activeMemberId = null,
+            demand = node.quantityIfAlone,
+        )
+
+        assertFalse(html.contains("origin"), "origin should be absent for drill-origin pickers")
+    }
+
+    @Test
     fun `source picker shows clear button when override is active`() {
         val ironIngotItem = item("iron_ingot", "Iron Ingot")
         val node = TargetTree(

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
@@ -16,7 +16,9 @@ import app.mcorg.domain.model.project.ProjectType
 import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -621,6 +623,14 @@ class DrillViewTest {
 
         assertContains(html, "Simple dungeon")
         assertContains(html, "Ancient city")
+    }
+
+    @Test
+    fun `lootTableName names loot sources by their file and ignores non-loot`() {
+        val chest = SourceNode(ResourceSource.SourceType.LootTypes.CHEST, "chests/desert_pyramid.json")
+        assertEquals("Desert pyramid", lootTableName(chest))
+        assertNull(lootTableName(mine), "block source already named by getName()")
+        assertNull(lootTableName(craft), "recipe carries ingredients, not a loot table")
     }
 
     @Test

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
@@ -8,6 +8,8 @@ import app.mcorg.engine.model.SourceNode
 import app.mcorg.engine.plan.PlanNodeStatus
 import app.mcorg.engine.plan.TargetTree
 import app.mcorg.domain.model.project.Project
+import kotlinx.html.div
+import kotlinx.html.stream.createHTML
 import app.mcorg.domain.model.project.ProjectStage
 import app.mcorg.domain.model.project.ProjectState
 import app.mcorg.domain.model.project.ProjectType
@@ -290,6 +292,27 @@ class DrillViewTest {
         // Picker slot id = "picker-{slug}" where slug = id with every non-alphanumeric → '-'
         // (so "minecraft:iron_ingot" → "minecraft-iron-ingot"; also neutralises '#' in tag ids).
         assertContains(html, "picker-minecraft-iron-ingot")
+    }
+
+    @Test
+    fun `drillChainContent renders the chain body without the project-content wrapper`() {
+        // This is the body shared with the full page shell for ?drill= deep-links.
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 200,
+            craftsIfAlone = 200,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val html = createHTML().div {
+            drillChainContent(testProject(worldId = 3, projectId = 7), tree, mapOf("minecraft:iron_ingot" to 1))
+        }
+
+        assertContains(html, "drill-chain")
+        assertContains(html, "Back to plan")
+        assertContains(html, "Iron Ingot")
+        // Back-to-plan returns to the list lens of this project.
+        assertContains(html, "/worlds/3/projects/7?lens=list")
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Phase 3 of the Gathering Planner ([MCO-222](https://linear.app/evegul/issue/MCO-222), epic [MCO-219](https://linear.app/evegul/issue/MCO-219)). Builds on the List lens (PR #318). Adds the **drill view** and the first UI for the two persisted plan overrides (`resource_gathering_plan_override`, already in the DB), then a round of review polish.

`preview` labelled — heavily visual; worth eyeballing the drill, picker, and the new plan-page source hints.

## What

**Drill** — reached from a `⇄` on any plan row:
- `GET .../plan/chain/{item}` renders the target's `perTarget` chain, depth-indented, into `#project-content` (swaps like the lens). Drilling a **derived intermediate** (raw iron, iron ingot) shows the **full chain it belongs to** with that node **highlighted** — not an isolated node. `?drill=<item>` is reload/share-safe (renders in the page shell).
- Each node states **what it consumes**: "Iron Ingot · Smelting · 1 Raw Iron", "Hopper · Crafting · 1 Chest + 5 Iron Ingot". Multi-output recipes read as a reduced ratio ("1 Oak Log → 4"), not a fraction.
- Forced (≤1-source) nodes show "· 1 way"; multi-source / open-tag nodes show a `⇄` chip that opens an inline picker.

**Overrides** — pin a source / resolve an open tag / clear, each persists via the existing project-scoped `PlanOverride` steps, re-derives the plan, and re-renders:
- **Ranked picker** reusing the engine's `SelectionScorer` **unchanged** — the only `mc-engine` change is one new read-only file (`SourceRanking.kt`) that mirrors `PlanSelector.rank`'s ordering; "best score ★" on the top pick, search box for high fan-out.
- Picker sources are **distinguishable**: recipes by ingredient ("from Deepslate Iron Ore"), and the ~30 chest-loot tables by their **loot location** ("Desert pyramid", "Bastion treasure") — `filename` was already extracted, so web-only.
- **Open-tag variants resolve inline in the List lens** (design block 3, "resolvable inline"): a "Pick variant" button drops the picker below the row and re-renders the list (`origin=list`), without a trip to the drill.

**Plan page (List lens)** now surfaces the same relationships on each row — "Iron Ingot · Smelting · 1 Raw Iron", and a pinned chest source reads "Chest Loot · Desert pyramid" — so you see how each item is made/sourced without drilling.

**Bug fixed along the way:** the list fragment had dropped `id="project-content"`, so an `outerHTML` swap onto it (lens pills, drill back-button) deleted the swap target and silently broke subsequent actions until reload. Latent since MCO-221.

## Notes / scope
- `mc-engine`: only the new read-only `SourceRanking.kt`; `SelectionScorer`/`PlanSelector` untouched (engine scoring suite stays green). No migrations.
- Picker demand uses the node's `quantityIfAlone` with empty supplied (intrinsic ranking) — "best score ★" can differ from the planner's accumulated-demand pick in multi-target plans; easy to thread real demand later if wanted.
- Follow-ups filed: **MCO-226** (List "targets vs full breakdown" switch), **MCO-227** (re-pick an already-resolved open tag).

## Tests
New `PlanChainIT`, `DrillViewTest`, `DrillTreeResolutionTest`; `ProjectDetailIT`/`GatheringPlannerIT` updated. Unit + database green; `mc-engine` scoring suite unchanged. Verified end-to-end in a browser against a real ingested graph (drill, highlight, ranked picker, pin→re-derive, inline tag resolve, plan-page hints, chest-loot names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)