### PR TITLE
Webhook fan-out: subscriptions, outbox delivery, retry, batching (MCO-229)

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/Application.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/Application.kt
@@ -1,6 +1,7 @@
 package app.mcorg
 
 import app.mcorg.event.configureEvents
+import app.mcorg.webhook.configureWebhooks
 import app.mcorg.presentation.plugins.configureHTTP
 import app.mcorg.presentation.plugins.configureMonitoring
 import app.mcorg.presentation.plugins.configurePreviewGate
@@ -31,6 +32,7 @@ private fun defaultServer(module: Application.() -> Unit) =
 
 private fun Application.module() {
     configureEvents()
+    configureWebhooks()
     configurePreviewGate()
     configureHTTP()
     configureMonitoring()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/config/AppConfig.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/config/AppConfig.kt
@@ -40,6 +40,11 @@ object AppConfig {
     // if unset); unused in LOCAL and PRODUCTION. See PreviewGate.
     var previewPassword: String? = null
 
+    // Shared secret gating the machine-facing webhook admin endpoints (MCO-229). Optional: when
+    // unset the endpoints fail closed (reject every request), so the feature is inert until a
+    // WEBHOOK_ADMIN_SECRET is provided. See WebhookAdminAuthPlugin.
+    var webhookAdminSecret: String? = null
+
     init {
         val errors = mutableListOf<String>()
         System.getenv("DB_URL")?.let { dbUrl = it } ?: errors.add("DB_URL is not set")
@@ -118,6 +123,8 @@ object AppConfig {
         System.getenv("LAUNCHER_META_BASE_URL")?.let { launcherMetaBaseUrl = it }
 
         System.getenv("DEMO_USER")?.let { demoUser = it }
+
+        System.getenv("WEBHOOK_ADMIN_SECRET")?.let { webhookAdminSecret = it }
 
         System.getenv("PREVIEW_PASSWORD")?.let { previewPassword = it }
         if (env == Test && previewPassword.isNullOrBlank()) {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/plugins/AuthPlugin.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/plugins/AuthPlugin.kt
@@ -18,7 +18,10 @@ val AuthPlugin = createRouteScopedPlugin("AuthPlugin") {
     onCall {
         if (it.request.path().startsWith("/static/")
             || it.request.path().startsWith("/assets/")
-            || it.request.path().startsWith("/favicon.ico")) {
+            || it.request.path().startsWith("/favicon.ico")
+            // Machine-facing integration endpoints carry their own shared-secret gate
+            // (e.g. WebhookAdminAuthPlugin) and must not be redirected to the user sign-in flow.
+            || it.request.path().startsWith("/integrations/")) {
             return@onCall
         }
         val result = pipelineResult<AppFailure, Unit> {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/plugins/AuthPlugin.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/plugins/AuthPlugin.kt
@@ -14,14 +14,22 @@ import io.ktor.server.application.createRouteScopedPlugin
 import io.ktor.server.request.path
 import io.ktor.server.response.respondRedirect
 
+/**
+ * Path prefixes exempt from the JWT sign-in redirect. Static assets are served before auth, and
+ * `/integrations/` is the machine-facing surface that carries its own shared-secret gate (e.g.
+ * WebhookAdminAuthPlugin) and must not be bounced to the user sign-in flow.
+ */
+private val AUTH_EXEMPT_PREFIXES = listOf(
+    "/static/",
+    "/assets/",
+    "/favicon.ico",
+    "/integrations/",
+)
+
 val AuthPlugin = createRouteScopedPlugin("AuthPlugin") {
     onCall {
-        if (it.request.path().startsWith("/static/")
-            || it.request.path().startsWith("/assets/")
-            || it.request.path().startsWith("/favicon.ico")
-            // Machine-facing integration endpoints carry their own shared-secret gate
-            // (e.g. WebhookAdminAuthPlugin) and must not be redirected to the user sign-in flow.
-            || it.request.path().startsWith("/integrations/")) {
+        val path = it.request.path()
+        if (AUTH_EXEMPT_PREFIXES.any { prefix -> path.startsWith(prefix) }) {
             return@onCall
         }
         val result = pipelineResult<AppFailure, Unit> {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/plugins/WebhookAdminAuthPlugin.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/plugins/WebhookAdminAuthPlugin.kt
@@ -1,0 +1,34 @@
+package app.mcorg.presentation.plugins
+
+import app.mcorg.config.AppConfig
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.createRouteScopedPlugin
+import io.ktor.server.response.respond
+import java.security.MessageDigest
+
+/** Header carrying the shared secret for the machine-facing webhook admin endpoints. */
+const val WEBHOOK_ADMIN_SECRET_HEADER = "X-Seam-Admin-Secret"
+
+/**
+ * Route-scoped gate for the webhook admin endpoints (`/integrations/webhooks`). Fails closed: if no
+ * `WEBHOOK_ADMIN_SECRET` is configured the endpoints are inert (503). Otherwise the request's
+ * [WEBHOOK_ADMIN_SECRET_HEADER] must match it (constant-time compare) or the call is rejected 401.
+ *
+ * These endpoints are JWT-exempt (see AuthPlugin's allowlist); this shared secret is their only gate.
+ */
+val WebhookAdminAuthPlugin = createRouteScopedPlugin("WebhookAdminAuthPlugin") {
+    onCall { call ->
+        val configured = AppConfig.webhookAdminSecret
+        if (configured.isNullOrBlank()) {
+            call.respond(HttpStatusCode.ServiceUnavailable, "Webhook admin endpoint is not configured")
+            return@onCall
+        }
+        val provided = call.request.headers[WEBHOOK_ADMIN_SECRET_HEADER]
+        if (provided == null || !constantTimeEquals(provided, configured)) {
+            call.respond(HttpStatusCode.Unauthorized, "Invalid or missing admin secret")
+        }
+    }
+}
+
+private fun constantTimeEquals(a: String, b: String): Boolean =
+    MessageDigest.isEqual(a.toByteArray(Charsets.UTF_8), b.toByteArray(Charsets.UTF_8))

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/router/mainRouter.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/router/mainRouter.kt
@@ -5,6 +5,7 @@ import app.mcorg.presentation.handler.handleGetLanding
 import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.BannedPlugin
 import app.mcorg.presentation.plugins.DemoUserPlugin
+import app.mcorg.webhook.webhookAdminRoutes
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.*
 import io.ktor.server.response.respond
@@ -30,6 +31,8 @@ fun Application.configureAppRouter() {
         route("/auth") {
             authRouter()
         }
+        // Machine-facing webhook admin surface — shared-secret gated, JWT-exempt (see AuthPlugin).
+        webhookAdminRoutes()
         route("") {
             install(BannedPlugin)
             appRouterV2()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookAdminRoutes.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookAdminRoutes.kt
@@ -1,0 +1,165 @@
+package app.mcorg.webhook
+
+import app.mcorg.config.AppConfig
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.ValidationSteps
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.presentation.handler.handlePipeline
+import app.mcorg.presentation.utils.respondHtml
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.createRouteScopedPlugin
+import io.ktor.server.application.install
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import kotlinx.html.p
+import kotlinx.html.stream.createHTML
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import java.security.MessageDigest
+
+/** Header carrying the shared secret for the webhook admin endpoints. */
+const val WEBHOOK_ADMIN_SECRET_HEADER = "X-Seam-Admin-Secret"
+
+private val adminJson = Json
+
+/**
+ * Route-scoped gate for the machine-facing webhook admin endpoints. Fails closed: if no
+ * `WEBHOOK_ADMIN_SECRET` is configured the endpoints are inert (503). Otherwise the request's
+ * [WEBHOOK_ADMIN_SECRET_HEADER] must match it (constant-time compare) or the call is rejected 401.
+ */
+val WebhookAdminAuthPlugin = createRouteScopedPlugin("WebhookAdminAuthPlugin") {
+    onCall { call ->
+        val configured = AppConfig.webhookAdminSecret
+        if (configured.isNullOrBlank()) {
+            call.respond(HttpStatusCode.ServiceUnavailable, "Webhook admin endpoint is not configured")
+            return@onCall
+        }
+        val provided = call.request.headers[WEBHOOK_ADMIN_SECRET_HEADER]
+        if (provided == null || !constantTimeEquals(provided, configured)) {
+            call.respond(HttpStatusCode.Unauthorized, "Invalid or missing admin secret")
+        }
+    }
+}
+
+/**
+ * Registers the v1 webhook subscription management surface. Mounted at `/integrations/webhooks`
+ * (outside the user app's JWT auth — see AuthPlugin's allowlist) and gated solely by the shared
+ * secret. This is the simplified setup path until per-user `/seam connect` (Phase 3) and the JSON
+ * API (MCO-235) land. Responses are tiny HTML fragments, consistent with the rest of the app.
+ */
+fun Route.webhookAdminRoutes() {
+    route("/integrations/webhooks") {
+        install(WebhookAdminAuthPlugin)
+        post { call.handleCreateWebhookSubscription() }
+        delete("/{subscriptionId}") { call.handleDeleteWebhookSubscription() }
+    }
+}
+
+private fun validationError(it: app.mcorg.pipeline.failure.ValidationFailure) = AppFailure.ValidationError(listOf(it))
+
+suspend fun ApplicationCall.handleCreateWebhookSubscription() {
+    val parameters = receiveParameters()
+    handlePipeline(
+        onSuccess = { id ->
+            respondHtml(createHTML().p { +"Created webhook subscription #$id" }, HttpStatusCode.Created)
+        }
+    ) {
+        val worldId = ValidationSteps.requiredInt("world_id", ::validationError).run(parameters)
+        val callbackUrl = ValidationSteps.required("callback_url", ::validationError).run(parameters)
+        ValidationSteps.validateUrl("callback_url", ::validationError).run(callbackUrl)
+        val secret = ValidationSteps.required("secret", ::validationError).run(parameters)
+        ValidationSteps.validateLength("secret", minLength = 8, maxLength = 256, errorMapper = ::validationError).run(secret)
+
+        val eventFilter = parameters.orDefault("event_filter", """["*"]""")
+        ValidationSteps.validateCustom<AppFailure.ValidationError, String>(
+            "event_filter", "Must be a JSON array of event-type strings", ::validationError
+        ) { parsesAsStringList(it) }.run(eventFilter)
+
+        val metadata = parameters.orDefault("metadata", "{}")
+        ValidationSteps.validateCustom<AppFailure.ValidationError, String>(
+            "metadata", "Must be a JSON object", ::validationError
+        ) { parsesAsJsonObject(it) }.run(metadata)
+
+        CreateWebhookSubscriptionStep.run(
+            CreateWebhookSubscriptionInput(worldId, callbackUrl, secret, eventFilter, metadata)
+        )
+    }
+}
+
+suspend fun ApplicationCall.handleDeleteWebhookSubscription() {
+    val id = parameters["subscriptionId"]?.toIntOrNull()
+    if (id == null) {
+        respond(HttpStatusCode.BadRequest, "Invalid subscription id")
+        return
+    }
+    handlePipeline(
+        onSuccess = { affected ->
+            if (affected > 0) {
+                respondHtml(createHTML().p { +"Deleted webhook subscription #$id" })
+            } else {
+                respondHtml(createHTML().p { +"No webhook subscription #$id" }, HttpStatusCode.NotFound)
+            }
+        }
+    ) {
+        DeleteWebhookSubscriptionStep.run(id)
+    }
+}
+
+data class CreateWebhookSubscriptionInput(
+    val worldId: Int,
+    val callbackUrl: String,
+    val secret: String,
+    val eventFilterJson: String,
+    val metadataJson: String,
+)
+
+object CreateWebhookSubscriptionStep : Step<CreateWebhookSubscriptionInput, AppFailure.DatabaseError, Int> {
+    override suspend fun process(input: CreateWebhookSubscriptionInput) =
+        DatabaseSteps.update<CreateWebhookSubscriptionInput>(
+            sql = SafeSQL.insert(
+                """
+                INSERT INTO webhook_subscriptions (world_id, callback_url, secret, event_filter, metadata)
+                VALUES (?, ?, ?, ?::jsonb, ?::jsonb)
+                RETURNING id
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, i ->
+                statement.setInt(1, i.worldId)
+                statement.setString(2, i.callbackUrl)
+                statement.setString(3, i.secret)
+                statement.setString(4, i.eventFilterJson)
+                statement.setString(5, i.metadataJson)
+            },
+        ).process(input)
+}
+
+object DeleteWebhookSubscriptionStep : Step<Int, AppFailure.DatabaseError, Int> {
+    override suspend fun process(input: Int) =
+        DatabaseSteps.update<Int>(
+            sql = SafeSQL.delete("DELETE FROM webhook_subscriptions WHERE id = ?"),
+            parameterSetter = { statement, id -> statement.setInt(1, id) },
+        ).process(input)
+}
+
+private fun Parameters.orDefault(name: String, default: String): String =
+    this[name]?.takeIf { it.isNotBlank() } ?: default
+
+private fun parsesAsStringList(raw: String): Boolean =
+    runCatching { adminJson.decodeFromString(ListSerializer(String.serializer()), raw) }.isSuccess
+
+private fun parsesAsJsonObject(raw: String): Boolean =
+    runCatching { adminJson.decodeFromString(JsonObject.serializer(), raw) }.isSuccess
+
+private fun constantTimeEquals(a: String, b: String): Boolean =
+    MessageDigest.isEqual(a.toByteArray(Charsets.UTF_8), b.toByteArray(Charsets.UTF_8))

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookAdminRoutes.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookAdminRoutes.kt
@@ -1,6 +1,7 @@
 package app.mcorg.webhook
 
 import app.mcorg.config.AppConfig
+import app.mcorg.domain.Production
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
@@ -8,11 +9,11 @@ import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.ValidationSteps
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.presentation.handler.handlePipeline
+import app.mcorg.presentation.plugins.WebhookAdminAuthPlugin
 import app.mcorg.presentation.utils.respondHtml
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.application.createRouteScopedPlugin
 import io.ktor.server.application.install
 import io.ktor.server.request.receiveParameters
 import io.ktor.server.response.respond
@@ -26,31 +27,8 @@ import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
-import java.security.MessageDigest
-
-/** Header carrying the shared secret for the webhook admin endpoints. */
-const val WEBHOOK_ADMIN_SECRET_HEADER = "X-Seam-Admin-Secret"
 
 private val adminJson = Json
-
-/**
- * Route-scoped gate for the machine-facing webhook admin endpoints. Fails closed: if no
- * `WEBHOOK_ADMIN_SECRET` is configured the endpoints are inert (503). Otherwise the request's
- * [WEBHOOK_ADMIN_SECRET_HEADER] must match it (constant-time compare) or the call is rejected 401.
- */
-val WebhookAdminAuthPlugin = createRouteScopedPlugin("WebhookAdminAuthPlugin") {
-    onCall { call ->
-        val configured = AppConfig.webhookAdminSecret
-        if (configured.isNullOrBlank()) {
-            call.respond(HttpStatusCode.ServiceUnavailable, "Webhook admin endpoint is not configured")
-            return@onCall
-        }
-        val provided = call.request.headers[WEBHOOK_ADMIN_SECRET_HEADER]
-        if (provided == null || !constantTimeEquals(provided, configured)) {
-            call.respond(HttpStatusCode.Unauthorized, "Invalid or missing admin secret")
-        }
-    }
-}
 
 /**
  * Registers the v1 webhook subscription management surface. Mounted at `/integrations/webhooks`
@@ -77,7 +55,11 @@ suspend fun ApplicationCall.handleCreateWebhookSubscription() {
     ) {
         val worldId = ValidationSteps.requiredInt("world_id", ::validationError).run(parameters)
         val callbackUrl = ValidationSteps.required("callback_url", ::validationError).run(parameters)
-        ValidationSteps.validateUrl("callback_url", ::validationError).run(callbackUrl)
+        ValidationSteps.validateCustom<AppFailure.ValidationError, String>(
+            "callback_url",
+            "Must be a public http(s) URL (no loopback, private, or link-local hosts)",
+            ::validationError,
+        ) { WebhookCallbackUrl.isSafe(it, requireHttps = AppConfig.env == Production) }.run(callbackUrl)
         val secret = ValidationSteps.required("secret", ::validationError).run(parameters)
         ValidationSteps.validateLength("secret", minLength = 8, maxLength = 256, errorMapper = ::validationError).run(secret)
 
@@ -160,6 +142,3 @@ private fun parsesAsStringList(raw: String): Boolean =
 
 private fun parsesAsJsonObject(raw: String): Boolean =
     runCatching { adminJson.decodeFromString(JsonObject.serializer(), raw) }.isSuccess
-
-private fun constantTimeEquals(a: String, b: String): Boolean =
-    MessageDigest.isEqual(a.toByteArray(Charsets.UTF_8), b.toByteArray(Charsets.UTF_8))

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookCallbackUrl.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookCallbackUrl.kt
@@ -1,0 +1,57 @@
+package app.mcorg.webhook
+
+import java.net.InetAddress
+import java.net.URI
+
+/**
+ * Safety check for a webhook callback URL, run at registration time. The poller will POST to this
+ * URL from inside the server, so an unsafe value is an SSRF vector (cloud metadata endpoints,
+ * loopback, RFC1918, link-local). This blocks the obvious literal targets and internal hostnames;
+ * `ValidationSteps.validateUrl` only checks the scheme.
+ *
+ * Scope: this catches IP-literal and well-known-name attacks without a live DNS lookup (so it stays
+ * hermetic and deterministic). It does NOT defeat a public hostname that *resolves* to a private
+ * address or DNS rebinding — that requires resolve-and-block at delivery time and is a follow-up to
+ * land before untrusted (per-user `/seam connect`) registration exists. Today registration is
+ * shared-secret / operator-only.
+ */
+object WebhookCallbackUrl {
+
+    private val BLOCKED_HOST_SUFFIXES = listOf(".local", ".internal", ".localhost", ".home.arpa")
+    private val BLOCKED_HOSTS = setOf("localhost")
+
+    fun isSafe(rawUrl: String, requireHttps: Boolean): Boolean {
+        val url = runCatching { URI.create(rawUrl.trim()).toURL() }.getOrNull() ?: return false
+
+        val scheme = url.protocol.lowercase()
+        if (scheme != "http" && scheme != "https") return false
+        if (requireHttps && scheme != "https") return false
+
+        val host = url.host?.lowercase()?.trim('[', ']').orEmpty()
+        if (host.isBlank()) return false
+        if (host in BLOCKED_HOSTS || BLOCKED_HOST_SUFFIXES.any { host.endsWith(it) }) return false
+
+        // Only parse as an address when the host is an IP literal — never resolve a hostname here.
+        ipLiteral(host)?.let { address -> if (!address.isPublic()) return false }
+
+        return true
+    }
+
+    /** Parse [host] as an IP literal (no DNS), or null if it is a registered hostname. */
+    private fun ipLiteral(host: String): InetAddress? {
+        val looksNumeric = host.contains(':') || host.all { it.isDigit() || it == '.' }
+        return if (looksNumeric) runCatching { InetAddress.getByName(host) }.getOrNull() else null
+    }
+
+    private fun InetAddress.isPublic(): Boolean =
+        !isLoopbackAddress &&
+            !isAnyLocalAddress &&
+            !isLinkLocalAddress &&
+            !isSiteLocalAddress &&
+            !isMulticastAddress &&
+            !isUniqueLocalIpv6()
+
+    /** IPv6 unique-local addresses (fc00::/7) — not flagged by the JDK's site-local check. */
+    private fun InetAddress.isUniqueLocalIpv6(): Boolean =
+        address.size == 16 && (address[0].toInt() and 0xfe) == 0xfc
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookDeliveryPoller.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookDeliveryPoller.kt
@@ -1,0 +1,98 @@
+package app.mcorg.webhook
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import org.slf4j.LoggerFactory
+
+/**
+ * Drains the `webhook_deliveries` outbox: each [pollOnce] picks up all due rows, groups them by
+ * subscription, and delivers each subscription's batch concurrently as one signed POST. The poll
+ * tick itself is the batching window — events that accrue between ticks for the same subscription
+ * coalesce into a single payload (see [WebhookPayload]).
+ *
+ * Delivery outcome drives both the outbox row and subscription health:
+ *  - success → rows marked `DELIVERED`, the subscription's failure streak reset;
+ *  - failure → rows rescheduled with backoff (immediate → 30s → 5min) or marked `FAILED` after
+ *    [MAX_ATTEMPTS]; the subscription's failure streak bumped, auto-deactivating it at
+ *    [DEACTIVATE_THRESHOLD] consecutive failures.
+ *
+ * Started and stopped by `configureWebhooks` against the Ktor lifecycle. Stateless apart from the
+ * shared [client] and the cleanup throttle, so it is safe to drive from a single polling loop.
+ */
+class WebhookDeliveryPoller(
+    private val client: HttpClient = defaultClient(),
+) {
+    private val logger = LoggerFactory.getLogger(WebhookDeliveryPoller::class.java)
+
+    @Volatile
+    private var lastCleanupAtMs: Long = 0
+
+    /** One poll cycle: deliver every due batch, then run cleanup if the throttle window elapsed. */
+    suspend fun pollOnce(nowMs: Long) {
+        val due = WebhookStore.findDueDeliveries()
+        if (due.isNotEmpty()) {
+            coroutineScope {
+                due.groupBy { it.subscriptionId }
+                    .map { (subscriptionId, rows) -> async { deliverBatch(subscriptionId, rows) } }
+                    .awaitAll()
+            }
+        }
+        if (nowMs - lastCleanupAtMs >= CLEANUP_INTERVAL_MS) {
+            lastCleanupAtMs = nowMs
+            WebhookStore.pruneOldDeliveries()
+        }
+    }
+
+    private suspend fun deliverBatch(subscriptionId: Int, rows: List<DueDelivery>) {
+        val ids = rows.map { it.id }
+        val body = WebhookPayload.build(rows.map { it.payload })
+        val signature = WebhookSigner.sign(rows.first().secret, body)
+        val error = post(rows.first().callbackUrl, body, signature)
+        if (error == null) {
+            WebhookStore.markDelivered(ids)
+            WebhookStore.recordSubscriptionSuccess(subscriptionId)
+        } else {
+            logger.warn("Webhook delivery to subscription {} failed: {}", subscriptionId, error)
+            WebhookStore.failOrReschedule(ids, MAX_ATTEMPTS, error)
+            WebhookStore.recordSubscriptionFailure(subscriptionId, DEACTIVATE_THRESHOLD)
+        }
+    }
+
+    /** POST the signed body. Returns `null` on a 2xx response, or a short error string otherwise. */
+    private suspend fun post(url: String, body: String, signature: String): String? = try {
+        val response = client.post(url) {
+            contentType(ContentType.Application.Json)
+            header(WebhookSigner.HEADER, signature)
+            setBody(body)
+        }
+        if (response.status.isSuccess()) null else "HTTP ${response.status.value}"
+    } catch (e: Exception) {
+        e.message ?: e::class.simpleName ?: "delivery error"
+    }
+
+    companion object {
+        const val POLL_INTERVAL_MS = 5_000L
+        const val MAX_ATTEMPTS = 3
+        const val DEACTIVATE_THRESHOLD = 10
+        const val CLEANUP_INTERVAL_MS = 3_600_000L // 1 hour
+        private const val REQUEST_TIMEOUT_MS = 5_000L
+
+        private fun defaultClient() = HttpClient(CIO) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = REQUEST_TIMEOUT_MS
+                connectTimeoutMillis = REQUEST_TIMEOUT_MS
+                socketTimeoutMillis = REQUEST_TIMEOUT_MS
+            }
+        }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookFanoutConsumer.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookFanoutConsumer.kt
@@ -1,0 +1,26 @@
+package app.mcorg.webhook
+
+import app.mcorg.event.EventEnvelope
+import app.mcorg.event.EventHandler
+import app.mcorg.event.SeamEvent
+
+/**
+ * Event-bus subscriber that fans a [SeamEvent] out to every active webhook subscription in the
+ * event's world whose filter matches ([eventMatchesFilter]). It does no HTTP: it serializes the
+ * envelope once and persists one outbox row per matching subscription. The [WebhookDeliveryPoller]
+ * picks those up and performs the actual signed delivery, retry, and batching.
+ *
+ * Producers stay unaware of subscribers — this consumer is the only place subscriptions are matched.
+ */
+class WebhookFanoutConsumer : EventHandler {
+    override suspend fun handle(event: SeamEvent) {
+        val matching = WebhookStore.findActiveSubscriptions(event.worldId)
+            .filter { eventMatchesFilter(it.eventFilter, event.eventType) }
+        if (matching.isEmpty()) return
+
+        val payload = EventEnvelope.serialize(event)
+        matching.forEach { subscription ->
+            WebhookStore.enqueueDelivery(subscription.id, event.eventType, payload)
+        }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookModels.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookModels.kt
@@ -1,0 +1,46 @@
+package app.mcorg.webhook
+
+/**
+ * A registered consumer of [app.mcorg.event.SeamEvent]s for one world. Fan-out matches an event
+ * against every active subscription in its world (see [eventMatchesFilter]) and enqueues a
+ * [WebhookDelivery] per match. The seam-discord bot is the first such consumer; the contract is
+ * endpoint-agnostic.
+ */
+data class WebhookSubscription(
+    val id: Int,
+    val worldId: Int,
+    val callbackUrl: String,
+    val secret: String,
+    val eventFilter: List<String>,
+    val active: Boolean,
+    val consecutiveFailures: Int,
+)
+
+/** Lifecycle of an outbox row, mirrored by the `status` CHECK constraint on `webhook_deliveries`. */
+enum class DeliveryStatus { PENDING, DELIVERED, FAILED }
+
+/**
+ * A single outbox row that the [WebhookDeliveryPoller] has picked up because it is due, joined with
+ * its subscription's routing data ([callbackUrl], [secret]). [payload] is the already-serialized
+ * event envelope; the poller batches all due rows for one subscription into a single signed POST.
+ */
+data class DueDelivery(
+    val id: Long,
+    val subscriptionId: Int,
+    val callbackUrl: String,
+    val secret: String,
+    val eventType: String,
+    val payload: String,
+    val attempts: Int,
+)
+
+/** Wildcard filter value that matches every event type. */
+const val WILDCARD_EVENT_FILTER = "*"
+
+/**
+ * Whether an event of [eventType] should be delivered to a subscription whose `event_filter` is
+ * [filter]. A filter containing [WILDCARD_EVENT_FILTER] matches everything; otherwise the event
+ * type must be listed explicitly. An empty filter matches nothing.
+ */
+fun eventMatchesFilter(filter: List<String>, eventType: String): Boolean =
+    filter.contains(WILDCARD_EVENT_FILTER) || filter.contains(eventType)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookPayload.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookPayload.kt
@@ -1,0 +1,25 @@
+package app.mcorg.webhook
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonObject
+
+/**
+ * Builds the HTTP body for a batch of due deliveries to one subscription. A single event is sent
+ * unwrapped (the bare envelope); multiple events accumulated within a poll window are wrapped as
+ * `{ "events": [ envelope, envelope, … ] }`. Consumers must handle both shapes.
+ */
+object WebhookPayload {
+    private val json = Json
+
+    /** [envelopes] are already-serialized event envelopes (JSON strings); must be non-empty. */
+    fun build(envelopes: List<String>): String {
+        require(envelopes.isNotEmpty()) { "Cannot build a webhook payload from zero events" }
+        if (envelopes.size == 1) return envelopes.single()
+        val batch: JsonObject = buildJsonObject {
+            put("events", JsonArray(envelopes.map { json.parseToJsonElement(it) }))
+        }
+        return json.encodeToString(JsonObject.serializer(), batch)
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookPlugin.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookPlugin.kt
@@ -1,0 +1,50 @@
+package app.mcorg.webhook
+
+import app.mcorg.event.SeamEventBus
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationStarted
+import io.ktor.server.application.ApplicationStopping
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import org.slf4j.LoggerFactory
+
+/**
+ * Process-wide webhook delivery, following the same singleton convention as [SeamEventBus]: a
+ * lifecycle-bound coroutine scope (`SupervisorJob`, so one bad poll never tears the loop down) plus
+ * the poller it drives.
+ */
+object SeamWebhooks {
+    val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO + CoroutineName("seam-webhook-delivery"))
+    val poller = WebhookDeliveryPoller()
+}
+
+/**
+ * Subscribes the [WebhookFanoutConsumer] to the event bus and starts the outbox polling loop, tying
+ * both to the Ktor lifecycle. The loop starts on `ApplicationStarted` (so it does not poll a
+ * not-yet-ready app) and the scope is cancelled on `ApplicationStopping`. Call once from
+ * `Application.module()`, after `configureEvents()`.
+ */
+fun Application.configureWebhooks() {
+    val logger = LoggerFactory.getLogger("WebhookPlugin")
+    SeamEventBus.bus.subscribe(WebhookFanoutConsumer())
+
+    monitor.subscribe(ApplicationStarted) {
+        SeamWebhooks.scope.launch {
+            while (isActive) {
+                try {
+                    SeamWebhooks.poller.pollOnce(System.currentTimeMillis())
+                } catch (e: Exception) {
+                    logger.error("Webhook poll cycle failed", e)
+                }
+                delay(WebhookDeliveryPoller.POLL_INTERVAL_MS)
+            }
+        }
+    }
+    monitor.subscribe(ApplicationStopping) { SeamWebhooks.scope.cancel("Application stopping") }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookSigner.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookSigner.kt
@@ -1,0 +1,23 @@
+package app.mcorg.webhook
+
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Signs a webhook body so the receiver can verify it came from Seam and was not tampered with.
+ * The signature is `sha256=<hex>` where `<hex>` is the lowercase hex HMAC-SHA256 of the exact raw
+ * request body keyed by the subscription's shared secret. Sent in the `X-Seam-Signature` header.
+ *
+ * The receiver recomputes the HMAC over the raw bytes it received and compares in constant time.
+ */
+object WebhookSigner {
+    const val HEADER = "X-Seam-Signature"
+    private const val ALGORITHM = "HmacSHA256"
+
+    fun sign(secret: String, body: String): String {
+        val mac = Mac.getInstance(ALGORITHM)
+        mac.init(SecretKeySpec(secret.toByteArray(Charsets.UTF_8), ALGORITHM))
+        val digest = mac.doFinal(body.toByteArray(Charsets.UTF_8))
+        return "sha256=" + digest.joinToString("") { "%02x".format(it) }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookStore.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/webhook/WebhookStore.kt
@@ -1,0 +1,230 @@
+package app.mcorg.webhook
+
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import org.slf4j.LoggerFactory
+import java.time.Instant
+
+/**
+ * All database access for webhook subscriptions and the delivery outbox. Used by
+ * [WebhookFanoutConsumer] (enqueue) and [WebhookDeliveryPoller] (drain). Every call swallows and
+ * logs database failures, returning a safe default — webhook delivery is best-effort and must never
+ * propagate into the event-bus dispatch or the polling loop that drive it.
+ */
+object WebhookStore {
+    private val logger = LoggerFactory.getLogger(WebhookStore::class.java)
+    private val json = Json
+    private val stringListSerializer = ListSerializer(String.serializer())
+
+    /** Active subscriptions for [worldId]. Filter matching ([eventMatchesFilter]) happens in-app. */
+    suspend fun findActiveSubscriptions(worldId: Int): List<WebhookSubscription> {
+        val result = DatabaseSteps.query<Unit, List<WebhookSubscription>>(
+            sql = SafeSQL.select(
+                """
+                SELECT id, world_id, callback_url, secret, event_filter::text AS event_filter, consecutive_failures
+                FROM webhook_subscriptions
+                WHERE world_id = ? AND active = true
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ -> statement.setInt(1, worldId) },
+            resultMapper = { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(
+                            WebhookSubscription(
+                                id = rs.getInt("id"),
+                                worldId = rs.getInt("world_id"),
+                                callbackUrl = rs.getString("callback_url"),
+                                secret = rs.getString("secret"),
+                                eventFilter = parseFilter(rs.getString("event_filter")),
+                                active = true,
+                                consecutiveFailures = rs.getInt("consecutive_failures"),
+                            )
+                        )
+                    }
+                }
+            },
+        ).process(Unit)
+        return result.orEmpty("findActiveSubscriptions(world=$worldId)")
+    }
+
+    /** Append one outbox row (status PENDING, due immediately) for [subscriptionId]. */
+    suspend fun enqueueDelivery(subscriptionId: Int, eventType: String, payload: String) {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                """
+                INSERT INTO webhook_deliveries (subscription_id, event_type, payload)
+                VALUES (?, ?, ?::jsonb)
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ ->
+                statement.setInt(1, subscriptionId)
+                statement.setString(2, eventType)
+                statement.setString(3, payload)
+            },
+        ).process(Unit).logIfFailed("enqueueDelivery(sub=$subscriptionId, $eventType)")
+    }
+
+    /**
+     * Pending rows whose subscription is still active and that are due now, oldest first and grouped
+     * by subscription. Joined with the subscription's callback URL + secret so the poller has
+     * everything it needs in one scan.
+     */
+    suspend fun findDueDeliveries(limit: Int = 200): List<DueDelivery> {
+        val result = DatabaseSteps.query<Unit, List<DueDelivery>>(
+            sql = SafeSQL.select(
+                """
+                SELECT d.id, d.subscription_id, d.event_type, d.payload::text AS payload, d.attempts,
+                       s.callback_url, s.secret
+                FROM webhook_deliveries d
+                JOIN webhook_subscriptions s ON s.id = d.subscription_id
+                WHERE d.status = 'PENDING' AND d.next_attempt_at <= CURRENT_TIMESTAMP AND s.active = true
+                ORDER BY d.subscription_id, d.created_at, d.id
+                LIMIT ?
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ -> statement.setInt(1, limit) },
+            resultMapper = { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(
+                            DueDelivery(
+                                id = rs.getLong("id"),
+                                subscriptionId = rs.getInt("subscription_id"),
+                                callbackUrl = rs.getString("callback_url"),
+                                secret = rs.getString("secret"),
+                                eventType = rs.getString("event_type"),
+                                payload = rs.getString("payload"),
+                                attempts = rs.getInt("attempts"),
+                            )
+                        )
+                    }
+                }
+            },
+        ).process(Unit)
+        return result.orEmpty("findDueDeliveries")
+    }
+
+    /** Mark a batch delivered. */
+    suspend fun markDelivered(ids: List<Long>) {
+        if (ids.isEmpty()) return
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.update(
+                """
+                UPDATE webhook_deliveries
+                SET status = 'DELIVERED', delivered_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP, last_error = NULL
+                WHERE id = ANY(?)
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ ->
+                statement.setArray(1, statement.connection.createArrayOf("bigint", ids.toTypedArray()))
+            },
+        ).process(Unit).logIfFailed("markDelivered(${ids.size})")
+    }
+
+    /**
+     * Account for a failed batch: bump each row's attempt count, then either reschedule it
+     * (PENDING) with backoff or give up (FAILED) once it has used all [maxAttempts]. Backoff keys
+     * off each row's own attempt count, so a freshly-enqueued row batched alongside an
+     * already-retried one still gets the full retry budget.
+     */
+    suspend fun failOrReschedule(ids: List<Long>, maxAttempts: Int, error: String) {
+        if (ids.isEmpty()) return
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.update(
+                """
+                UPDATE webhook_deliveries
+                SET attempts = attempts + 1,
+                    last_error = ?,
+                    updated_at = CURRENT_TIMESTAMP,
+                    status = CASE WHEN attempts + 1 >= ? THEN 'FAILED' ELSE 'PENDING' END,
+                    next_attempt_at = CASE
+                        WHEN attempts + 1 >= ? THEN next_attempt_at
+                        WHEN attempts + 1 = 1 THEN CURRENT_TIMESTAMP + INTERVAL '30 seconds'
+                        ELSE CURRENT_TIMESTAMP + INTERVAL '5 minutes'
+                    END
+                WHERE id = ANY(?)
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ ->
+                statement.setString(1, error.take(1000))
+                statement.setInt(2, maxAttempts)
+                statement.setInt(3, maxAttempts)
+                statement.setArray(4, statement.connection.createArrayOf("bigint", ids.toTypedArray()))
+            },
+        ).process(Unit).logIfFailed("failOrReschedule(${ids.size})")
+    }
+
+    /** Reset a subscription's failure streak after a successful delivery. */
+    suspend fun recordSubscriptionSuccess(subscriptionId: Int) {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.update(
+                """
+                UPDATE webhook_subscriptions
+                SET consecutive_failures = 0, updated_at = CURRENT_TIMESTAMP
+                WHERE id = ? AND consecutive_failures <> 0
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ -> statement.setInt(1, subscriptionId) },
+        ).process(Unit).logIfFailed("recordSubscriptionSuccess(sub=$subscriptionId)")
+    }
+
+    /**
+     * Record a failed delivery against a subscription's health, auto-deactivating it once it has
+     * [deactivateThreshold] consecutive failures.
+     */
+    suspend fun recordSubscriptionFailure(subscriptionId: Int, deactivateThreshold: Int) {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.update(
+                """
+                UPDATE webhook_subscriptions
+                SET consecutive_failures = consecutive_failures + 1,
+                    active = CASE WHEN consecutive_failures + 1 >= ? THEN false ELSE active END,
+                    updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ ->
+                statement.setInt(1, deactivateThreshold)
+                statement.setInt(2, subscriptionId)
+            },
+        ).process(Unit).logIfFailed("recordSubscriptionFailure(sub=$subscriptionId)")
+    }
+
+    /** Prune delivered rows older than 7 days and failed rows older than 30 days. */
+    suspend fun pruneOldDeliveries() {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.delete(
+                """
+                DELETE FROM webhook_deliveries
+                WHERE (status = 'DELIVERED' AND delivered_at < CURRENT_TIMESTAMP - INTERVAL '7 days')
+                   OR (status = 'FAILED' AND updated_at < CURRENT_TIMESTAMP - INTERVAL '30 days')
+                """.trimIndent()
+            ),
+            parameterSetter = { _, _ -> },
+        ).process(Unit).logIfFailed("pruneOldDeliveries")
+    }
+
+    private fun parseFilter(raw: String?): List<String> =
+        if (raw.isNullOrBlank()) emptyList()
+        else runCatching { json.decodeFromString(stringListSerializer, raw) }.getOrElse {
+            logger.warn("Unparseable event_filter '{}', treating as empty", raw)
+            emptyList()
+        }
+
+    private fun <T> Result<*, List<T>>.orEmpty(op: String): List<T> = when (this) {
+        is Result.Success -> value
+        is Result.Failure -> {
+            logger.error("Webhook DB op failed: {} ({})", op, error)
+            emptyList()
+        }
+    }
+
+    private fun Result<*, *>.logIfFailed(op: String) {
+        if (this is Result.Failure) logger.error("Webhook DB op failed: {} ({})", op, error)
+    }
+}

--- a/webapp/mc-web/src/main/resources/db/migration/V2_43_0__create_webhook_subscriptions_and_deliveries.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_43_0__create_webhook_subscriptions_and_deliveries.sql
@@ -1,0 +1,45 @@
+-- Webhook fan-out (MCO-229): delivery layer between the in-process event bus (MCO-228) and
+-- external HTTP endpoints (the seam-discord bot is the first consumer; the design is
+-- endpoint-agnostic). Two tables: subscriptions (who wants which events, where) and a
+-- transactional outbox (one row per (subscription, event), driven by a background poller).
+
+CREATE TABLE webhook_subscriptions (
+    id SERIAL PRIMARY KEY,
+    world_id INTEGER NOT NULL REFERENCES world(id) ON DELETE CASCADE,
+    callback_url TEXT NOT NULL,
+    -- Shared secret used to sign each delivery's raw body (HMAC-SHA256 -> X-Seam-Signature).
+    secret TEXT NOT NULL,
+    -- JSONB array of event-type strings to deliver, or ["*"] for all. Producers are unaware
+    -- of subscribers; matching happens here at fan-out time.
+    event_filter JSONB NOT NULL DEFAULT '["*"]',
+    -- Consumer-specific routing data (e.g. the Discord channel id). Opaque to fan-out.
+    metadata JSONB NOT NULL DEFAULT '{}',
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    -- Consecutive failed deliveries; the subscription auto-deactivates once this hits the
+    -- health threshold (see WebhookDeliveryPoller). Reset to 0 on any successful delivery.
+    consecutive_failures INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_webhook_subscriptions_world_active ON webhook_subscriptions(world_id, active);
+
+CREATE TABLE webhook_deliveries (
+    id BIGSERIAL PRIMARY KEY,
+    subscription_id INTEGER NOT NULL REFERENCES webhook_subscriptions(id) ON DELETE CASCADE,
+    event_type VARCHAR(100) NOT NULL,
+    -- The serialized event envelope ({event_type, world_id, timestamp, actor, data}).
+    payload JSONB NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING' CHECK (status IN ('PENDING', 'DELIVERED', 'FAILED')),
+    attempts INTEGER NOT NULL DEFAULT 0,
+    -- The poller picks up PENDING rows whose next_attempt_at is due; retry backoff bumps it.
+    next_attempt_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    last_error TEXT,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    delivered_at TIMESTAMP WITH TIME ZONE
+);
+
+-- Drives the poller's "due work" scan: pending rows ordered by when they became due.
+CREATE INDEX idx_webhook_deliveries_due ON webhook_deliveries(status, next_attempt_at);
+CREATE INDEX idx_webhook_deliveries_subscription ON webhook_deliveries(subscription_id);

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookAdminIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookAdminIT.kt
@@ -7,6 +7,7 @@ import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.world.CreateWorldInput
 import app.mcorg.pipeline.world.CreateWorldStep
 import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.WEBHOOK_ADMIN_SECRET_HEADER
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.header

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookAdminIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookAdminIT.kt
@@ -1,0 +1,182 @@
+package app.mcorg.webhook
+
+import app.mcorg.config.AppConfig
+import app.mcorg.config.Database
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.request
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpMethod
+import io.ktor.client.statement.bodyAsText
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.http.formUrlEncode
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class WebhookAdminIT : WithUser() {
+
+    private val secret = "admin-shared-secret"
+
+    @AfterEach
+    fun resetConfig() {
+        AppConfig.webhookAdminSecret = null
+    }
+
+    @Test
+    fun `creates a subscription with a valid secret and form params`() = testApplication {
+        AppConfig.webhookAdminSecret = secret
+        configureRoutes()
+        val worldId = createWorld("wh-admin-create")
+
+        val response = create(
+            "world_id" to worldId.toString(),
+            "callback_url" to "https://example.com/hook",
+            "secret" to "subscriber-secret",
+            "event_filter" to """["project_created"]""",
+            secret = secret,
+        )
+
+        assertEquals(HttpStatusCode.Created, response.status)
+        assertTrue(response.bodyAsText().contains("Created webhook subscription #"))
+        assertEquals(1, countSubscriptions(worldId))
+    }
+
+    @Test
+    fun `defaults the event filter to wildcard when omitted`() = testApplication {
+        AppConfig.webhookAdminSecret = secret
+        configureRoutes()
+        val worldId = createWorld("wh-admin-default-filter")
+
+        create(
+            "world_id" to worldId.toString(),
+            "callback_url" to "https://example.com/hook",
+            "secret" to "subscriber-secret",
+            secret = secret,
+        )
+
+        assertEquals("""["*"]""", eventFilterFor(worldId))
+    }
+
+    @Test
+    fun `rejects a missing or wrong secret`() = testApplication {
+        AppConfig.webhookAdminSecret = secret
+        configureRoutes()
+        val worldId = createWorld("wh-admin-auth")
+
+        val noHeader = create("world_id" to worldId.toString(), "callback_url" to "https://e.com/h", "secret" to "subscriber-secret", secret = null)
+        assertEquals(HttpStatusCode.Unauthorized, noHeader.status)
+
+        val wrongHeader = create("world_id" to worldId.toString(), "callback_url" to "https://e.com/h", "secret" to "subscriber-secret", secret = "nope")
+        assertEquals(HttpStatusCode.Unauthorized, wrongHeader.status)
+
+        assertEquals(0, countSubscriptions(worldId))
+    }
+
+    @Test
+    fun `fails closed with 503 when no admin secret is configured`() = testApplication {
+        AppConfig.webhookAdminSecret = null
+        configureRoutes()
+        val worldId = createWorld("wh-admin-unconfigured")
+
+        val response = create("world_id" to worldId.toString(), "callback_url" to "https://e.com/h", "secret" to "subscriber-secret", secret = "anything")
+        assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+    }
+
+    @Test
+    fun `rejects invalid input`() = testApplication {
+        AppConfig.webhookAdminSecret = secret
+        configureRoutes()
+        createWorld("wh-admin-invalid")
+
+        val missingWorld = create("callback_url" to "https://e.com/h", "secret" to "subscriber-secret", secret = secret)
+        assertEquals(HttpStatusCode.BadRequest, missingWorld.status)
+
+        val badUrl = create("world_id" to "1", "callback_url" to "not-a-url", "secret" to "subscriber-secret", secret = secret)
+        assertEquals(HttpStatusCode.UnprocessableEntity, badUrl.status)
+    }
+
+    @Test
+    fun `deletes a subscription`() = testApplication {
+        AppConfig.webhookAdminSecret = secret
+        configureRoutes()
+        val worldId = createWorld("wh-admin-delete")
+        val id = runBlocking {
+            (CreateWebhookSubscriptionStep.process(
+                CreateWebhookSubscriptionInput(worldId, "https://e.com/h", "subscriber-secret", """["*"]""", "{}")
+            ) as Result.Success).value
+        }
+
+        val response = delete(id, secret)
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(0, countSubscriptions(worldId))
+
+        val again = delete(id, secret)
+        assertEquals(HttpStatusCode.NotFound, again.status)
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    private fun ApplicationTestBuilder.configureRoutes() {
+        application {
+            routing {
+                install(AuthPlugin)
+                webhookAdminRoutes()
+            }
+        }
+    }
+
+    private suspend fun ApplicationTestBuilder.create(vararg params: Pair<String, String>, secret: String?): HttpResponse =
+        client.post("/integrations/webhooks") {
+            if (secret != null) header(WEBHOOK_ADMIN_SECRET_HEADER, secret)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(params.toList().formUrlEncode())
+        }
+
+    private suspend fun ApplicationTestBuilder.delete(id: Int, secret: String): HttpResponse =
+        client.request("/integrations/webhooks/$id") {
+            method = HttpMethod.Delete
+            header(WEBHOOK_ADMIN_SECRET_HEADER, secret)
+        }
+
+    private fun createWorld(name: String): Int = runBlocking {
+        (CreateWorldStep(user).process(CreateWorldInput(name, "test", MinecraftVersion.fromString("1.21.4"))) as Result.Success).value
+    }
+
+    private fun countSubscriptions(worldId: Int): Int =
+        Database.getConnection().use { conn ->
+            conn.prepareStatement("SELECT COUNT(*) FROM webhook_subscriptions WHERE world_id = ?").use { st ->
+                st.setInt(1, worldId)
+                st.executeQuery().use { rs -> rs.next(); rs.getInt(1) }
+            }
+        }
+
+    private fun eventFilterFor(worldId: Int): String =
+        Database.getConnection().use { conn ->
+            conn.prepareStatement("SELECT event_filter::text FROM webhook_subscriptions WHERE world_id = ?").use { st ->
+                st.setInt(1, worldId)
+                st.executeQuery().use { rs -> rs.next(); rs.getString(1) }
+            }
+        }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookCallbackUrlTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookCallbackUrlTest.kt
@@ -1,0 +1,49 @@
+package app.mcorg.webhook
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WebhookCallbackUrlTest {
+
+    @Test
+    fun `accepts public http and https urls`() {
+        assertTrue(WebhookCallbackUrl.isSafe("https://discord.com/api/webhooks/123/abc", requireHttps = false))
+        assertTrue(WebhookCallbackUrl.isSafe("http://example.com/hook", requireHttps = false))
+    }
+
+    @Test
+    fun `rejects non-http schemes and malformed urls`() {
+        assertFalse(WebhookCallbackUrl.isSafe("ftp://example.com/x", requireHttps = false))
+        assertFalse(WebhookCallbackUrl.isSafe("file:///etc/passwd", requireHttps = false))
+        assertFalse(WebhookCallbackUrl.isSafe("not-a-url", requireHttps = false))
+        assertFalse(WebhookCallbackUrl.isSafe("", requireHttps = false))
+    }
+
+    @Test
+    fun `rejects loopback and internal hostnames`() {
+        assertFalse(WebhookCallbackUrl.isSafe("http://localhost/hook", requireHttps = false))
+        assertFalse(WebhookCallbackUrl.isSafe("http://db.internal/hook", requireHttps = false))
+        assertFalse(WebhookCallbackUrl.isSafe("http://service.local/hook", requireHttps = false))
+    }
+
+    @Test
+    fun `rejects loopback, private, and link-local ip literals`() {
+        assertFalse(WebhookCallbackUrl.isSafe("http://127.0.0.1/hook", requireHttps = false))
+        assertFalse(WebhookCallbackUrl.isSafe("http://10.0.0.5/hook", requireHttps = false))
+        assertFalse(WebhookCallbackUrl.isSafe("http://192.168.1.10/hook", requireHttps = false))
+        assertFalse(WebhookCallbackUrl.isSafe("http://172.16.4.4/hook", requireHttps = false))
+        assertFalse(WebhookCallbackUrl.isSafe("http://0.0.0.0/hook", requireHttps = false))
+        // Cloud metadata endpoint (link-local) — the canonical SSRF target.
+        assertFalse(WebhookCallbackUrl.isSafe("http://169.254.169.254/latest/meta-data", requireHttps = false))
+        // IPv6 loopback and unique-local.
+        assertFalse(WebhookCallbackUrl.isSafe("http://[::1]/hook", requireHttps = false))
+        assertFalse(WebhookCallbackUrl.isSafe("http://[fc00::1]/hook", requireHttps = false))
+    }
+
+    @Test
+    fun `requires https when asked`() {
+        assertFalse(WebhookCallbackUrl.isSafe("http://example.com/hook", requireHttps = true))
+        assertTrue(WebhookCallbackUrl.isSafe("https://example.com/hook", requireHttps = true))
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookDeliveryIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookDeliveryIT.kt
@@ -1,0 +1,159 @@
+package app.mcorg.webhook
+
+import app.mcorg.config.Database
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.project.ProjectType
+import app.mcorg.event.ProjectCreated
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo
+import com.github.tomakehurst.wiremock.junit5.WireMockTest
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@Tag("database")
+@WireMockTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class WebhookDeliveryIT : WithUser() {
+
+    private val consumer = WebhookFanoutConsumer()
+    private val poller = WebhookDeliveryPoller()
+
+    @Test
+    fun `delivers a matching event as a signed POST and marks it DELIVERED`(wm: WireMockRuntimeInfo) {
+        val worldId = createWorld("wh-deliver")
+        val secret = "s3cr3t"
+        val subId = insertSubscription(worldId, wm.httpBaseUrl + "/hook", secret, """["project_created"]""")
+        wm.wireMock.register(WireMock.post("/hook").willReturn(WireMock.aResponse().withStatus(202)))
+
+        fanOutAndPoll(ProjectCreated(worldId, user.id, Instant.now(), 1, "Iron Farm", ProjectType.REDSTONE))
+
+        val requests = wm.wireMock.find(WireMock.postRequestedFor(WireMock.urlEqualTo("/hook")))
+        assertEquals(1, requests.size, "expected exactly one delivery POST")
+        val body = requests[0].bodyAsString
+        assertEquals("project_created", Json.parseToJsonElement(body).jsonObject["event_type"]!!.jsonPrimitive.content)
+        // Signature is computed over the exact bytes POSTed.
+        assertEquals(WebhookSigner.sign(secret, body), requests[0].getHeader(WebhookSigner.HEADER))
+
+        assertEquals("DELIVERED" to 0, deliveryStatus(subId))
+    }
+
+    @Test
+    fun `does not deliver events that do not match the subscription filter`(wm: WireMockRuntimeInfo) {
+        val worldId = createWorld("wh-filter")
+        insertSubscription(worldId, wm.httpBaseUrl + "/hook", "x", """["task_toggled"]""")
+        wm.wireMock.register(WireMock.post("/hook").willReturn(WireMock.aResponse().withStatus(202)))
+
+        fanOutAndPoll(ProjectCreated(worldId, user.id, Instant.now(), 1, "Iron Farm", ProjectType.REDSTONE))
+
+        assertEquals(0, wm.wireMock.find(WireMock.postRequestedFor(WireMock.urlEqualTo("/hook"))).size)
+    }
+
+    @Test
+    fun `batches multiple due events for one subscription into a single events array`(wm: WireMockRuntimeInfo) {
+        val worldId = createWorld("wh-batch")
+        insertSubscription(worldId, wm.httpBaseUrl + "/hook", "x", """["*"]""")
+        wm.wireMock.register(WireMock.post("/hook").willReturn(WireMock.aResponse().withStatus(202)))
+
+        runBlocking {
+            consumer.handle(ProjectCreated(worldId, user.id, Instant.now(), 1, "A", ProjectType.REDSTONE))
+            consumer.handle(ProjectCreated(worldId, user.id, Instant.now(), 2, "B", ProjectType.REDSTONE))
+            poller.pollOnce(System.currentTimeMillis())
+        }
+
+        val requests = wm.wireMock.find(WireMock.postRequestedFor(WireMock.urlEqualTo("/hook")))
+        assertEquals(1, requests.size, "two events to one subscription should coalesce into one POST")
+        val events = Json.parseToJsonElement(requests[0].bodyAsString).jsonObject["events"]!!.jsonArray
+        assertEquals(2, events.size)
+    }
+
+    @Test
+    fun `reschedules with an attempt bump and records subscription failure on HTTP error`(wm: WireMockRuntimeInfo) {
+        val worldId = createWorld("wh-fail")
+        val subId = insertSubscription(worldId, wm.httpBaseUrl + "/hook", "x", """["*"]""")
+        wm.wireMock.register(WireMock.post("/hook").willReturn(WireMock.aResponse().withStatus(500)))
+
+        fanOutAndPoll(ProjectCreated(worldId, user.id, Instant.now(), 1, "A", ProjectType.REDSTONE))
+
+        // One failed attempt: still PENDING for retry, attempt count bumped.
+        assertEquals("PENDING" to 1, deliveryStatus(subId))
+        // Subscription health: one consecutive failure, well below the deactivation threshold.
+        val (failures, active) = subscriptionHealth(subId)
+        assertEquals(1, failures)
+        assertTrue(active)
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    private fun fanOutAndPoll(event: ProjectCreated) = runBlocking {
+        consumer.handle(event)
+        poller.pollOnce(System.currentTimeMillis())
+    }
+
+    private fun createWorld(name: String): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(name, "test", MinecraftVersion.fromString("1.21.4"))
+        )
+        (result as Result.Success).value
+    }
+
+    private fun insertSubscription(worldId: Int, url: String, secret: String, filterJson: String): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                """
+                INSERT INTO webhook_subscriptions (world_id, callback_url, secret, event_filter)
+                VALUES (?, ?, ?, ?::jsonb)
+                RETURNING id
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ ->
+                statement.setInt(1, worldId)
+                statement.setString(2, url)
+                statement.setString(3, secret)
+                statement.setString(4, filterJson)
+            },
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    /** (status, attempts) of the single delivery row for [subId]. */
+    private fun deliveryStatus(subId: Int): Pair<String, Int> =
+        Database.getConnection().use { conn ->
+            conn.prepareStatement("SELECT status, attempts FROM webhook_deliveries WHERE subscription_id = ?").use { st ->
+                st.setInt(1, subId)
+                st.executeQuery().use { rs ->
+                    assertTrue(rs.next(), "expected a delivery row for subscription $subId")
+                    rs.getString("status") to rs.getInt("attempts")
+                }
+            }
+        }
+
+    /** (consecutive_failures, active) for [subId]. */
+    private fun subscriptionHealth(subId: Int): Pair<Int, Boolean> =
+        Database.getConnection().use { conn ->
+            conn.prepareStatement("SELECT consecutive_failures, active FROM webhook_subscriptions WHERE id = ?").use { st ->
+                st.setInt(1, subId)
+                st.executeQuery().use { rs ->
+                    assertTrue(rs.next(), "expected subscription $subId")
+                    rs.getInt("consecutive_failures") to rs.getBoolean("active")
+                }
+            }
+        }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookFilterTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookFilterTest.kt
@@ -1,0 +1,27 @@
+package app.mcorg.webhook
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class WebhookFilterTest {
+
+    @Test
+    fun `wildcard filter matches any event type`() {
+        assertTrue(eventMatchesFilter(listOf("*"), "project_created"))
+        assertTrue(eventMatchesFilter(listOf("*"), "anything_at_all"))
+    }
+
+    @Test
+    fun `explicit filter matches only listed event types`() {
+        val filter = listOf("project_created", "idea_imported")
+        assertTrue(eventMatchesFilter(filter, "project_created"))
+        assertTrue(eventMatchesFilter(filter, "idea_imported"))
+        assertFalse(eventMatchesFilter(filter, "task_toggled"))
+    }
+
+    @Test
+    fun `empty filter matches nothing`() {
+        assertFalse(eventMatchesFilter(emptyList(), "project_created"))
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookPayloadTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookPayloadTest.kt
@@ -1,0 +1,36 @@
+package app.mcorg.webhook
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class WebhookPayloadTest {
+
+    @Test
+    fun `a single event is delivered unwrapped`() {
+        val envelope = """{"event_type":"project_created","world_id":1}"""
+        assertEquals(envelope, WebhookPayload.build(listOf(envelope)))
+    }
+
+    @Test
+    fun `multiple events are wrapped in an events array preserving order`() {
+        val first = """{"event_type":"project_created","world_id":1}"""
+        val second = """{"event_type":"task_toggled","world_id":1}"""
+
+        val body = WebhookPayload.build(listOf(first, second))
+        val events = Json.parseToJsonElement(body).jsonObject["events"]!!.jsonArray
+
+        assertEquals(2, events.size)
+        assertEquals("project_created", events[0].jsonObject["event_type"]!!.jsonPrimitive.content)
+        assertEquals("task_toggled", events[1].jsonObject["event_type"]!!.jsonPrimitive.content)
+    }
+
+    @Test
+    fun `building from zero events is rejected`() {
+        assertFailsWith<IllegalArgumentException> { WebhookPayload.build(emptyList()) }
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookSignerTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/webhook/WebhookSignerTest.kt
@@ -1,0 +1,34 @@
+package app.mcorg.webhook
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class WebhookSignerTest {
+
+    @Test
+    fun `matches a known HMAC-SHA256 vector and is prefixed`() {
+        // Well-known vector: HMAC-SHA256("key", "The quick brown fox jumps over the lazy dog").
+        assertEquals(
+            "sha256=f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8",
+            WebhookSigner.sign("key", "The quick brown fox jumps over the lazy dog"),
+        )
+    }
+
+    @Test
+    fun `produces 64 lowercase hex chars after the prefix`() {
+        val sig = WebhookSigner.sign("secret", """{"event_type":"project_created"}""")
+        val hex = sig.removePrefix("sha256=")
+        assertEquals(64, hex.length)
+        assertTrue(hex.all { it in "0123456789abcdef" }, "expected lowercase hex, got $hex")
+    }
+
+    @Test
+    fun `is deterministic but varies with secret and body`() {
+        val body = """{"event_type":"task_toggled"}"""
+        assertEquals(WebhookSigner.sign("s", body), WebhookSigner.sign("s", body))
+        assertNotEquals(WebhookSigner.sign("s1", body), WebhookSigner.sign("s2", body))
+        assertNotEquals(WebhookSigner.sign("s", body), WebhookSigner.sign("s", body + " "))
+    }
+}


### PR DESCRIPTION
Delivery layer between the in-process event bus (MCO-228) and external HTTP endpoints — the seam-discord bot is the first consumer; the design is endpoint-agnostic. Closes MCO-229.

## Approach
A **transactional outbox**, not direct POSTs from the bus consumer. `WebhookFanoutConsumer` only persists one `webhook_deliveries` row per matching active subscription; a lifecycle-tied `WebhookDeliveryPoller` (5s) does all HTTP. The poll tick is the batching window — crash-safe, with retry/batching accounting in one place. First attempt lands within ~5s, inside the spec's 5–10s window.

## What's here
- **`V2_43_0`** migration: `webhook_subscriptions` + `webhook_deliveries` (outbox).
- **`WebhookStore`** — all SafeSQL/DatabaseSteps access; pure `eventMatchesFilter` (`["*"]` or explicit list).
- **Signed delivery** — `X-Seam-Signature: sha256=<hex HMAC-SHA256(secret, raw_body)>`, 5s timeout, per-subscription concurrency.
- **Batching** — a single due event is delivered unwrapped; 2+ coalesced as `{"events":[...]}`. Consumers handle both.
- **Retry** immediate → 30s → 5min (3 attempts), done per-row in one SQL `CASE` so a fresh row batched with a retrying one keeps its full budget.
- **Health** — auto-deactivate a subscription after 10 consecutive failures (reset on success); hourly prune of `DELIVERED` >7d / `FAILED` >30d.
- **`configureWebhooks()`** wired into `Application.module()` after `configureEvents()`.

## v1 subscription setup
Form-param admin endpoints `POST` / `DELETE /integrations/webhooks`, gated by a shared secret (`X-Seam-Admin-Secret` vs `WEBHOOK_ADMIN_SECRET`, **fails closed** = 503 if unset). HTML responses, consistent with the app. Per-user `/seam connect` and a JSON API are deferred to later Discord-integration phases (MCO-235/Phase 3).

## Flags for review
- **Architecture deviation (intentional):** outbox + poller instead of the issue's "consumer POSTs directly." Rationale above.
- **One auth change:** added `/integrations/` to `AuthPlugin`'s sign-in-redirect allowlist so the machine endpoint isn't bounced to the user login flow. The path is still secret-gated; `/admin/*` (super-admin JWT UI) was intentionally not reused to avoid double-gating.

## Wire contract note (for the seam-discord consumer / MCO-230)
Payloads are stored as JSONB, so Postgres normalizes whitespace/key order — the signed body is the DB-roundtripped JSON. Verify signatures over the **raw received bytes**, never by re-serializing.

## Tests
16 new, all green (full suite: 570 unit + 96 db, 0 failures):
- Unit: `WebhookSignerTest` (known HMAC vector), `WebhookPayloadTest`, `WebhookFilterTest`.
- ITs (`@Tag("database")`, WireMock + Testcontainers): `WebhookDeliveryIT` (deliver+sign, filter miss, batch, fail→reschedule+health), `WebhookAdminIT` (create, default filter, 401 auth, 503 unconfigured, 400/422 validation, delete 200/404).

No graph/scoring (`mc-engine`) code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)