### PR TITLE
Gathering Planner — Drill: Active choices panel for overrides (MCO-227)

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -7,8 +7,10 @@ import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.project.commonsteps.GetProjectByIdStep
 import app.mcorg.pipeline.project.commonsteps.GetViewPreferenceInput
 import app.mcorg.pipeline.project.commonsteps.GetViewPreferenceStep
+import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.pipeline.resources.GatheringPlanInput
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
+import app.mcorg.pipeline.resources.GetPlanOverridesStep
 import app.mcorg.pipeline.resources.buildCandidateCounts
 import app.mcorg.pipeline.resources.buildNodeIngredients
 import app.mcorg.pipeline.resources.drillTreeFor
@@ -95,6 +97,7 @@ suspend fun ApplicationCall.handleGetProject() {
     val drillGraph = if (drillTarget != null) getGraphForWorld(worldId) else null
     val drillCandidateCounts = if (drillTarget != null) buildCandidateCounts(drillTarget, drillGraph) else emptyMap()
     val drillNodeIngredients = if (drillTarget != null && plan != null) buildNodeIngredients(plan) else emptyMap()
+    val drillOverrides = if (drillTarget != null) GetPlanOverridesStep.process(projectId).getOrNull() ?: PlanOverrides.NONE else PlanOverrides.NONE
 
     respondHtml(
         projectDetailPage(
@@ -102,6 +105,7 @@ suspend fun ApplicationCall.handleGetProject() {
             isWorldAdmin = isAdmin, plan = plan, progressMap = progressMap,
             drillTarget = drillTarget, drillCandidateCounts = drillCandidateCounts,
             drillNodeIngredients = drillNodeIngredients, drillHighlightItemId = drillItemId,
+            drillOverrides = drillOverrides, drillGraph = drillGraph,
         )
     )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -3,6 +3,8 @@ package app.mcorg.pipeline.resources
 import app.mcorg.domain.model.minecraft.MinecraftTag
 import app.mcorg.engine.model.ItemSourceGraph
 import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.engine.plan.TargetTree
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.failure.AppFailure
@@ -87,8 +89,9 @@ suspend fun ApplicationCall.handleGetDrillChain() {
     // Build candidateCounts map: item-id → number of source candidates in the graph
     val candidateCounts = buildCandidateCounts(targetTree, graph)
     val nodeIngredients = buildNodeIngredients(plan)
+    val overrides = GetPlanOverridesStep.process(projectId).getOrNull() ?: PlanOverrides.NONE
 
-    respondHtml(drillChainFragment(project, targetTree, candidateCounts, nodeIngredients, highlightItemId = itemId))
+    respondHtml(drillChainFragment(project, targetTree, candidateCounts, nodeIngredients, overrides = overrides, graph = graph, highlightItemId = itemId))
 }
 
 /**
@@ -129,11 +132,6 @@ suspend fun ApplicationCall.handleGetNodePicker() {
         return
     }
 
-    val node = findNodeById(targetTree, nodeId) ?: run {
-        respondHtml(pickerNotFoundFragment("Node '$nodeId' not found in chain."))
-        return
-    }
-
     val graph = getGraphForWorld(worldId)
 
     // Load current overrides so we can highlight the active selection
@@ -141,6 +139,16 @@ suspend fun ApplicationCall.handleGetNodePicker() {
         is Result.Success -> r.value
         is Result.Failure -> null
     }
+
+    // Primary: look up the node in the derived target tree.
+    // Fallback: for a resolved tag (node absent from tree because redirectTag replaced it),
+    // synthesize a TargetTree from the graph so the tag-member picker can still be opened.
+    val node = findNodeById(targetTree, nodeId)
+        ?: synthesizeTagNode(nodeId, graph)
+        ?: run {
+            respondHtml(pickerNotFoundFragment("Node '$nodeId' not found in chain."))
+            return
+        }
 
     respondHtml(
         nodePickerFragment(
@@ -314,7 +322,8 @@ private suspend fun ApplicationCall.respondDrillRerender(
     val graph = getGraphForWorld(worldId)
     val candidateCounts = buildCandidateCounts(targetTree, graph)
     val nodeIngredients = buildNodeIngredients(plan)
-    respondHtml(drillChainFragment(project, targetTree, candidateCounts, nodeIngredients, highlightItemId = targetItemId))
+    val overrides = GetPlanOverridesStep.process(projectId).getOrNull() ?: PlanOverrides.NONE
+    respondHtml(drillChainFragment(project, targetTree, candidateCounts, nodeIngredients, overrides = overrides, graph = graph, highlightItemId = targetItemId))
 }
 
 /**
@@ -437,6 +446,34 @@ internal fun buildNodeIngredients(plan: GatheringPlan): Map<String, String> {
             val reducedOutput = output / divisor
             node.item.id to if (reducedOutput > 1) "$inputs → $reducedOutput" else inputs
         }
+}
+
+/**
+ * Synthesizes a [TargetTree] for a tag id that is absent from the derived target tree
+ * (because [PlanOverrides.tagMember] redirected it to a concrete member). Only succeeds
+ * when the id starts with `#` (i.e. it is a tag id) and the graph contains the tag's
+ * item node — which carries the [MinecraftTag] with its full member list. Returns null
+ * when the graph is unavailable or the tag is not found.
+ *
+ * The synthesized node has status [PlanNodeStatus.OPEN_TAG] so [nodePickerFragment]
+ * opens the tag-member variant of the picker. Quantities are 0 (the tag itself is not in
+ * the derived plan — the member item holds the real demand). The active override is read
+ * from [overrides] so the picker can highlight the current choice.
+ */
+internal fun synthesizeTagNode(
+    nodeId: String,
+    graph: ItemSourceGraph?,
+): TargetTree? {
+    if (graph == null || !nodeId.startsWith("#")) return null
+    val tagItemNode = graph.getItemNodesByStringId(nodeId).firstOrNull() ?: return null
+    val tag = tagItemNode.item as? MinecraftTag ?: return null
+    return TargetTree(
+        item = tag,
+        quantityIfAlone = 0L,
+        craftsIfAlone = 0L,
+        status = PlanNodeStatus.OPEN_TAG,
+        source = null,
+    )
 }
 
 /** Builds a minimal validation error HTML string for respondBadRequest. */

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
@@ -6,6 +6,7 @@ import app.mcorg.domain.model.project.Project
 import app.mcorg.engine.model.ItemSourceGraph
 import app.mcorg.engine.model.SourceNode
 import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.engine.plan.SourceRanking
 import app.mcorg.engine.plan.TargetTree
 import kotlinx.html.*
@@ -25,31 +26,41 @@ private const val PICKER_MAX_OPTIONS = 30
  * @param target the resolved [TargetTree] for the drill target.
  * @param candidateCounts item-id → number of source candidates in the graph. Used to decide
  *   whether a node is "forced" (≤ 1 candidate) or "multi-source" (≥ 2 candidates).
+ * @param overrides the current project overrides — when non-empty, the "Active choices" panel
+ *   is rendered below the chain so resolved tags and pinned sources remain reachable.
+ * @param graph the live item-source graph — used by the panel to resolve item names for labels.
  */
 fun drillChainFragment(
     project: Project,
     target: TargetTree,
     candidateCounts: Map<String, Int>,
     nodeIngredients: Map<String, String> = emptyMap(),
+    overrides: PlanOverrides = PlanOverrides.NONE,
+    graph: ItemSourceGraph? = null,
     highlightItemId: String? = null,
 ): String = createHTML().div {
     id = "project-content"
-    drillChainContent(project, target, candidateCounts, nodeIngredients, highlightItemId)
+    drillChainContent(project, target, candidateCounts, nodeIngredients, overrides, graph, highlightItemId)
 }
 
 /**
- * The drill body (back-header + chain), rendered into the caller's flow. Shared by
- * [drillChainFragment] (the HTMX swap response) and the full page shell, so that a
+ * The drill body (back-header + chain + active choices panel), rendered into the caller's flow.
+ * Shared by [drillChainFragment] (the HTMX swap response) and the full page shell, so that a
  * `?drill=` page load renders the same drill inside #project-content.
  *
  * @param nodeIngredients item-id → its source's ingredient summary ("5 Iron Ingot + 1 Chest"),
  *   shown in each node's hint so the indented children read as those exact inputs.
+ * @param overrides the current project overrides — when non-empty, renders the "Active choices"
+ *   panel below the chain so resolved tags and pinned sources remain reachable.
+ * @param graph the live item-source graph — used by the panel to resolve item names for labels.
  */
 fun FlowContent.drillChainContent(
     project: Project,
     target: TargetTree,
     candidateCounts: Map<String, Int>,
     nodeIngredients: Map<String, String> = emptyMap(),
+    overrides: PlanOverrides = PlanOverrides.NONE,
+    graph: ItemSourceGraph? = null,
     highlightItemId: String? = null,
 ) {
     val worldId = project.worldId
@@ -75,6 +86,8 @@ fun FlowContent.drillChainContent(
     div("drill-chain") {
         renderTargetTree(target, candidateCounts, nodeIngredients, highlightItemId, depth = 0, worldId = worldId, projectId = projectId, encodedTargetId = encodedTargetId)
     }
+
+    activeChoicesPanel(worldId, projectId, encodedTargetId, overrides, graph)
 }
 
 /** Renders a [TargetTree] node and recurses into children. */
@@ -409,6 +422,133 @@ private fun FlowContent.overflowNote(shown: Int, matching: Int, q: String) {
  * Rendered into `#picker-{nodeSlug}` via innerHTML.
  */
 fun pickerNotFoundFragment(reason: String): String = createHTML().p("picker__empty") { +reason }
+
+// ---------------------------------------------------------------------------
+// Active choices panel
+// ---------------------------------------------------------------------------
+
+/**
+ * "Active choices" panel: lists every active override (source pins and tag-member resolutions)
+ * so the user can edit or clear any of them — even when the overridden node is absent from the
+ * current derived tree (e.g. a resolved tag whose node was replaced by the concrete member).
+ *
+ * Renders nothing when there are no overrides.
+ *
+ * Each row shows a human-readable label and two controls:
+ * - **Edit**: reopens the source/tag picker in a slot inside the row (hx-get to /sources).
+ * - **Clear**: calls DELETE /override → re-renders #project-content (outerHTML).
+ *
+ * The picker slot per row uses id `panel-picker-{slug}` to avoid collisions with the
+ * `picker-{slug}` slots that live inside the chain itself.
+ *
+ * @param worldId world id
+ * @param projectId project id
+ * @param encodedTargetId URL-encoded id of the drill target (used in endpoint URLs)
+ * @param overrides the current set of active overrides
+ * @param graph the live item-source graph — used to resolve item/tag names for labels
+ */
+fun FlowContent.activeChoicesPanel(
+    worldId: Int,
+    projectId: Int,
+    encodedTargetId: String,
+    overrides: PlanOverrides,
+    graph: ItemSourceGraph?,
+) {
+    val hasSources = overrides.sourceByItem.isNotEmpty()
+    val hasTagMembers = overrides.tagMember.isNotEmpty()
+    if (!hasSources && !hasTagMembers) return
+
+    div("active-choices") {
+        id = "active-choices"
+        span("section-label active-choices__label") { +"Active choices" }
+
+        div("active-choices__list") {
+            // Source pins
+            for ((itemId, sourceKey) in overrides.sourceByItem) {
+                val itemName = resolveItemName(itemId, graph)
+                val sourceMethod = trySourceMethodLabel(sourceKey)
+                val label = "$itemName — $sourceMethod"
+                val slug = itemId.replace(Regex("[^a-zA-Z0-9]"), "-")
+                val encodedNodeId = encodeId(itemId)
+                val pickerSlotId = "panel-picker-$slug"
+                val pickerUrl = "/worlds/$worldId/projects/$projectId/plan/chain/$encodedTargetId/sources?node=$encodedNodeId"
+                val clearUrl = "/worlds/$worldId/projects/$projectId/plan/chain/$encodedTargetId/override?node=$encodedNodeId"
+
+                activeChoiceRow(label, pickerSlotId, pickerUrl, clearUrl)
+            }
+
+            // Tag member resolutions
+            for ((tagId, memberItemId) in overrides.tagMember) {
+                val tagName = resolveItemName(tagId, graph)
+                val memberName = resolveItemName(memberItemId, graph)
+                val label = "$tagName → $memberName"
+                val slug = tagId.replace(Regex("[^a-zA-Z0-9]"), "-")
+                val encodedNodeId = encodeId(tagId)
+                val pickerSlotId = "panel-picker-$slug"
+                val pickerUrl = "/worlds/$worldId/projects/$projectId/plan/chain/$encodedTargetId/sources?node=$encodedNodeId"
+                val clearUrl = "/worlds/$worldId/projects/$projectId/plan/chain/$encodedTargetId/override?node=$encodedNodeId"
+
+                activeChoiceRow(label, pickerSlotId, pickerUrl, clearUrl)
+            }
+        }
+    }
+}
+
+/** One row of the active-choices panel. */
+private fun FlowContent.activeChoiceRow(
+    label: String,
+    pickerSlotId: String,
+    pickerUrl: String,
+    clearUrl: String,
+) {
+    div("active-choice") {
+        span("active-choice__label") { +label }
+        div("active-choice__actions") {
+            button(classes = "btn btn--ghost btn--sm active-choice__edit") {
+                type = ButtonType.button
+                attributes["hx-get"] = pickerUrl
+                attributes["hx-target"] = "#$pickerSlotId"
+                attributes["hx-swap"] = "innerHTML"
+                +"⇄ Edit"
+            }
+            button(classes = "btn btn--ghost btn--sm active-choice__clear") {
+                type = ButtonType.button
+                attributes["hx-delete"] = clearUrl
+                attributes["hx-target"] = "#project-content"
+                attributes["hx-swap"] = "outerHTML"
+                +"× Clear"
+            }
+        }
+        // Picker slot for this row — filled by hx-get on Edit click
+        div("chain-node__picker") {
+            id = pickerSlotId
+        }
+    }
+}
+
+/**
+ * Resolves a human-readable item/tag name from [graph]. Falls back to prettifying
+ * the id when the graph is null or the id is not found (test environment, no graph).
+ */
+private fun resolveItemName(id: String, graph: ItemSourceGraph?): String {
+    if (graph != null) {
+        val node = graph.getItemNodesByStringId(id).firstOrNull()
+        if (node != null) return node.item.name
+    }
+    // Fallback: strip namespace prefix and prettify ("minecraft:oak_planks" → "Oak Planks")
+    val bare = id.removePrefix("#").substringAfter(":")
+    return bare.replace('_', ' ').trim().replaceFirstChar { it.uppercaseChar() }
+}
+
+/**
+ * Returns the method label for a source key ("Break Block", "Crafting", etc.),
+ * or a prettified fallback when parsing fails.
+ */
+private fun trySourceMethodLabel(sourceKey: String): String = try {
+    SourceNode.fromKey(sourceKey).getMethodLabel()
+} catch (_: Exception) {
+    sourceKey.substringAfterLast(':').replace('_', ' ').replaceFirstChar { it.uppercaseChar() }
+}
 
 // ---------------------------------------------------------------------------
 // Private utilities

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -4,10 +4,12 @@ import app.mcorg.domain.model.project.Project
 import app.mcorg.domain.model.resources.ResourceGatheringItem
 import app.mcorg.domain.model.task.ActionTask
 import app.mcorg.domain.model.user.TokenProfile
+import app.mcorg.engine.model.ItemSourceGraph
 import app.mcorg.engine.plan.Activity
 import app.mcorg.engine.plan.ActivityGroup
 import app.mcorg.engine.plan.GatheringPlan
 import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.presentation.hxDelete
 import app.mcorg.presentation.hxGet
 import app.mcorg.presentation.hxOutOfBands
@@ -52,6 +54,8 @@ fun projectDetailPage(
     drillCandidateCounts: Map<String, Int> = emptyMap(),
     drillNodeIngredients: Map<String, String> = emptyMap(),
     drillHighlightItemId: String? = null,
+    drillOverrides: PlanOverrides = PlanOverrides.NONE,
+    drillGraph: ItemSourceGraph? = null,
 ): String = pageShell(
     pageTitle = "Seam — ${project.name}",
     user = user,
@@ -112,7 +116,7 @@ fun projectDetailPage(
                 id = "project-content"
                 if (drillTarget != null) {
                     // ?drill=<item> deep-links straight into a target's chain (reload/share-safe).
-                    drillChainContent(project, drillTarget, drillCandidateCounts, drillNodeIngredients, drillHighlightItemId)
+                    drillChainContent(project, drillTarget, drillCandidateCounts, drillNodeIngredients, overrides = drillOverrides, graph = drillGraph, highlightItemId = drillHighlightItemId)
                 } else {
                     gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap)
                 }

--- a/webapp/mc-web/src/main/resources/static/styles/components/drill.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/drill.css
@@ -189,6 +189,48 @@
     margin-top: var(--space-2);
 }
 
+/* ==========================================================================
+   ACTIVE CHOICES PANEL — lists every active override (source pins + tag resolutions)
+   ========================================================================== */
+
+.active-choices {
+    margin-top: var(--space-4);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.active-choices__label {
+    display: block;
+    padding: var(--space-2) var(--space-4);
+    background: var(--bg-raised);
+    border-bottom: 1px solid var(--border);
+}
+
+/* One override row */
+.active-choice {
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-surface);
+}
+
+.active-choice:last-child {
+    border-bottom: none;
+}
+
+.active-choice__label {
+    display: block;
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+    padding: var(--space-3) var(--space-4) var(--space-2);
+}
+
+.active-choice__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: 0 var(--space-4) var(--space-3);
+}
+
 /* Mobile */
 @media (max-width: 768px) {
     .chain-node {
@@ -202,5 +244,9 @@
 
     .picker {
         padding: var(--space-2) var(--space-3);
+    }
+
+    .active-choice__actions {
+        flex-wrap: wrap;
     }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanChainIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanChainIT.kt
@@ -210,6 +210,25 @@ class PlanChainIT : WithUser() {
         assertContains(body, "picker")
     }
 
+    @Test
+    fun `GET sources with a tag node id that is absent from plan returns graceful picker`() = testApplication {
+        setupAllRoutes()
+
+        // Tag node ("#minecraft:planks") may be absent from the derived tree when it has been
+        // resolved to a concrete member. In the Testcontainers DB there is no graph, so the
+        // synthesize path can't find the tag, but the endpoint must still respond gracefully.
+        val response = client.get(
+            "/worlds/$worldId/projects/$projectId/plan/chain/minecraft:iron_ingot/sources?node=%23minecraft:planks"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        // Must return a picker-family fragment, never a 500
+        assertContains(body, "picker")
+    }
+
     // -------------------------------------------------------------------------
     // POST /pin — source override persistence
     // -------------------------------------------------------------------------

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillViewTest.kt
@@ -6,8 +6,10 @@ import app.mcorg.domain.model.resources.ResourceSource
 import app.mcorg.engine.model.ItemSourceGraph
 import app.mcorg.engine.model.SourceNode
 import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.engine.plan.TargetTree
 import app.mcorg.domain.model.project.Project
+import app.mcorg.pipeline.resources.synthesizeTagNode
 import kotlinx.html.div
 import kotlinx.html.stream.createHTML
 import app.mcorg.domain.model.project.ProjectStage
@@ -18,6 +20,7 @@ import java.time.ZonedDateTime
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -868,5 +871,317 @@ class DrillViewTest {
         assertContains(html, "Clear override")
         assertContains(html, "hx-delete")
         assertContains(html, "/override")
+    }
+
+    // -------------------------------------------------------------------------
+    // activeChoicesPanel — "Active choices" panel
+    // -------------------------------------------------------------------------
+
+    /** Builds a graph containing a MinecraftTag "#minecraft:planks" with two members. */
+    private fun planksTagGraph(): ItemSourceGraph {
+        val oakPlanks = Item("minecraft:oak_planks", "Oak Planks")
+        val sprucePlanks = Item("minecraft:spruce_planks", "Spruce Planks")
+        val tag = MinecraftTag("#minecraft:planks", "Any Planks", listOf(oakPlanks, sprucePlanks))
+        val builder = ItemSourceGraph.builder()
+        builder.addItemNode(tag)
+        return builder.build()
+    }
+
+    @Test
+    fun `active choices panel is absent when there are no overrides`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 64,
+            craftsIfAlone = 64,
+            status = PlanNodeStatus.RAW_GATHER,
+            source = mine,
+        )
+        val html = drillChainFragment(testProject(), tree, emptyMap(), overrides = PlanOverrides.NONE)
+
+        assertFalse(html.contains("active-choices"), "Panel should not render when no overrides: $html")
+    }
+
+    @Test
+    fun `active choices panel renders a row for a source pin override`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 64,
+            craftsIfAlone = 64,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val graph = ironGraph()
+        val sourceKey = mine.getKey()
+        val overrides = PlanOverrides(sourceByItem = mapOf("minecraft:iron_ingot" to sourceKey))
+
+        val html = drillChainFragment(testProject(), tree, emptyMap(), overrides = overrides, graph = graph)
+
+        assertContains(html, "active-choices")
+        assertContains(html, "Active choices")
+        // Item name appears in row label
+        assertContains(html, "Iron Ingot")
+    }
+
+    @Test
+    fun `active choices panel source pin row has edit and clear controls`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 64,
+            craftsIfAlone = 64,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val graph = ironGraph()
+        val sourceKey = mine.getKey()
+        val overrides = PlanOverrides(sourceByItem = mapOf("minecraft:iron_ingot" to sourceKey))
+
+        val html = drillChainFragment(testProject(worldId = 1, projectId = 2), tree, emptyMap(), overrides = overrides, graph = graph)
+
+        // Edit control: hx-get to /sources
+        assertContains(html, "/sources?node=")
+        assertContains(html, "active-choice__edit")
+        // Clear control: hx-delete to /override
+        assertContains(html, "hx-delete")
+        assertContains(html, "/override")
+        assertContains(html, "active-choice__clear")
+    }
+
+    @Test
+    fun `active choices panel renders a row for a tag member override`() {
+        val tree = TargetTree(
+            // Resolved tag: the chain now shows oak_planks, not the tag node
+            item = item("oak_planks", "Oak Planks"),
+            quantityIfAlone = 320,
+            craftsIfAlone = 320,
+            status = PlanNodeStatus.RESOLVED,
+            source = craft,
+        )
+        val graph = planksTagGraph()
+        val overrides = PlanOverrides(tagMember = mapOf("#minecraft:planks" to "minecraft:oak_planks"))
+
+        val html = drillChainFragment(testProject(), tree, emptyMap(), overrides = overrides, graph = graph)
+
+        assertContains(html, "active-choices")
+        // Tag name in label
+        assertContains(html, "Any Planks")
+        // Member name in label after arrow
+        assertContains(html, "Oak Planks")
+        assertContains(html, "→")
+    }
+
+    @Test
+    fun `active choices panel tag member row has edit and clear controls`() {
+        val tree = TargetTree(
+            item = item("oak_planks", "Oak Planks"),
+            quantityIfAlone = 320,
+            craftsIfAlone = 320,
+            status = PlanNodeStatus.RESOLVED,
+            source = craft,
+        )
+        val graph = planksTagGraph()
+        val overrides = PlanOverrides(tagMember = mapOf("#minecraft:planks" to "minecraft:oak_planks"))
+
+        val html = drillChainFragment(testProject(worldId = 1, projectId = 2), tree, emptyMap(), overrides = overrides, graph = graph)
+
+        // Edit control uses the tag id (not the member id) in the node param
+        assertContains(html, "sources?node=")
+        assertContains(html, "active-choice__edit")
+        // Clear control
+        assertContains(html, "hx-delete")
+        assertContains(html, "/override")
+        assertContains(html, "active-choice__clear")
+    }
+
+    @Test
+    fun `active choices panel renders both source and tag member rows`() {
+        val tree = TargetTree(
+            item = item("iron_pickaxe", "Iron Pickaxe"),
+            quantityIfAlone = 2,
+            craftsIfAlone = 2,
+            status = PlanNodeStatus.RESOLVED,
+            source = craft,
+        )
+        // Build a combined graph with iron ingot AND the planks tag
+        val ironIngot = item("iron_ingot", "Iron Ingot")
+        val oakPlanks = Item("minecraft:oak_planks", "Oak Planks")
+        val sprucePlanks = Item("minecraft:spruce_planks", "Spruce Planks")
+        val tag = MinecraftTag("#minecraft:planks", "Any Planks", listOf(oakPlanks, sprucePlanks))
+        val builder = ItemSourceGraph.builder()
+        builder.addItemNode(ironIngot)
+        builder.addItemNode(tag)
+        val graph = builder.build()
+
+        val overrides = PlanOverrides(
+            sourceByItem = mapOf("minecraft:iron_ingot" to mine.getKey()),
+            tagMember = mapOf("#minecraft:planks" to "minecraft:oak_planks"),
+        )
+
+        val html = drillChainFragment(testProject(), tree, emptyMap(), overrides = overrides, graph = graph)
+
+        assertContains(html, "active-choices")
+        assertContains(html, "Iron Ingot")
+        assertContains(html, "Any Planks")
+    }
+
+    @Test
+    fun `active choices panel picker slot has panel-specific id to avoid collision with chain slots`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 64,
+            craftsIfAlone = 64,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val overrides = PlanOverrides(sourceByItem = mapOf("minecraft:iron_ingot" to mine.getKey()))
+
+        val html = drillChainFragment(testProject(), tree, emptyMap(), overrides = overrides)
+
+        // Panel picker slot uses "panel-picker-" prefix, distinct from chain's "picker-" slots
+        assertContains(html, "panel-picker-minecraft-iron-ingot")
+    }
+
+    // -------------------------------------------------------------------------
+    // synthesizeTagNode — absent-tag picker path
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `synthesizeTagNode returns OPEN_TAG TargetTree for a known tag id`() {
+        val graph = planksTagGraph()
+        val node = synthesizeTagNode("#minecraft:planks", graph)
+
+        assertNotNull(node, "Expected a synthesized TargetTree for a known tag, got null")
+        assertEquals(PlanNodeStatus.OPEN_TAG, node.status)
+        // Item should be the MinecraftTag
+        assertTrue(node.item is MinecraftTag, "Expected item to be MinecraftTag, got: ${node.item}")
+        assertEquals("#minecraft:planks", node.item.id)
+    }
+
+    @Test
+    fun `synthesizeTagNode returns null for a non-tag item id`() {
+        val graph = ironGraph()
+        // "minecraft:iron_ingot" does not start with "#" — not a tag
+        val node = synthesizeTagNode("minecraft:iron_ingot", graph)
+
+        assertNull(node, "Expected null for a non-tag id")
+    }
+
+    @Test
+    fun `synthesizeTagNode returns null when graph is null`() {
+        val node = synthesizeTagNode("#minecraft:planks", graph = null)
+
+        assertNull(node, "Expected null when graph is null")
+    }
+
+    @Test
+    fun `synthesizeTagNode returns null when tag is not in the graph`() {
+        // Graph with no tags at all
+        val builder = ItemSourceGraph.builder()
+        builder.addItemNode(Item("minecraft:iron_ingot", "Iron Ingot"))
+        val graph = builder.build()
+
+        val node = synthesizeTagNode("#minecraft:unknown_tag", graph)
+
+        assertNull(node, "Expected null for an unknown tag id")
+    }
+
+    // -------------------------------------------------------------------------
+    // Fix 1: active choices panel present on full-page ?drill= deep-link render
+    // -------------------------------------------------------------------------
+
+    /**
+     * Regression: on a hard browser reload of a `?drill=` URL, `drillChainContent` is called
+     * directly in the page shell (not via the HTMX fragment path). Before the fix it was called
+     * without `overrides`/`graph` so the Active choices panel was silently absent even when
+     * the project had active overrides. This test verifies the panel is present when
+     * `drillChainContent` receives non-empty overrides — as it now does via the fixed
+     * `handleGetProject` path.
+     */
+    @Test
+    fun `drillChainContent renders active choices panel when overrides are passed (full-page deep-link path)`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 64,
+            craftsIfAlone = 64,
+            status = PlanNodeStatus.RESOLVED,
+            source = mine,
+        )
+        val graph = ironGraph()
+        val overrides = PlanOverrides(sourceByItem = mapOf("minecraft:iron_ingot" to mine.getKey()))
+
+        // Mimics the exact call in ProjectDetailPage.kt for the ?drill= deep-link path.
+        val html = createHTML().div {
+            drillChainContent(
+                project = testProject(worldId = 1, projectId = 2),
+                target = tree,
+                candidateCounts = emptyMap(),
+                overrides = overrides,
+                graph = graph,
+            )
+        }
+
+        // Panel must be present — this was the bug: on full-page load it was missing.
+        assertTrue(html.contains("active-choices"), "Active choices panel must render on full-page ?drill= load when overrides exist")
+        assertContains(html, "Active choices")
+        assertContains(html, "Iron Ingot")
+    }
+
+    @Test
+    fun `drillChainContent omits active choices panel when overrides are empty (full-page deep-link path)`() {
+        val tree = TargetTree(
+            item = item("iron_ingot", "Iron Ingot"),
+            quantityIfAlone = 64,
+            craftsIfAlone = 64,
+            status = PlanNodeStatus.RAW_GATHER,
+            source = mine,
+        )
+
+        val html = createHTML().div {
+            drillChainContent(
+                project = testProject(),
+                target = tree,
+                candidateCounts = emptyMap(),
+                overrides = PlanOverrides.NONE,
+                graph = null,
+            )
+        }
+
+        assertFalse(html.contains("active-choices"), "Panel must not render when overrides are empty on full-page load")
+    }
+
+    @Test
+    fun `nodePickerFragment with synthesized tag node renders tag member picker`() {
+        val oakPlanks = Item("minecraft:oak_planks", "Oak Planks")
+        val sprucePlanks = Item("minecraft:spruce_planks", "Spruce Planks")
+        val tag = MinecraftTag("#minecraft:planks", "Any Planks", listOf(oakPlanks, sprucePlanks))
+        val graph = planksTagGraph()
+
+        // Synthesize a TargetTree as the absent-node path would produce
+        val synthNode = TargetTree(
+            item = tag,
+            quantityIfAlone = 0L,
+            craftsIfAlone = 0L,
+            status = PlanNodeStatus.OPEN_TAG,
+            source = null,
+        )
+
+        val html = nodePickerFragment(
+            worldId = 1,
+            projectId = 2,
+            targetItemId = "minecraft:chest",
+            node = synthNode,
+            graph = graph,
+            activeSourceKey = null,
+            activeMemberId = "minecraft:oak_planks",
+            demand = synthNode.quantityIfAlone,
+        )
+
+        // Should render the tag-member picker with both planks options
+        assertContains(html, "Pick a variant")
+        assertContains(html, "Oak Planks")
+        assertContains(html, "Spruce Planks")
+        // Active member is marked selected
+        assertContains(html, "picker-opt--sel")
+        // Clear override shown because member override is active
+        assertContains(html, "Clear override")
     }
 }


### PR DESCRIPTION
Fixes [MCO-227](https://linear.app/evegul/issue/MCO-227). Follow-up from MCO-222 (Drill, Phase 3) of the Gathering Planner UI epic (MCO-219).

## Problem
Resolving an `OPEN_TAG` node in the drill (e.g. "Any Planks" → Oak Planks) was **one-way**. The engine's `redirectTag` swaps the tag node out of the re-derived DAG, so `perTarget` expands the member and the tag node — with its `⇄` chip, picker, and "Clear override" control — no longer appears in the chain. The `TagMember` override row persisted in `resource_gathering_plan_override` but nothing surfaced it, so the variant couldn't be changed or cleared. Source pins didn't have this problem (the pinned node stays in the chain).

## Fix — "Active choices" panel (Option 2, web-only)
- New drill `activeChoicesPanel` listing **every** active override for the project (source pins + tag-member resolutions), each with **edit** (reopens the picker) and **clear** controls — independent of whether the node is still visible in the chain. Quiet empty state when there are none.
- `handleGetNodePicker` falls back to `synthesizeTagNode` when the node is absent from the derived tree: it builds an `OPEN_TAG` node from a **read-only** `ItemSourceGraph` lookup, so the member picker stays reachable for a redirected tag. Prefers the real node when present.
- Threaded overrides + graph through the full-page `?drill=` deep-link path (`GetProjectPipeline` → `projectDetailPage` → `drillChainContent`) so the panel also renders on hard reload / shared links, not just HTMX swaps.
- Reuses existing override endpoints (`DELETE …/override?node=`, picker GET/pin/tag); no new migration.

Scope: drill-only (List-lens placement deferred). **No `mc-engine`/`mc-data` changes** — only a read-only graph query.

## Tests
- Unit (`DrillViewTest`): panel renders source-pin & tag-member rows with edit/clear controls; absent when no overrides; full-page `?drill=` render includes the panel; `synthesizeTagNode` happy/non-tag/null-graph/unknown-tag; picker renders members for a synthesized tag node.
- Integration (`PlanChainIT`): absent-tag-node picker path.
- `mvn clean compile` clean; **617 unit + 96 database tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)