### PR TITLE
Rank choice-tag members by a canonical-default prior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,6 @@ This mirrors CI (`.github/workflows/dev.yml`): the `unit-tests` job runs the def
 tier; the `integration-tests` job runs `-Dgroups=database`.
 
 Notes:
-- `test.sh` invokes the ambient `mvn`, so the JDK-25 `JAVA_HOME` prefix from the build
-  environment still applies: `JAVA_HOME=~/.jdks/jdk-25.0.3+9 ./webapp/scripts/test.sh ...`.
 - It auto-generates JWT signing keys (`mc-web/create-keys.sh`) on first run if missing.
 - `--integration` (failsafe) expects a running server; the `--database` tier is
   self-contained (Testcontainers spins up its own PostgreSQL).

--- a/webapp/mc-engine/src/main/kotlin/app/mcorg/engine/plan/MemberPrior.kt
+++ b/webapp/mc-engine/src/main/kotlin/app/mcorg/engine/plan/MemberPrior.kt
@@ -1,0 +1,159 @@
+package app.mcorg.engine.plan
+
+import app.mcorg.domain.model.minecraft.MinecraftId
+
+/**
+ * A canonical-default ordering over the *members* of a choice (an open tag or a synthetic
+ * `#mcorg:choice/…` set), used purely as a **tiebreak** when two members are otherwise equally
+ * good. Minecraft offers many cosmetically-equivalent alternatives for one ingredient slot —
+ * TNT accepts `sand` or `red_sand`, a plank recipe accepts any of twelve woods — and the scorer
+ * cannot separate them because they are structurally identical in the graph. Left to an
+ * alphabetical tiebreak the *less* canonical member wins ("Red Sand" before "Sand", black before
+ * white, acacia before oak). This prior fixes that by encoding the obvious default.
+ *
+ * It is **not** an abundance metric and reads no world data; the defaults are human judgments about
+ * which variant a player reaches for first. It is intentionally a tiebreak only: callers compare by
+ * source score first and fall back to this when scores tie (see [comparator]). At bulk demand, where
+ * the scorer genuinely separates members (e.g. charcoal's smelt recipe earning the recipe-threshold
+ * bonus over mined coal), the score decides and this prior never fires.
+ *
+ * The ordering is **axis-based**, not per-tag: a handful of controlled vocabularies parsed from the
+ * item id (wood species, wood form, dye colour, stone base, decorative form) cover ~80 distinct
+ * choice points and survive Minecraft version bumps — a thirteenth wood ranks correctly with no new
+ * entry. Members in a given choice set are homogeneous along all but one axis, so only the axis that
+ * varies decides; the rest are constant and drop out of the comparison.
+ *
+ * Lower rank = more canonical = preferred first.
+ */
+object MemberPrior {
+
+    /** Compares two ids by their [RankKey]; more-canonical first. */
+    fun compare(a: String, b: String): Int = rankKey(a).compareTo(rankKey(b))
+
+    /**
+     * A [Comparator] over [MinecraftId] for use as a tiebreak. Chain it *after* the primary
+     * score comparator so the prior only orders members the scorer rates equally:
+     * ```
+     * compareByDescending<RankedMember> { it.score }
+     *     .then(MemberPrior.comparator { it.member })
+     *     .thenBy { it.member.name }
+     * ```
+     */
+    fun <T> comparator(select: (T) -> MinecraftId): Comparator<T> =
+        Comparator { x, y -> compare(select(x).id, select(y).id) }
+
+    /**
+     * The composite rank for one item id. Axes are compared in priority order: an explicit pair
+     * always wins (so coal/charcoal, soul_sand/soul_soil are unambiguous), then wood species, then
+     * wood form, then colour, then stone base, then decorative form. Within a homogeneous choice set
+     * only the differentiating axis is non-constant, so the trailing order rarely matters — but
+     * species deliberately precedes form so the `#minecraft:logs` set (species *and* form vary)
+     * prefers the canonical species even in a less canonical form.
+     */
+    internal fun rankKey(id: String): RankKey {
+        val local = id.substringAfterLast(':')
+        val tokens = local.split('_')
+        return RankKey(
+            explicit = EXPLICIT[local] ?: UNRANKED,
+            species = woodSpeciesRank(local),
+            woodForm = woodFormRank(tokens),
+            colour = colourRank(local),
+            stone = STONE_BASE[local] ?: UNRANKED,
+            decorForm = decorFormRank(tokens),
+        )
+    }
+
+    /** Sentinel for "this axis does not apply" — constant within a homogeneous set, so it drops out. */
+    private const val UNRANKED = Int.MAX_VALUE
+
+    /**
+     * Explicit pairs the structural axes can't derive. Each maps to an intra-pair order (0 = default).
+     * coal beats charcoal at a score tie (low demand); soul_sand beats soul_soil.
+     */
+    private val EXPLICIT: Map<String, Int> = mapOf(
+        "coal" to 0, "charcoal" to 1,
+        "soul_sand" to 0, "soul_soil" to 1,
+    )
+
+    /** Cobblestone is the everyday crafting stone; deepslate and blackstone are biome-gated. */
+    private val STONE_BASE: Map<String, Int> = mapOf(
+        "cobblestone" to 0, "cobbled_deepslate" to 1, "blackstone" to 2,
+    )
+
+    /**
+     * Wood species in canonical rank order, oak first — the list index *is* the rank.
+     * `contains` (not prefix) because the species sits mid-id in stripped forms
+     * (`stripped_oak_log`).
+     */
+    private val WOOD_SPECIES: List<String> = listOf(
+        "oak", "spruce", "birch", "jungle", "acacia", "dark_oak",
+        "mangrove", "cherry", "pale_oak", "bamboo", "crimson", "warped",
+    )
+
+    /**
+     * Match order is by descending name length, decoupled from rank order: `dark_oak`/`pale_oak`
+     * must be tested before `oak` so the substring match resolves to the longer (correct) species,
+     * even though oak ranks first.
+     */
+    private val WOOD_SPECIES_BY_MATCH_LENGTH: List<String> = WOOD_SPECIES.sortedByDescending { it.length }
+
+    private fun woodSpeciesRank(local: String): Int {
+        val match = WOOD_SPECIES_BY_MATCH_LENGTH.firstOrNull { local.contains(it) } ?: return UNRANKED
+        return WOOD_SPECIES.indexOf(match)
+    }
+
+    /**
+     * Form of a log-family block: plain log/stem/block beats wood/hyphae, and unstripped beats
+     * stripped. Base 0 (not [UNRANKED]) so non-wood members are all equal here and the colour axis
+     * decides instead.
+     */
+    private fun woodFormRank(tokens: List<String>): Int {
+        val stripped = "stripped" in tokens
+        val secondary = "wood" in tokens || "hyphae" in tokens
+        val isWoodForm = secondary || "log" in tokens || "stem" in tokens || "block" in tokens
+        if (!isWoodForm) return 0
+        return (if (stripped) 2 else 0) + (if (secondary) 1 else 0)
+    }
+
+    /**
+     * Dye colours in Minecraft's canonical order, white first. An id carrying no colour prefix is
+     * "uncoloured" and ranks ahead of every colour (rank 0) — so `sand` beats `red_sand`, plain
+     * `bundle`/`shulker_box` beat their dyed variants, and `egg` beats `blue_egg`. Detected as a
+     * `"<colour>_"` prefix, which is anchored (so `blackstone` is not colour-black and
+     * `light_gray_*` is not gray).
+     */
+    private val COLOURS: List<String> = listOf(
+        "white", "orange", "magenta", "light_blue", "yellow", "lime", "pink", "gray",
+        "light_gray", "cyan", "purple", "blue", "brown", "green", "red", "black",
+    )
+
+    private fun colourRank(local: String): Int {
+        val idx = COLOURS.indexOfFirst { local.startsWith("${it}_") }
+        return if (idx >= 0) 1 + idx else 0
+    }
+
+    /** Decorative stone form: base block, then cut, chiseled, pillar. Token-matched to avoid false hits. */
+    private fun decorFormRank(tokens: List<String>): Int = when {
+        "chiseled" in tokens -> 2
+        "pillar" in tokens -> 3
+        "cut" in tokens -> 1
+        else -> 0
+    }
+
+    /**
+     * Composite rank compared field-by-field in priority order. Smaller is more canonical.
+     */
+    internal data class RankKey(
+        val explicit: Int,
+        val species: Int,
+        val woodForm: Int,
+        val colour: Int,
+        val stone: Int,
+        val decorForm: Int,
+    ) : Comparable<RankKey> {
+        override fun compareTo(other: RankKey): Int = compareValuesBy(
+            this, other,
+            { it.explicit }, { it.species }, { it.woodForm }, { it.colour }, { it.stone }, { it.decorForm },
+        )
+    }
+}

--- a/webapp/mc-engine/src/test/kotlin/app/mcorg/engine/plan/MemberPriorTest.kt
+++ b/webapp/mc-engine/src/test/kotlin/app/mcorg/engine/plan/MemberPriorTest.kt
@@ -1,0 +1,197 @@
+package app.mcorg.engine.plan
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftId
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The member prior is a tiebreak over the alternatives of one choice set. Each test sorts a real
+ * choice set (taken from the 1.21.10 recipe corpus) by the prior and asserts the canonical member
+ * lands first — that being the bug this fixes (alphabetical order surfaced the *less* canonical one).
+ */
+class MemberPriorTest {
+
+    private fun sortedByPrior(vararg ids: String): List<String> =
+        ids.sortedWith { a, b -> MemberPrior.compare(a, b) }
+
+    private fun mc(local: String): String = "minecraft:$local"
+
+    @Test
+    fun `sand beats red sand — the motivating TNT case`() {
+        assertEquals(
+            listOf(mc("sand"), mc("red_sand")),
+            sortedByPrior(mc("red_sand"), mc("sand")),
+        )
+    }
+
+    @Test
+    fun `oak is the default plank species`() {
+        val planks = listOf(
+            "oak_planks", "spruce_planks", "birch_planks", "jungle_planks", "acacia_planks",
+            "dark_oak_planks", "pale_oak_planks", "crimson_planks", "warped_planks",
+            "mangrove_planks", "bamboo_planks", "cherry_planks",
+        ).map { mc(it) }
+        val first = planks.sortedWith { a, b -> MemberPrior.compare(a, b) }.first()
+        assertEquals(mc("oak_planks"), first)
+    }
+
+    @Test
+    fun `dark_oak does not get mistaken for oak`() {
+        // 'oak' is a substring of 'dark_oak'; the longer name must win the species match so
+        // dark_oak ranks as its own (later) species, not as plain oak.
+        assertEquals(
+            listOf(mc("oak_planks"), mc("dark_oak_planks")),
+            sortedByPrior(mc("dark_oak_planks"), mc("oak_planks")),
+        )
+    }
+
+    @Test
+    fun `plain log beats wood and stripped forms within a species`() {
+        assertEquals(
+            listOf(mc("oak_log"), mc("oak_wood"), mc("stripped_oak_log"), mc("stripped_oak_wood")),
+            sortedByPrior(mc("stripped_oak_wood"), mc("oak_wood"), mc("stripped_oak_log"), mc("oak_log")),
+        )
+    }
+
+    @Test
+    fun `species outranks form across the logs set`() {
+        // #minecraft:logs varies in BOTH species and form. Canonical species wins even when it
+        // appears in a less canonical form: stripped_oak_log beats plain spruce_log.
+        assertEquals(
+            listOf(mc("stripped_oak_log"), mc("spruce_log")),
+            sortedByPrior(mc("spruce_log"), mc("stripped_oak_log")),
+        )
+    }
+
+    @Test
+    fun `white is the default colour`() {
+        val wool = listOf(
+            "white_wool", "orange_wool", "magenta_wool", "light_blue_wool", "yellow_wool",
+            "lime_wool", "pink_wool", "gray_wool", "light_gray_wool", "cyan_wool", "purple_wool",
+            "blue_wool", "brown_wool", "green_wool", "red_wool", "black_wool",
+        ).map { mc(it) }
+        val first = wool.sortedWith { a, b -> MemberPrior.compare(a, b) }.first()
+        assertEquals(mc("white_wool"), first)
+    }
+
+    @Test
+    fun `uncoloured base beats every dyed variant`() {
+        // shulker_boxes / bundles include the plain uncoloured member; it is the true base.
+        assertEquals(
+            listOf(mc("shulker_box"), mc("red_shulker_box")),
+            sortedByPrior(mc("red_shulker_box"), mc("shulker_box")),
+        )
+        assertEquals(mc("bundle"), sortedByPrior(mc("black_bundle"), mc("bundle"), mc("white_bundle")).first())
+    }
+
+    @Test
+    fun `light_gray is not mistaken for gray, and blackstone is not colour-black`() {
+        // 'gray' is a substring of 'light_gray' — anchored "<colour>_" prefix keeps them distinct.
+        assertEquals(
+            listOf(mc("gray_wool"), mc("light_gray_wool")),
+            sortedByPrior(mc("light_gray_wool"), mc("gray_wool")),
+        )
+        // 'blackstone' must not read as colour black; it is a stone base, ranked by that axis.
+        assertEquals(
+            listOf(mc("cobblestone"), mc("cobbled_deepslate"), mc("blackstone")),
+            sortedByPrior(mc("blackstone"), mc("cobblestone"), mc("cobbled_deepslate")),
+        )
+    }
+
+    @Test
+    fun `coal is the default fuel at a tie`() {
+        assertEquals(
+            listOf(mc("coal"), mc("charcoal")),
+            sortedByPrior(mc("charcoal"), mc("coal")),
+        )
+    }
+
+    @Test
+    fun `decorative base form beats cut, chiseled and pillar`() {
+        assertEquals(
+            listOf(mc("sandstone"), mc("cut_sandstone"), mc("chiseled_sandstone")),
+            sortedByPrior(mc("chiseled_sandstone"), mc("cut_sandstone"), mc("sandstone")),
+        )
+        assertEquals(
+            listOf(mc("quartz_block"), mc("quartz_pillar")),
+            sortedByPrior(mc("quartz_pillar"), mc("quartz_block")),
+        )
+    }
+
+    @Test
+    fun `egg beats coloured eggs and soul_sand beats soul_soil`() {
+        // egg (uncoloured) first; among the dyed ones the colour axis orders blue (11) before brown (12).
+        assertEquals(
+            listOf(mc("egg"), mc("blue_egg"), mc("brown_egg")),
+            sortedByPrior(mc("brown_egg"), mc("blue_egg"), mc("egg")),
+        )
+        assertEquals(
+            listOf(mc("soul_sand"), mc("soul_soil")),
+            sortedByPrior(mc("soul_soil"), mc("soul_sand")),
+        )
+    }
+
+    @Test
+    fun `unrelated items with no applicable axis compare as equal`() {
+        assertEquals(0, MemberPrior.compare(mc("gunpowder"), mc("diamond")))
+    }
+
+    // --- Tiebreak semantics: the prior must only ever break score ties, never override score. ---
+
+    private data class Member(val id: MinecraftId, val score: Int)
+
+    private fun rank(members: List<Member>): List<String> =
+        members.sortedWith(
+            compareByDescending<Member> { it.score }
+                .then(MemberPrior.comparator { it.id })
+                .thenBy { it.id.name }
+        ).map { it.id.id }
+
+    @Test
+    fun `score dominates the prior`() {
+        // red_sand is more canonical-losing by prior, but if it scores higher it must still win:
+        // the prior is a tiebreak, not an override (e.g. charcoal winning at bulk demand).
+        val ranked = rank(
+            listOf(
+                Member(Item(mc("sand"), "Sand"), score = 10),
+                Member(Item(mc("red_sand"), "Red Sand"), score = 50),
+            )
+        )
+        assertEquals(listOf(mc("red_sand"), mc("sand")), ranked)
+    }
+
+    @Test
+    fun `prior breaks the tie when scores are equal`() {
+        val ranked = rank(
+            listOf(
+                Member(Item(mc("red_sand"), "Red Sand"), score = 30),
+                Member(Item(mc("sand"), "Sand"), score = 30),
+            )
+        )
+        assertEquals(listOf(mc("sand"), mc("red_sand")), ranked)
+    }
+
+    @Test
+    fun `name breaks a tie only when the prior is also equal`() {
+        // Two ids the prior cannot separate fall through to the alphabetical name tiebreak.
+        val ranked = rank(
+            listOf(
+                Member(Item(mc("zebra"), "Zebra"), score = 5),
+                Member(Item(mc("apple"), "Apple"), score = 5),
+            )
+        )
+        assertEquals(listOf(mc("apple"), mc("zebra")), ranked)
+    }
+
+    @Test
+    fun `the previous alphabetical-only ordering was backwards for sand`() {
+        // Documents the bug: name-only sort put Red Sand first; the prior now corrects it.
+        val byNameOnly = listOf(
+            Member(Item(mc("sand"), "Sand"), score = 30),
+            Member(Item(mc("red_sand"), "Red Sand"), score = 30),
+        ).sortedBy { it.id.name }.map { it.id.id }
+        assertTrue(byNameOnly.first() == mc("red_sand"))
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/DrillView.kt
@@ -5,6 +5,7 @@ import app.mcorg.domain.model.minecraft.MinecraftTag
 import app.mcorg.domain.model.project.Project
 import app.mcorg.engine.model.ItemSourceGraph
 import app.mcorg.engine.model.SourceNode
+import app.mcorg.engine.plan.MemberPrior
 import app.mcorg.engine.plan.PlanNodeStatus
 import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.engine.plan.SourceRanking
@@ -281,7 +282,11 @@ fun nodePickerFragment(
                     val best = graph?.let { SourceRanking.rankSources(it, member, demand).firstOrNull() }
                     RankedMember(member, best?.source, best?.score ?: Int.MIN_VALUE)
                 }
-                .sortedWith(compareByDescending<RankedMember> { it.score }.thenBy { it.member.name })
+                .sortedWith(
+                    compareByDescending<RankedMember> { it.score }
+                        .then(MemberPrior.comparator { it.member })
+                        .thenBy { it.member.name }
+                )
             val topId = ranked.firstOrNull()?.member?.id
             val filtered = if (q.isEmpty()) ranked else ranked.filter { it.member.name.contains(q, ignoreCase = true) }
             val displayed = filtered.take(PICKER_MAX_OPTIONS)


### PR DESCRIPTION
## What

The variant picker (`DrillView.nodePickerFragment`) ranked an open tag's members by best-source score, then alphabetically by name. Structurally identical alternatives — `sand` vs `red_sand`, the twelve woods, the sixteen wool colours — tie on score, so the alphabetical tiebreak surfaced the **less** canonical member as "best": Red Sand before Sand, acacia before oak, black before white.

This adds a canonical-default **prior** used purely as a tiebreak, so ties resolve to the member a player actually reaches for first.

## How

- **`mc-engine/plan/MemberPrior.kt`** (new) — an axis-based ordering parsed from the item id: explicit pairs (coal>charcoal, soul_sand>soul_soil) > wood species (oak first) > wood form (log>wood>stripped) > dye colour (uncoloured/white first) > stone base (cobblestone first) > decorative form (base>cut>chiseled>pillar). Axis-based rather than per-tag, so ~80 choice points are covered by a handful of vocabularies that survive Minecraft version bumps. It reads **no world data** — the defaults are human judgments, not an abundance metric. Kept in `mc-engine` (pure, no mc-web dep) so a future `PlanSelector` auto-resolve can reuse it.
- **`DrillView.kt`** — inserted `MemberPrior.comparator` between the score sort and the name fallback. **Tiebreak only**: score still dominates and name is still the final fallback, so the prior fires solely on score ties. Tags stay `OPEN_TAG`; selection behaviour is unchanged. At bulk demand, where the scorer genuinely separates members (charcoal's smelt recipe over mined coal), the score decides and the prior never fires.
- **`CLAUDE.md`** — dropped a stale JDK-25 `JAVA_HOME` note (all machines run Java 25 now).

## Scope / non-goals

- **Tiebreak-only by design.** Auto-resolving a tag to its default in `PlanSelector` is deferred — that's a future "complete plan vs. all options" user choice, and the model has no user choices yet.
- **No scorer changes.** `SelectionScorer` / `PlanSelector` / graph are untouched, so this stays out of the scoring human-checkpoint area. (A separate follow-up will penalize re-dye sources, which is unrelated to this tiebreak.)

## Tests

- `MemberPriorTest` — 16 cases: each axis's canonical winner (sand>red_sand, oak, white, cobblestone, base-form, coal), the substring traps (`dark_oak`≠oak, `light_gray`≠gray, `blackstone`≠black), and tiebreak semantics (score overrides prior; prior overrides name; documents that the old name-only sort was backwards).
- Full unit tier green (659 tests), including the existing 49-test `DrillViewTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)