### PR TITLE
MCO-226: List lens resolution toggle ("What I need" / "How to make it")

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -245,7 +245,12 @@ private fun FlowContent.lensComingSoon(worldId: Int, projectId: Int, lens: Strin
 }
 
 /**
- * The List lens: definition controls + grouped activity list (or empty/error state).
+ * The List lens. Renders two resolutions of the same plan behind a client-side toggle
+ * (MCO-226): "What I need" (the targets the user defined) and "How to make it" (the engine's
+ * full dependency breakdown). Both bodies are rendered; the toggle shows one at a time and its
+ * choice is persisted in sessionStorage so it survives #project-content re-renders (e.g. the
+ * inline variant pick, which re-renders the whole list via origin=list). The Tasks section
+ * sits below both and is always visible.
  */
 private fun FlowContent.listLensContent(
     project: Project,
@@ -254,95 +259,110 @@ private fun FlowContent.listLensContent(
     plan: GatheringPlan?,
     progressMap: Map<String, Int> = emptyMap(),
 ) {
-    // Resources / definition section
-    div("project-detail__section") {
-        div("project-detail__section-header") {
-            span("project-detail__section-title section-label") { +"Resources" }
-            div("project-detail__section-actions") {
-                button(classes = "btn btn--ghost btn--sm") {
-                    id = "plan-upload-schematic-btn"
-                    type = ButtonType.button
-                    attributes["onclick"] =
-                        "document.getElementById('resource-schematic-modal')?.showModal()"
-                    +"Upload schematic"
-                }
-                button(classes = "btn btn--secondary btn--sm plan-add-resource-btn") {
-                    id = "plan-add-resource-btn"
-                    type = ButtonType.button
-                    +"+ Add resource"
-                }
-            }
-        }
+    // Resolution toggle (client-side; default "targets" applied by plan-view.js).
+    listResolutionToggle()
 
-        // Add resource form (hidden by default via JS)
-        div("plan-add-resource-form") {
-            id = "plan-add-resource-form"
-            form {
-                id = "plan-resource-form"
-                div("plan-add-resource-form__fields") {
-                    div("plan-add-resource-form__field plan-add-resource-form__field--item") {
-                        label("plan-add-resource-form__label") {
-                            htmlFor = "plan-item-search"
-                            +"Item"
-                        }
-                        div("item-search-field") {
-                            input(type = InputType.text, classes = "form-control") {
-                                id = "plan-item-search"
-                                placeholder = "Search items by name..."
-                                autoComplete = "off"
-                                hxGet("/items/search")
-                                hxTrigger("input changed delay:300ms")
-                                hxTarget("#plan-item-search-results")
-                                hxSwap("innerHTML")
-                                attributes["hx-vals"] = "js:{q: this.value}"
-                            }
-                            div("item-search-results") {
-                                id = "plan-item-search-results"
-                            }
-                        }
-                        hiddenInput {
-                            id = "plan-selected-item-id"
-                            name = "requiredItemId"
-                        }
+    // "What I need" — the defined targets, with the add/upload definition controls.
+    div("list-resolution-view") {
+        id = "list-targets-view"
+        attributes["data-resolution-view"] = "targets"
+
+        div("project-detail__section") {
+            div("project-detail__section-header") {
+                span("project-detail__section-title section-label") { +"Resources" }
+                div("project-detail__section-actions") {
+                    button(classes = "btn btn--ghost btn--sm") {
+                        id = "plan-upload-schematic-btn"
+                        type = ButtonType.button
+                        attributes["onclick"] =
+                            "document.getElementById('resource-schematic-modal')?.showModal()"
+                        +"Upload schematic"
                     }
-                    div("plan-add-resource-form__field plan-add-resource-form__field--qty") {
-                        label("plan-add-resource-form__label") {
-                            htmlFor = "plan-item-amount"
-                            +"Quantity"
-                        }
-                        input(type = InputType.number, classes = "form-control") {
-                            id = "plan-item-amount"
-                            name = "requiredAmount"
-                            min = "1"
-                            max = "2000000000"
-                            value = "1"
-                        }
-                    }
-                    div("plan-add-resource-form__actions") {
-                        button(classes = "btn btn--primary btn--sm") {
-                            id = "plan-add-resource-submit"
-                            type = ButtonType.button
-                            +"Add"
-                        }
-                        button(classes = "btn btn--ghost btn--sm") {
-                            id = "plan-add-resource-cancel"
-                            type = ButtonType.button
-                            +"Cancel"
-                        }
+                    button(classes = "btn btn--secondary btn--sm plan-add-resource-btn") {
+                        id = "plan-add-resource-btn"
+                        type = ButtonType.button
+                        +"+ Add resource"
                     }
                 }
             }
+
+            // Add resource form (hidden by default via JS)
+            div("plan-add-resource-form") {
+                id = "plan-add-resource-form"
+                form {
+                    id = "plan-resource-form"
+                    div("plan-add-resource-form__fields") {
+                        div("plan-add-resource-form__field plan-add-resource-form__field--item") {
+                            label("plan-add-resource-form__label") {
+                                htmlFor = "plan-item-search"
+                                +"Item"
+                            }
+                            div("item-search-field") {
+                                input(type = InputType.text, classes = "form-control") {
+                                    id = "plan-item-search"
+                                    placeholder = "Search items by name..."
+                                    autoComplete = "off"
+                                    hxGet("/items/search")
+                                    hxTrigger("input changed delay:300ms")
+                                    hxTarget("#plan-item-search-results")
+                                    hxSwap("innerHTML")
+                                    attributes["hx-vals"] = "js:{q: this.value}"
+                                }
+                                div("item-search-results") {
+                                    id = "plan-item-search-results"
+                                }
+                            }
+                            hiddenInput {
+                                id = "plan-selected-item-id"
+                                name = "requiredItemId"
+                            }
+                        }
+                        div("plan-add-resource-form__field plan-add-resource-form__field--qty") {
+                            label("plan-add-resource-form__label") {
+                                htmlFor = "plan-item-amount"
+                                +"Quantity"
+                            }
+                            input(type = InputType.number, classes = "form-control") {
+                                id = "plan-item-amount"
+                                name = "requiredAmount"
+                                min = "1"
+                                max = "2000000000"
+                                value = "1"
+                            }
+                        }
+                        div("plan-add-resource-form__actions") {
+                            button(classes = "btn btn--primary btn--sm") {
+                                id = "plan-add-resource-submit"
+                                type = ButtonType.button
+                                +"Add"
+                            }
+                            button(classes = "btn btn--ghost btn--sm") {
+                                id = "plan-add-resource-cancel"
+                                type = ButtonType.button
+                                +"Cancel"
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Resource table — always rendered as HTMX swap target
+            planResourceTable(project.worldId, project.id, resources)
+
+            // Schematic upload modal
+            resourceSchematicModal(project.worldId, project.id, resources.filter { it.required > 0 }.size)
         }
-
-        // Resource table — always rendered as HTMX swap target
-        planResourceTable(project.worldId, project.id, resources)
-
-        // Schematic upload modal
-        resourceSchematicModal(project.worldId, project.id, resources.filter { it.required > 0 }.size)
     }
 
-    // Gathering plan activity sections
-    gatheringPlanSections(project, plan, progressMap)
+    // "How to make it" — the engine's full dependency breakdown (grouped activities).
+    // Hidden by default (targets is the default resolution); plan-view.js reveals it when
+    // the persisted choice is "breakdown", avoiding a both-views flash before JS runs.
+    div("list-resolution-view list-resolution-view--hidden") {
+        id = "list-breakdown-view"
+        attributes["data-resolution-view"] = "breakdown"
+
+        gatheringPlanSections(project, plan, progressMap)
+    }
 
     // Tasks section (collapsed)
     div("project-detail__section") {
@@ -372,6 +392,33 @@ private fun FlowContent.listLensContent(
             }
             taskList(project.worldId, project.id, tasks)
             addTaskInline(project.worldId, project.id)
+        }
+    }
+}
+
+/**
+ * Segmented toggle between the two List-lens resolutions (MCO-226). Plain buttons wired by
+ * plan-view.js (no server round-trip — both views are already in the DOM). The active state
+ * and which view is shown are driven client-side and persisted per project in sessionStorage,
+ * so the choice survives #project-content re-renders. "What I need" is the default.
+ */
+private fun FlowContent.listResolutionToggle() {
+    div("list-resolution") {
+        attributes["role"] = "tablist"
+        attributes["aria-label"] = "Plan resolution"
+        button(classes = "list-resolution__option list-resolution__option--active") {
+            type = ButtonType.button
+            attributes["data-resolution"] = "targets"
+            attributes["role"] = "tab"
+            attributes["aria-selected"] = "true"
+            +"What I need"
+        }
+        button(classes = "list-resolution__option") {
+            type = ButtonType.button
+            attributes["data-resolution"] = "breakdown"
+            attributes["role"] = "tab"
+            attributes["aria-selected"] = "false"
+            +"How to make it"
         }
     }
 }
@@ -662,14 +709,6 @@ fun TR.planResourceRow(worldId: Int, projectId: Int, item: ResourceGatheringItem
             hxTrigger("change")
         }
     }
-    val sourceLabel = when (item.sourceType) {
-        "manual" -> "Manual gather"
-        "project" -> item.solvedByProject?.second ?: "Unknown project"
-        else -> "--"
-    }
-    td("plan-resource-table__source") {
-        span("plan-resource-table__source-badge") { +sourceLabel }
-    }
     td("plan-resource-table__action") {
         button(classes = "btn btn--ghost btn--sm plan-resource-table__delete-btn") {
             type = ButtonType.button
@@ -695,7 +734,6 @@ fun FlowContent.planResourceTable(worldId: Int, projectId: Int, resources: List<
                     th { classes = setOf("plan-resource-table__col-status") }
                     th { classes = setOf("plan-resource-table__col-item"); +"Item" }
                     th { classes = setOf("plan-resource-table__col-qty"); +"Qty" }
-                    th { classes = setOf("plan-resource-table__col-source"); +"Source" }
                     th { classes = setOf("plan-resource-table__col-action") }
                 }
             }
@@ -722,7 +760,6 @@ fun planResourceTableFragment(worldId: Int, projectId: Int, resources: List<Reso
                     th { classes = setOf("plan-resource-table__col-status") }
                     th { classes = setOf("plan-resource-table__col-item"); +"Item" }
                     th { classes = setOf("plan-resource-table__col-qty"); +"Qty" }
-                    th { classes = setOf("plan-resource-table__col-source"); +"Source" }
                     th { classes = setOf("plan-resource-table__col-action") }
                 }
             }

--- a/webapp/mc-web/src/main/resources/static/scripts/plan-view.js
+++ b/webapp/mc-web/src/main/resources/static/scripts/plan-view.js
@@ -258,6 +258,70 @@
     }
 
     // -------------------------------------------------------------------------
+    // List resolution toggle (MCO-226): "What I need" (targets) <-> "How to make
+    // it" (breakdown). Both views are already in the DOM; this just shows one and
+    // persists the choice per project so it survives #project-content re-renders
+    // (e.g. the inline variant pick, which re-renders the whole list).
+    // -------------------------------------------------------------------------
+
+    var RESOLUTION_DEFAULT = 'targets';
+
+    function resolutionStorageKey() {
+        var projectId = getProjectIdFromUrl();
+        return projectId ? 'planResolution:' + projectId : null;
+    }
+
+    function readResolution() {
+        var key = resolutionStorageKey();
+        if (!key) return RESOLUTION_DEFAULT;
+        try {
+            var stored = window.sessionStorage.getItem(key);
+            return stored === 'breakdown' ? 'breakdown' : RESOLUTION_DEFAULT;
+        } catch (e) {
+            return RESOLUTION_DEFAULT;
+        }
+    }
+
+    function writeResolution(value) {
+        var key = resolutionStorageKey();
+        if (!key) return;
+        try {
+            window.sessionStorage.setItem(key, value);
+        } catch (e) { /* storage unavailable — non-fatal, state just won't persist */ }
+    }
+
+    function applyResolution(value) {
+        document.querySelectorAll('.list-resolution-view').forEach(function (view) {
+            var active = view.dataset.resolutionView === value;
+            view.classList.toggle('list-resolution-view--hidden', !active);
+        });
+        document.querySelectorAll('.list-resolution__option').forEach(function (btn) {
+            var active = btn.dataset.resolution === value;
+            btn.classList.toggle('list-resolution__option--active', active);
+            btn.setAttribute('aria-selected', active ? 'true' : 'false');
+        });
+    }
+
+    function initResolutionToggle() {
+        var toggle = document.querySelector('.list-resolution');
+        if (!toggle) return;
+        // Re-apply the persisted choice on every settle (the toggle re-renders with
+        // #project-content), but only bind click handlers once.
+        applyResolution(readResolution());
+        if (toggle.dataset.initialized) return;
+        toggle.dataset.initialized = 'true';
+
+        toggle.addEventListener('click', function (e) {
+            var btn = e.target.closest('.list-resolution__option');
+            if (!btn) return;
+            var value = btn.dataset.resolution;
+            if (value !== 'targets' && value !== 'breakdown') return;
+            writeResolution(value);
+            applyResolution(value);
+        });
+    }
+
+    // -------------------------------------------------------------------------
     // Item search selection (plan view)
     // -------------------------------------------------------------------------
 
@@ -339,6 +403,7 @@
         initAddResourceForm();
         initItemSearchKeyNav();
         initPlanCountEdit();
+        initResolutionToggle();
     }
 
     document.addEventListener('DOMContentLoaded', init);

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
@@ -205,6 +205,50 @@
     margin: 0;
 }
 
+/* List resolution toggle (MCO-226): What I need <-> How to make it.
+   Segmented control; mirrors the pill-tab visual language but as an inset segmented group. */
+.list-resolution {
+    display: inline-flex;
+    gap: var(--space-1);
+    margin-top: var(--space-4);
+    padding: var(--space-1);
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+}
+
+.list-resolution__option {
+    cursor: pointer;
+    padding: 6px var(--space-3);
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: var(--text-muted);
+    font-family: var(--font-ui);
+    font-size: var(--text-ui);
+    font-weight: 500;
+    transition: background 150ms ease, color 150ms ease;
+}
+
+.list-resolution__option:hover {
+    color: var(--text-primary);
+}
+
+.list-resolution__option--active {
+    background: var(--accent);
+    color: var(--on-accent);
+}
+
+.list-resolution__option--active:hover {
+    background: var(--accent-hover);
+    color: var(--on-accent);
+}
+
+/* Only one resolution view is shown at a time (toggled by plan-view.js). */
+.list-resolution-view--hidden {
+    display: none;
+}
+
 /* Plan resource table */
 .plan-resource-table {
     width: 100%;
@@ -264,10 +308,6 @@
     width: 120px;
 }
 
-.plan-resource-table__col-source {
-    width: 120px;
-}
-
 .plan-resource-table__col-action {
     width: 40px;
 }
@@ -316,13 +356,6 @@
 
 .plan-resource-table__qty--editing .plan-resource-table__qty-input {
     display: inline;
-}
-
-/* Source badge */
-.plan-resource-table__source-badge {
-    font-size: var(--text-xs);
-    color: var(--text-muted);
-    font-family: var(--font-ui);
 }
 
 /* Delete button */

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/GatheringPlannerIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/GatheringPlannerIT.kt
@@ -93,6 +93,48 @@ class GatheringPlannerIT : WithUser() {
     }
 
     @Test
+    fun `list lens renders the resolution toggle and both resolution views (MCO-226)`() = testApplication {
+        setupRoutes()
+
+        val response = client.get(
+            "/worlds/$worldId/projects/$projectId/detail-content?lens=list"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        // Segmented toggle with both resolutions
+        assertContains(body, "list-resolution")
+        assertContains(body, "What I need")
+        assertContains(body, "How to make it")
+        // Both resolution view containers are present (toggled client-side)
+        assertContains(body, "id=\"list-targets-view\"")
+        assertContains(body, "id=\"list-breakdown-view\"")
+        // Breakdown is hidden by default (targets is the default resolution)
+        assertContains(body, "list-resolution-view list-resolution-view--hidden")
+    }
+
+    @Test
+    fun `targets table no longer renders the stale Source column (MCO-244 #4)`() = testApplication {
+        setupRoutes()
+
+        val response = client.get(
+            "/worlds/$worldId/projects/$projectId/detail-content?lens=list"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        // The defined target still renders in the table...
+        assertContains(body, "plan-row-$resourceGatheringId")
+        // ...but the stale Source column (header + per-row badge) is gone.
+        assertFalse(body.contains("plan-resource-table__col-source"))
+        assertFalse(body.contains("plan-resource-table__source-badge"))
+    }
+
+    @Test
     fun `GET detail-content with lens=next returns coming-soon stub`() = testApplication {
         setupRoutes()
 


### PR DESCRIPTION
## Summary

Fast-follow refinement of the List lens (MCO-221). Replaces the stacked "double view" — the Resources definition table on top and the engine-derived activity sections below — with a client-side toggle between two resolutions of the **same** plan:

- **What I need** — the targets the user defined, with the add-resource + schematic-upload definition controls.
- **How to make it** — the engine's full dependency breakdown (the existing grouped activity sections).

Resolved the issue's open questions:
- **Toggle placement** — a sub-control inside the List body (not a top-level lens pill), since it's a resolution of the List lens.
- **Definition controls** (add / upload / qty-edit / delete) live only in the **What I need** view.
- **Progress counters** stay only in the **How to make it** breakdown (targets is a pure definition list, as before).
- **Mechanism** — client-side show/hide, no server round-trip (both views are already in the DOM). Choice persists per project in `sessionStorage` so it **survives `#project-content` re-renders** — notably the inline "Pick variant" resolution, which re-renders the whole list via `origin=list`. Default is "What I need"; the breakdown renders hidden in HTML to avoid a both-views flash before JS runs.

Also folds in **MCO-244 #4** — removes the stale **Source** column from the targets table (header + per-row badge in `planResourceRow`, plus the now-dead `col-source` / `source-badge` CSS). Scoped to the table column only; the status dot and the broader source concept (resource detail panel, `/source` routes, ResumeHero/FieldLog) are untouched.

## Touch points
- `ProjectDetailPage.kt` — `listLensContent()` restructure + `listResolutionToggle()`; Source column removal. No engine changes; both views derive from the same `GatheringPlan`.
- `plan-view.js` — `initResolutionToggle()` (persist + re-apply on `htmx:afterSettle`).
- `project-detail.css` — segmented toggle styles; removed source-column rules.

## Testing
- `mvn clean compile` — clean.
- Unit tier (`test.sh`) — green.
- Database tier (`test.sh --database`) — green, incl. 2 new ITs in `GatheringPlannerIT`: toggle + both view containers render (breakdown hidden by default); Source column/badge gone while the target row still renders.
- Local visual check was blocked by work-network access to the Neon branch — relying on this preview deploy to eyeball.

Closes MCO-226. Addresses MCO-244 #4 (the rest of MCO-244 — items 1/2/3/9 — stays in that issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)