### PR TITLE
Litematica planner list: quantity-desc sort + drop placed-effect BLOCKED rows

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
@@ -165,8 +165,10 @@ data class MapSchematicToMaterialsStep(
      *    (birch_wall_sign -> birch_sign, dead_horn_coral_wall_fan -> dead_horn_coral_fan).
      * 4. Otherwise resolve by the id itself, or drop when the version has no such item.
      *
-     * Truly non-obtainable blocks (budding_amethyst, portals, fire) are intentionally
-     * left to resolve to nothing and surface as a BLOCKED row rather than a wrong guess.
+     * Truly non-obtainable blocks (budding_amethyst, portals) are intentionally left to
+     * resolve to nothing and surface as a BLOCKED row rather than a wrong guess. Placed
+     * *effect* blocks whose material is a separate cell already counted plus a reusable
+     * tool (fire, soul_fire, bubble_column) are dropped as non-materials — see [isDropped].
      */
     private fun resolveMaterial(blockId: String, byId: Map<String, Item>): Item? {
         if (isDropped(blockId)) return null
@@ -186,9 +188,18 @@ data class MapSchematicToMaterialsStep(
     companion object {
         /**
          * Blocks that occupy a cell in a schematic but are not a material of their own —
-         * the piston already accounts for its extended head and the moving block.
+         * the piston already accounts for its extended head and the moving block; the
+         * placed-effect blocks (fire, soul_fire, bubble_column) are created in-world from
+         * the block below them (a separate, already-counted cell) plus a reusable tool
+         * (flint & steel / a water bucket), so they carry no material of their own.
          */
-        private val NON_MATERIAL_BLOCKS = setOf("minecraft:piston_head", "minecraft:moving_piston")
+        private val NON_MATERIAL_BLOCKS = setOf(
+            "minecraft:piston_head",
+            "minecraft:moving_piston",
+            "minecraft:fire",
+            "minecraft:soul_fire",
+            "minecraft:bubble_column",
+        )
 
         /**
          * Placed block-state ids whose gathered item has a *different* id. Crops resolve

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetAllResourceGatheringItemsStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetAllResourceGatheringItemsStep.kt
@@ -17,7 +17,7 @@ val GetAllResourceGatheringItemsStep = DatabaseSteps.query<Int, List<ResourceGat
                ON rgp.project_id = rg.project_id AND rgp.item_id = rg.item_id
         LEFT JOIN projects p ON p.id = rg.solved_by_project_id
         WHERE rg.project_id = ?
-        ORDER BY rg.required
+        ORDER BY rg.required DESC, rg.name
         """.trimIndent()
     ),
     parameterSetter = { statement, projectId -> statement.setInt(1, projectId) },

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/MapSchematicToMaterialsStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/MapSchematicToMaterialsStepTest.kt
@@ -24,6 +24,9 @@ class MapSchematicToMaterialsStepTest {
         "minecraft:redstone",
         "minecraft:string",
         "minecraft:torch",
+        "minecraft:soul_fire",
+        "minecraft:bubble_column",
+        "minecraft:soul_sand",
     ).map { Item(it, it.substringAfterLast(':')) }
 
     private fun litematica(items: Map<String, Int>) =
@@ -118,6 +121,24 @@ class MapSchematicToMaterialsStepTest {
         assertNull(byId["minecraft:black_candle_cake"])
         assertNull(byId["minecraft:infested_stone"])
         assertEquals(9, byId["minecraft:oak_planks"], "real materials still pass through")
+    }
+
+    @Test
+    fun `placed effect blocks are dropped even when present in the catalog`() {
+        // soul_fire and bubble_column exist as block ids but carry no material of their own:
+        // the block they sit on (here soul_sand) is a separate, already-counted cell and the
+        // activation (flint & steel / water bucket) is a reusable tool. They must drop out
+        // rather than surface as a BLOCKED row with no feasible source.
+        val byId = map(
+            mapOf(
+                "minecraft:soul_fire" to 4,
+                "minecraft:bubble_column" to 6,
+                "minecraft:soul_sand" to 10,
+            )
+        )
+        assertNull(byId["minecraft:soul_fire"])
+        assertNull(byId["minecraft:bubble_column"])
+        assertEquals(10, byId["minecraft:soul_sand"], "the underlying block is still counted, not inflated")
     }
 
     @Test

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/AddResourcesFromSchematicIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/AddResourcesFromSchematicIT.kt
@@ -51,7 +51,12 @@ class AddResourcesFromSchematicIT : WithUser() {
         litematicBytes = javaClass.getResourceAsStream("/litematica-test.litematic")!!.readBytes()
 
         val litematica = (LitematicaReader.readLitematica(litematicBytes) as Result.Success).value
-        expectedItemIds = litematica.items.keys.toSet()
+        // The mapping redirects placed-effect block ids to the item actually gathered
+        // (redstone_wall_torch -> redstone_torch, redstone_wire -> redstone). Both targets
+        // are themselves cells in this fixture, so the two source ids collapse onto them and
+        // do not survive as their own resources.
+        expectedItemIds = litematica.items.keys.toSet() -
+            setOf("minecraft:redstone_wall_torch", "minecraft:redstone_wire")
         runBlocking {
             DatabaseSteps.update<Unit>(
                 sql = SafeSQL.insert("INSERT INTO minecraft_version (version) VALUES ('1.21.4') ON CONFLICT DO NOTHING"),


### PR DESCRIPTION
Quick wins from litematica project-creator feedback. Two commits (fine to squash on merge).

## Changes

**Sort "What I need" by quantity descending** — `GetAllResourceGatheringItemsStep` was ordering ascending (smallest pile first); now descending with name as a stable tiebreak, matching what you'd expect from a gather list.

**Stop surfacing placed-effect blocks as BLOCKED** — `fire`, `soul_fire`, and `bubble_column` are now treated as non-material placed effects (like `piston_head`). Each is created in-world from the block beneath it — a *separately-counted* schematic cell — plus a reusable tool (flint & steel / water bucket), so it carries no material of its own. Redirecting them to soul_sand/water would have double-counted; dropping them is the correct-quantity fix. Covered by a new unit test in `MapSchematicToMaterialsStepTest`.

**Fix a pre-existing red IT (separate commit)** — `AddResourcesFromSchematicIT` asserted the schematic output equals its raw block ids, but the material mapping already redirects `redstone_wall_torch → redstone_torch` and `redstone_wire → redstone` (shipped in 04106cd); those source ids collapse onto targets already in the fixture. The expectation predated the redirects and had been failing on master. Updated with a comment.

## Tests
- `mvn clean compile` ✅
- Full unit tier: 660 pass ✅
- Affected mc-web ITs (`ProjectDetailIT`, `PlanViewIT`, `GatheringPlannerIT`, `ResourceDetailPanelIT`, `AddResourcesFromSchematicIT`): 45 pass ✅

## Follow-up
The higher-value feedback — explaining *why* each baseline material is needed (reverse-provenance) and revisiting the default lens — is tracked in [MCO-245](https://linear.app/evegul/issue/MCO-245).

🤖 Generated with [Claude Code](https://claude.com/claude-code)