### PR TITLE
MCO-245: show why each material is needed (reverse-provenance)

### DIFF
--- a/webapp/mc-engine/src/main/kotlin/app/mcorg/engine/plan/GatheringPlan.kt
+++ b/webapp/mc-engine/src/main/kotlin/app/mcorg/engine/plan/GatheringPlan.kt
@@ -170,6 +170,46 @@ class GatheringPlan(
     }
 
     /**
+     * Reverse-provenance: node id -> the set of target item ids whose selected chain
+     * transitively consumes that node — "what does gathering this go toward". Powers
+     * the "feeds 24 Birch Door · 40 Chest" annotation.
+     *
+     * - A node's own target id is not in its own set — a target does not feed itself.
+     * - A target that is also an ingredient of another target is attributed to that
+     *   other target (and its own id propagates to its ingredients).
+     * - A pure target nothing else consumes maps to an empty set (no annotation).
+     *
+     * Computed by seeding each target root with its target id and propagating down the
+     * [PlanNode.requires] edges in reverse-topological order (consumers before
+     * ingredients), so a single pass fills every node. O(nodes + edges).
+     */
+    val feeders: Map<String, Set<String>> by lazy {
+        val result = HashMap<String, MutableSet<String>>(nodes.size)
+        nodes.keys.forEach { result[it] = HashSet() }
+
+        // nodeId -> target item ids it directly fulfills (differs from the node id only
+        // for a tag target redirected to a concrete member via [roots]).
+        val ownTargets = HashMap<String, MutableSet<String>>()
+        for ((targetItemId, nodeId) in roots) {
+            ownTargets.getOrPut(nodeId) { HashSet() }.add(targetItemId)
+        }
+
+        // activityList is topological (ingredients before consumers); reversed gives
+        // consumers first, so a node's feeder set is complete before we push it down.
+        for (activity in activityList.asReversed()) {
+            val id = activity.item.id
+            val node = nodes[id] ?: continue
+            val attribution = HashSet(result.getValue(id))
+            ownTargets[id]?.let { attribution.addAll(it) }
+            if (attribution.isEmpty()) continue
+            for (req in node.requires) {
+                if (req.itemId != id) result[req.itemId]?.addAll(attribution)
+            }
+        }
+        result
+    }
+
+    /**
      * Drill-down tree for one target, or null if [targetItemId] is not a target.
      * Quantities are "if gathered alone" — see [TargetTree].
      */

--- a/webapp/mc-engine/src/test/kotlin/app/mcorg/engine/plan/GatheringPlanTest.kt
+++ b/webapp/mc-engine/src/test/kotlin/app/mcorg/engine/plan/GatheringPlanTest.kt
@@ -284,6 +284,80 @@ class GatheringPlanTest {
         assertTrue(aAgain.children.isEmpty())
     }
 
+    // ── feeders (reverse-provenance) ─────────────────────────────────────────
+
+    @Test
+    fun `feeders attribute a shared material to every target that consumes it`() {
+        val feeders = chestAndStickPlan().feeders
+
+        assertEquals(setOf("minecraft:chest", "minecraft:stick"), feeders.getValue("minecraft:log"))
+        assertEquals(setOf("minecraft:chest", "minecraft:stick"), feeders.getValue("minecraft:planks"))
+    }
+
+    @Test
+    fun `a target that nothing else consumes has no feeders`() {
+        val feeders = chestAndStickPlan().feeders
+
+        assertTrue(feeders.getValue("minecraft:chest").isEmpty())
+        assertTrue(feeders.getValue("minecraft:stick").isEmpty())
+    }
+
+    @Test
+    fun `a target that is also an ingredient is attributed to the other target, not itself`() {
+        // targets: 4 chests and 10 planks; chest <- 8 planks; planks <- 1 log.
+        val nodes = mapOf(
+            "minecraft:chest" to PlanNode(
+                item = item("chest"), quantity = 4, crafts = 4, leftover = 0,
+                status = PlanNodeStatus.RESOLVED, source = craft,
+                requires = listOf(PlanRequirement("minecraft:planks", 8))
+            ),
+            "minecraft:planks" to PlanNode(
+                item = item("planks"), quantity = 42, crafts = 11, leftover = 2,
+                status = PlanNodeStatus.RESOLVED, source = craft, producedQuantity = 4,
+                requires = listOf(PlanRequirement("minecraft:log", 1))
+            ),
+            "minecraft:log" to PlanNode(
+                item = item("log"), quantity = 11, crafts = 11, leftover = 0,
+                status = PlanNodeStatus.RAW_GATHER, source = mine
+            )
+        )
+        val plan = GatheringPlan(
+            nodes = nodes,
+            targets = listOf(PlanTarget(item("chest"), 4), PlanTarget(item("planks"), 10))
+        )
+
+        // planks is itself a target but is consumed by chest -> feeds chest, never itself.
+        assertEquals(setOf("minecraft:chest"), plan.feeders.getValue("minecraft:planks"))
+        // the log feeds both the chest target and the planks target.
+        assertEquals(setOf("minecraft:chest", "minecraft:planks"), plan.feeders.getValue("minecraft:log"))
+        assertTrue(plan.feeders.getValue("minecraft:chest").isEmpty())
+    }
+
+    @Test
+    fun `feeders attribute to the target id even when the root is tag-redirected`() {
+        val tag = MinecraftTag("minecraft:planks_tag", "Planks", emptyList())
+        val nodes = mapOf(
+            "minecraft:oak_planks" to PlanNode(
+                item = item("oak_planks"), quantity = 12, crafts = 3, leftover = 0,
+                status = PlanNodeStatus.RESOLVED, source = craft, producedQuantity = 4,
+                requires = listOf(PlanRequirement("minecraft:log", 1))
+            ),
+            "minecraft:log" to PlanNode(
+                item = item("log"), quantity = 3, crafts = 3, leftover = 0,
+                status = PlanNodeStatus.RAW_GATHER, source = mine
+            )
+        )
+        val plan = GatheringPlan(
+            nodes = nodes,
+            targets = listOf(PlanTarget(tag, 12)),
+            roots = mapOf("minecraft:planks_tag" to "minecraft:oak_planks")
+        )
+
+        // the log is attributed to the tag target id, not the concrete member node.
+        assertEquals(setOf("minecraft:planks_tag"), plan.feeders.getValue("minecraft:log"))
+        assertTrue(plan.feeders.getValue("minecraft:oak_planks").isEmpty())
+    }
+
     // ── ceilDiv ─────────────────────────────────────────────────────────────
 
     @Test

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -5,6 +5,7 @@ import app.mcorg.engine.model.ItemSourceGraph
 import app.mcorg.engine.plan.GatheringPlan
 import app.mcorg.engine.plan.PlanNodeStatus
 import app.mcorg.engine.plan.PlanOverrides
+import app.mcorg.engine.plan.PlanTarget
 import app.mcorg.engine.plan.TargetTree
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.failure.AppFailure
@@ -446,6 +447,38 @@ internal fun buildNodeIngredients(plan: GatheringPlan): Map<String, String> {
             val reducedOutput = output / divisor
             node.item.id to if (reducedOutput > 1) "$inputs → $reducedOutput" else inputs
         }
+}
+
+/**
+ * A reverse-provenance annotation for one material row: the capped [text] shown inline
+ * ("Feeds 64 Stick · 40 Chest · 24 Birch Door · +1 more") plus, when the list was
+ * truncated, the full uncapped list as a [title] tooltip so the hidden entries remain
+ * discoverable on hover. [title] is null when nothing was truncated.
+ */
+data class FeedsLabel(val text: String, val title: String?)
+
+/**
+ * Reverse-provenance labels: item id → the end-item target(s) whose chain consumes this
+ * material (from [GatheringPlan.feeders]). Each target renders as its name and its
+ * net-of-collected required amount, ordered by amount desc then name, capped at [cap] with
+ * a "+N more" tail (the full list surviving as a tooltip). Nodes that feed nothing (pure
+ * targets) are absent from the map.
+ */
+internal fun buildFeedsLabels(plan: GatheringPlan, cap: Int = 3): Map<String, FeedsLabel> {
+    val targetsById: Map<String, PlanTarget> = plan.targets.associateBy { it.item.id }
+    fun render(targets: List<PlanTarget>) = "Feeds " + targets.joinToString(" · ") { "${it.amount} ${it.item.name}" }
+    return plan.feeders.entries.mapNotNull { (nodeId, targetIds) ->
+        val targets = targetIds
+            .mapNotNull { targetsById[it] }
+            .sortedWith(compareByDescending<PlanTarget> { it.amount }.thenBy { it.item.name })
+        if (targets.isEmpty()) return@mapNotNull null
+        if (targets.size <= cap) {
+            nodeId to FeedsLabel(render(targets), null)
+        } else {
+            val text = render(targets.take(cap)) + " · +${targets.size - cap} more"
+            nodeId to FeedsLabel(text, render(targets))
+        }
+    }.toMap()
 }
 
 /**

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanProgressPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanProgressPipeline.kt
@@ -10,6 +10,7 @@ import app.mcorg.pipeline.resources.commonsteps.UpsertProgressByItemInput
 import app.mcorg.pipeline.resources.commonsteps.UpsertProgressByItemStep
 import app.mcorg.presentation.handler.handlePipeline
 import app.mcorg.presentation.hxOutOfBands
+import app.mcorg.presentation.templated.dsl.pages.feedsLine
 import app.mcorg.presentation.templated.dsl.pages.lootTableName
 import app.mcorg.presentation.templated.dsl.pages.overallProgressInner
 import app.mcorg.presentation.templated.dsl.pages.planActivityCount
@@ -95,6 +96,9 @@ suspend fun ApplicationCall.handleUpdatePlanProgress() {
                 .ifEmpty { null }
         }
 
+        // Keep the "feeds …" reverse-provenance line on the swapped row, matching the initial render.
+        val feedsLabel = plan?.let { buildFeedsLabels(it)[input.itemId] }
+
         PlanProgressResult(
             itemId = input.itemId,
             itemName = input.itemId.substringAfterLast(':').replace('_', ' ')
@@ -102,6 +106,7 @@ suspend fun ApplicationCall.handleUpdatePlanProgress() {
             collected = collected.toLong(),
             required = input.required,
             sourceLabel = sourceLabel,
+            feedsLabel = feedsLabel,
             overallTotals = overallTotals,
         )
     }
@@ -113,6 +118,8 @@ data class PlanProgressResult(
     val collected: Long,
     val required: Long,
     val sourceLabel: String?,
+    /** "Feeds 24 Birch Door · 40 Chest" reverse-provenance line; null when this feeds nothing. */
+    val feedsLabel: FeedsLabel? = null,
     /** Project-wide (totalRequired, totalCollected) across countable activities; null if plan unavailable. */
     val overallTotals: Pair<Long, Long>? = null,
 )
@@ -167,6 +174,7 @@ private fun buildPlanProgressResponse(worldId: Int, projectId: Int, result: Plan
                 }
             }
         }
+        feedsLine(result.feedsLabel)
     }
 
     // OOB update for #overall-progress — project-wide totals from plan re-derive.

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -36,6 +36,8 @@ import app.mcorg.presentation.templated.dsl.taskList
 import kotlinx.html.*
 import kotlinx.html.stream.createHTML
 import app.mcorg.engine.plan.TargetTree
+import app.mcorg.pipeline.resources.FeedsLabel
+import app.mcorg.pipeline.resources.buildFeedsLabels
 import app.mcorg.pipeline.resources.buildNodeIngredients
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -449,6 +451,7 @@ fun FlowContent.gatheringPlanSections(
     val byGroup = plan.activityList.groupBy { it.group }
     val groupOrder = ActivityGroup.values()
     val nodeIngredients = buildNodeIngredients(plan)
+    val feedsLabels = buildFeedsLabels(plan)
 
     div {
         id = "gathering-plan-sections"
@@ -456,17 +459,39 @@ fun FlowContent.gatheringPlanSections(
             val activities = byGroup[group] ?: return@forEach
             if (activities.isEmpty()) return@forEach
 
+            // Independent groups (raw activities with no intra-group ingredient edges) sort
+            // biggest-pile-first so gathering is prioritised by quantity. Smelt/Craft keep the
+            // engine's topological order so an ingredient still precedes what it builds.
+            val ordered = if (group in QUANTITY_SORTED_GROUPS) {
+                activities.sortedWith(compareByDescending<Activity> { it.quantity }.thenBy { it.item.name })
+            } else {
+                activities
+            }
+
             div("project-detail__section") {
                 span("section-label") { +groupLabel(group) }
                 div("resource-list") {
-                    activities.forEach { activity ->
-                        planActivityRow(project.worldId, project.id, activity, progressMap, nodeIngredients)
+                    ordered.forEach { activity ->
+                        planActivityRow(project.worldId, project.id, activity, progressMap, nodeIngredients, feedsLabels)
                     }
                 }
             }
         }
     }
 }
+
+/**
+ * Groups whose rows carry no ingredient edges between each other, so they can be sorted
+ * by quantity for prioritisation without breaking the "ingredients before consumers" reading
+ * that Smelt/Craft rely on.
+ */
+private val QUANTITY_SORTED_GROUPS = setOf(
+    ActivityGroup.COLLECT_SUPPLIED,
+    ActivityGroup.GATHER,
+    ActivityGroup.HUNT,
+    ActivityGroup.LOOT,
+    ActivityGroup.TRADE,
+)
 
 /** Renders a single activity row. Presentation depends on status. */
 private fun FlowContent.planActivityRow(
@@ -475,18 +500,33 @@ private fun FlowContent.planActivityRow(
     activity: Activity,
     progressMap: Map<String, Int> = emptyMap(),
     nodeIngredients: Map<String, String> = emptyMap(),
+    feedsLabels: Map<String, FeedsLabel> = emptyMap(),
 ) {
     when (activity.status) {
-        PlanNodeStatus.SUPPLIED -> suppliedActivityRow(worldId, projectId, activity)
+        PlanNodeStatus.SUPPLIED -> suppliedActivityRow(worldId, projectId, activity, feedsLabels[activity.item.id])
         PlanNodeStatus.OPEN_TAG -> openTagActivityRow(worldId, projectId, activity)
         PlanNodeStatus.BLOCKED -> blockedActivityRow(worldId, projectId, activity)
         PlanNodeStatus.RESOLVED, PlanNodeStatus.RAW_GATHER ->
-            counterActivityRow(worldId, projectId, activity, progressMap, nodeIngredients)
+            counterActivityRow(worldId, projectId, activity, progressMap, nodeIngredients, feedsLabels[activity.item.id])
+    }
+}
+
+/** Renders the "Feeds 24 Birch Door · 40 Chest" reverse-provenance line, when present. */
+internal fun FlowContent.feedsLine(label: FeedsLabel?) {
+    if (label == null) return
+    div("resource-row__feeds") {
+        label.title?.let { attributes["title"] = it }
+        +label.text
     }
 }
 
 /** SUPPLIED row: badge + supply label, no counter. */
-private fun FlowContent.suppliedActivityRow(worldId: Int, projectId: Int, activity: Activity) {
+private fun FlowContent.suppliedActivityRow(
+    worldId: Int,
+    projectId: Int,
+    activity: Activity,
+    feedsLabel: FeedsLabel? = null,
+) {
     val supplyLabel = activity.supply?.label ?: "Supplied"
     val encodedItemId = URLEncoder.encode(activity.item.id, StandardCharsets.UTF_8)
     div("resource-row") {
@@ -497,6 +537,7 @@ private fun FlowContent.suppliedActivityRow(worldId: Int, projectId: Int, activi
             span("resource-row__source") { +"from $supplyLabel" }
             drillButton(worldId, projectId, encodedItemId)
         }
+        feedsLine(feedsLabel)
     }
 }
 
@@ -553,6 +594,7 @@ fun FlowContent.counterActivityRow(
     activity: Activity,
     progressMap: Map<String, Int> = emptyMap(),
     nodeIngredients: Map<String, String> = emptyMap(),
+    feedsLabel: FeedsLabel? = null,
 ) {
     val itemSlug = activity.item.id.replace(":", "-")
     val rowId = "plan-activity-$itemSlug"
@@ -611,6 +653,7 @@ fun FlowContent.counterActivityRow(
                 }
             }
         }
+        feedsLine(feedsLabel)
     }
 }
 

--- a/webapp/mc-web/src/main/resources/static/styles/components/resource-row.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/resource-row.css
@@ -105,6 +105,26 @@
     flex: 0 0 auto;
 }
 
+/* Reverse-provenance line ("Feeds 24 Birch Door · 40 Chest") hung under a material row. */
+.resource-row__feeds {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    padding-left: var(--space-4);
+}
+
+.resource-row__feeds::before {
+    content: "↳ ";
+    color: var(--border);
+}
+
+/* A truncated list ("+N more") exposes the full set via a title tooltip — hint it. */
+.resource-row__feeds[title] {
+    cursor: help;
+    text-decoration: underline dotted var(--border);
+    text-underline-offset: 2px;
+}
+
 .resource-row__counters {
     display: flex;
     gap: 2px;

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/BuildFeedsLabelsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/BuildFeedsLabelsTest.kt
@@ -1,0 +1,114 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.resources.ResourceSource
+import app.mcorg.engine.model.SourceNode
+import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.engine.plan.PlanNode
+import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.PlanRequirement
+import app.mcorg.engine.plan.PlanTarget
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class BuildFeedsLabelsTest {
+
+    private val craft = SourceNode(ResourceSource.SourceType.RecipeTypes.CRAFTING_SHAPED, "recipe.json")
+    private val mine = SourceNode(ResourceSource.SourceType.LootTypes.BLOCK, "blocks/log.json")
+
+    private fun item(id: String, name: String) = Item("minecraft:$id", name)
+
+    private fun resolved(id: String, name: String, vararg requires: Pair<String, Int>) = PlanNode(
+        item = item(id, name), quantity = 1, crafts = 1, leftover = 0,
+        status = PlanNodeStatus.RESOLVED, source = craft,
+        requires = requires.map { PlanRequirement("minecraft:${it.first}", it.second) }
+    )
+
+    private fun rawGather(id: String, name: String) = PlanNode(
+        item = item(id, name), quantity = 1, crafts = 1, leftover = 0,
+        status = PlanNodeStatus.RAW_GATHER, source = mine
+    )
+
+    /**
+     * Four end-item targets (stick 64, chest 40, door 24, boat 10) all consume planks,
+     * which consumes a log. So both planks and the log feed all four targets.
+     */
+    private fun fourTargetPlan(): GatheringPlan {
+        val nodes = mapOf(
+            "minecraft:stick" to resolved("stick", "Stick", "planks" to 2),
+            "minecraft:chest" to resolved("chest", "Chest", "planks" to 8),
+            "minecraft:door" to resolved("door", "Birch Door", "planks" to 6),
+            "minecraft:boat" to resolved("boat", "Boat", "planks" to 5),
+            "minecraft:planks" to resolved("planks", "Birch Planks", "log" to 1),
+            "minecraft:log" to rawGather("log", "Birch Log"),
+        )
+        return GatheringPlan(
+            nodes = nodes,
+            targets = listOf(
+                PlanTarget(item("stick", "Stick"), 64),
+                PlanTarget(item("chest", "Chest"), 40),
+                PlanTarget(item("door", "Birch Door"), 24),
+                PlanTarget(item("boat", "Boat"), 10),
+            )
+        )
+    }
+
+    @Test
+    fun `label lists feeding targets by amount descending, capped with a plus-N-more tail`() {
+        val labels = buildFeedsLabels(fourTargetPlan())
+
+        // 64 Stick, 40 Chest, 24 Birch Door shown; 10 Boat folded into "+1 more".
+        assertEquals("Feeds 64 Stick · 40 Chest · 24 Birch Door · +1 more", labels["minecraft:log"]?.text)
+    }
+
+    @Test
+    fun `a truncated label carries the full uncapped list as a tooltip title`() {
+        val label = buildFeedsLabels(fourTargetPlan())["minecraft:log"]!!
+        // The hidden "10 Boat" is recoverable from the title even though it's not in the text.
+        assertEquals("Feeds 64 Stick · 40 Chest · 24 Birch Door · 10 Boat", label.title)
+    }
+
+    @Test
+    fun `a shared intermediate carries the same feeds label as the leaf below it`() {
+        val labels = buildFeedsLabels(fourTargetPlan())
+        assertEquals(labels["minecraft:log"], labels["minecraft:planks"])
+    }
+
+    @Test
+    fun `targets that feed nothing are absent from the map`() {
+        val labels = buildFeedsLabels(fourTargetPlan())
+        listOf("minecraft:stick", "minecraft:chest", "minecraft:door", "minecraft:boat").forEach {
+            assertNull(labels[it], "$it is a pure target and should have no feeds label")
+        }
+    }
+
+    @Test
+    fun `no plus-N-more tail or tooltip when the feeder count is within the cap`() {
+        val nodes = mapOf(
+            "minecraft:chest" to resolved("chest", "Chest", "planks" to 8),
+            "minecraft:planks" to resolved("planks", "Birch Planks", "log" to 1),
+            "minecraft:log" to rawGather("log", "Birch Log"),
+        )
+        val plan = GatheringPlan(nodes, listOf(PlanTarget(item("chest", "Chest"), 40)))
+
+        val label = buildFeedsLabels(plan)["minecraft:log"]!!
+        assertEquals("Feeds 40 Chest", label.text)
+        assertFalse(label.text.contains("more"))
+        assertNull(label.title, "an untruncated list needs no tooltip")
+    }
+
+    @Test
+    fun `the cap is configurable`() {
+        val labels = buildFeedsLabels(fourTargetPlan(), cap = 2)
+        assertEquals("Feeds 64 Stick · 40 Chest · +2 more", labels["minecraft:log"]?.text)
+    }
+
+    @Test
+    fun `an empty plan yields no labels`() {
+        val plan = GatheringPlan(emptyMap(), emptyList())
+        assertTrue(buildFeedsLabels(plan).isEmpty())
+    }
+}


### PR DESCRIPTION
Implements [MCO-245](https://linear.app/evegul/issue/MCO-245) — reverse-provenance ("why do I need this?") on the "How to make it" list.

## What

Each material row now shows a **`Feeds 24 Birch Door · 40 Chest`** line naming the end-item target(s) whose chain consumes it — so a "gather 146 Birch Log" row explains *what it's for* instead of just telling you to go get it.

## mc-engine (additive derived view — no scoring or graph-shape change)

- `GatheringPlan.feeders`: node id → the set of target item ids that transitively consume it, computed by reverse-topological propagation over the existing `requires` edges (single pass, O(nodes+edges)). A node's own target id is excluded (a target doesn't feed itself); a target that's also an ingredient is attributed to the *other* target. `perTarget`/`activityList`/scoring untouched.

## mc-web

- `buildFeedsLabels` → `FeedsLabel(text, title)`: target name + net-of-collected amount, ordered by amount desc, **capped at 3 with a `+N more` tail**; the full list is preserved as a `title` **tooltip** (dotted underline + help cursor hint the hover).
- Rendered on gather + supplied rows and kept on the progress-update (`+N`) row swap.
- **Group sort:** independent groups (Gather/Hunt/Loot/Trade/Supplied) now render **biggest-quantity-first**; Smelt/Craft stay topological so an ingredient still precedes what it builds.
- `.resource-row__feeds` styling — hung under the row with a `↳` marker.

## Decisions worth a look

- Cap = 3, quantity-desc order (both easy to tune).
- Feeds line is on gather/supplied rows, not the blocked/open-tag callouts.
- Smelt/Craft deliberately not quantity-sorted (topology).

## Tests
- mc-engine `feeders`: 4 cases (diamond, shared intermediate, target-as-ingredient, tag-redirect). Full engine suite 128 ✓
- mc-web `buildFeedsLabels`: 7 cases (order, cap, tooltip, no-tooltip, configurable cap, empty). Unit tier 667 ✓
- Plan ITs (ProjectDetail/PlanView/GatheringPlanner/ResourceDetailPanel/AddResourcesFromSchematic) 45 ✓

## Follow-ups filed (not in this PR)
MCO-246 (swap end-item variant), MCO-247 (ignore blocks), MCO-248 (infested block source — mc-data + re-ingest), MCO-249 (player "report" button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
