### PR TITLE
MCO-248: Exclude infested blocks as a phantom source

### DIFF
--- a/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/ExtractionVersion.kt
+++ b/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/ExtractionVersion.kt
@@ -14,7 +14,12 @@ package app.mcorg.data.minecraft
  *  - 1: synthetic obtain-sources (water/honey/concrete/nether star), wall + crop import
  *       mapping, and shaped/shapeless/simple alternative ingredients — from the
  *       gathering-planner review (2026-06).
+ *  - 2: drop infested blocks' `minecraft:block` loot tables (infested_stone,
+ *       infested_cobblestone, infested_stone_bricks, infested_mossy/cracked/chiseled_stone_bricks,
+ *       infested_deepslate) — their base-block Silk Touch drop is a phantom overridden by
+ *       InfestedBlock's code-level destroy handling and was winning over crafting as a fake
+ *       raw-gather source (MCO-248, 2026-07).
  */
 object ExtractionVersion {
-    const val CURRENT = 1
+    const val CURRENT = 2
 }

--- a/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/extract/loot/ExtractLootTables.kt
+++ b/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/extract/loot/ExtractLootTables.kt
@@ -14,6 +14,20 @@ import app.mcorg.domain.pipeline.Step
 import kotlinx.serialization.json.Json
 import org.slf4j.LoggerFactory
 
+/**
+ * Infested blocks' `minecraft:block` loot tables list a Silk Touch drop of the *base* block
+ * (e.g. `infested_stone_bricks.json` drops `minecraft:stone_bricks`), but `InfestedBlock`
+ * overrides destroy handling in game code: without Silk Touch it drops nothing (spawns a
+ * silverfish instead), and with Silk Touch it drops the infested block itself, never the base
+ * block. The loot-table entry is a phantom the JSON data can't reveal, and its filename
+ * (`infested_stone_bricks`) doesn't match the item it phantom-drops (`stone_bricks`), so
+ * without this guard it reads as a legitimate raw-gather source and wins over crafting.
+ */
+internal fun isPhantomInfestedBlockLoot(filename: String): Boolean {
+    val stem = filename.substringAfterLast('/').substringBeforeLast('.')
+    return stem.startsWith("infested_")
+}
+
 data object ExtractLootTables : Step<ExtractionContext, ExtractionFailure, List<ResourceSource>> {
     private val logger = LoggerFactory.getLogger(this.javaClass)
 
@@ -48,9 +62,22 @@ data object ExtractLootTables : Step<ExtractionContext, ExtractionFailure, List<
         }
 
         return when (val stringType = type.getOrThrow()) {
+            "minecraft:block" -> {
+                if (isPhantomInfestedBlockLoot(filename)) {
+                    logger.debug("Dropping phantom infested-block loot table: $filename")
+                    Result.success(
+                        ResourceSource(
+                            type = ResourceSource.SourceType.LootTypes.BLOCK,
+                            filename = filename,
+                            producedItems = emptyList()
+                        )
+                    )
+                } else {
+                    lootTableParser.parse(json, filename)
+                }
+            }
             "minecraft:archaeology",
             "minecraft:fishing",
-            "minecraft:block",
             "minecraft:block_interact",
             "minecraft:barter",
             "minecraft:entity",

--- a/webapp/mc-data/src/test/kotlin/app/mcorg/data/minecraft/extract/loot/ExtractLootTablesUnitTest.kt
+++ b/webapp/mc-data/src/test/kotlin/app/mcorg/data/minecraft/extract/loot/ExtractLootTablesUnitTest.kt
@@ -1,0 +1,105 @@
+package app.mcorg.data.minecraft.extract.loot
+
+import app.mcorg.data.minecraft.TestUtils
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.data.minecraft.extract.ExtractionContext
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+/**
+ * Unit-level coverage for [ExtractLootTables] that doesn't require downloaded server data
+ * (see [ExtractLootTablesTest] for the real-data E2E coverage) — specifically the
+ * infested-block phantom-loot guard from MCO-248.
+ */
+class ExtractLootTablesUnitTest {
+
+    private val version = MinecraftVersion.Release(1, 21, 0)
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private fun contextFor(tempDir: Path): ExtractionContext = ExtractionContext(
+        version = version,
+        root = tempDir,
+        names = mapOf(
+            "minecraft:stone_bricks" to "Stone Bricks (Item)",
+            "minecraft:infested_stone_bricks" to "Infested Stone Bricks (Item)",
+        ),
+        tags = emptyMap(),
+        itemIds = setOf("minecraft:stone_bricks", "minecraft:infested_stone_bricks"),
+    )
+
+    private fun writeLootTable(tempDir: Path, relativePath: String, json: String) {
+        val file = tempDir.resolve("loot_table").resolve(relativePath)
+        file.parent.toFile().mkdirs()
+        file.toFile().writeText(json)
+    }
+
+    @Test
+    fun `isPhantomInfestedBlockLoot matches infested block filenames`() {
+        assertTrue(isPhantomInfestedBlockLoot("blocks/infested_stone_bricks.json"))
+        assertTrue(isPhantomInfestedBlockLoot("infested_deepslate.json"))
+        assertFalse(isPhantomInfestedBlockLoot("blocks/stone_bricks.json"))
+        assertFalse(isPhantomInfestedBlockLoot("blocks/monster_egg.json"))
+    }
+
+    @Test
+    fun `drops the infested block loot table and keeps a normal block loot table`() {
+        writeLootTable(
+            tempDir,
+            "blocks/infested_stone_bricks.json",
+            """
+            {
+                "type": "minecraft:block",
+                "pools": [
+                    {
+                        "conditions": [
+                            {
+                                "condition": "minecraft:match_tool",
+                                "predicate": {
+                                    "predicates": {
+                                        "minecraft:enchantments": [
+                                            {"enchantments": "minecraft:silk_touch", "levels": {"min": 1}}
+                                        ]
+                                    }
+                                }
+                            }
+                        ],
+                        "entries": [
+                            {"type": "minecraft:item", "name": "minecraft:stone_bricks"}
+                        ],
+                        "rolls": 1.0
+                    }
+                ]
+            }
+            """.trimIndent()
+        )
+        writeLootTable(
+            tempDir,
+            "blocks/stone_bricks.json",
+            """
+            {
+                "type": "minecraft:block",
+                "pools": [
+                    {
+                        "entries": [
+                            {"type": "minecraft:item", "name": "minecraft:stone_bricks"}
+                        ],
+                        "rolls": 1.0
+                    }
+                ]
+            }
+            """.trimIndent()
+        )
+
+        val sources = TestUtils.executeAndAssertSuccess(ExtractLootTables, contextFor(tempDir))
+
+        assertEquals(1, sources.size, "Expected only the normal block loot table to survive, got: ${sources.map { it.filename }}")
+        assertEquals("blocks/stone_bricks.json", sources.single().filename)
+        assertEquals("minecraft:stone_bricks", sources.single().producedItems.single().first.id)
+    }
+}


### PR DESCRIPTION
The planner was picking "Break Block · Infested Stone Brick" as the source for Stone Brick over crafting from Stone. Infested blocks aren't a real acquisition path — mining without Silk Touch drops nothing (spawns a silverfish); with Silk Touch you get the *infested* block, not the base. The base-block drop is cancelled by `InfestedBlock`'s code-level destroy override, which the loot-table JSON can't reveal — so extraction read it as a legit raw-gather source and it won.

## Fix — data exclusion at extraction (agreed direction, no scorer change)
`ExtractLootTables` now drops `minecraft:block` loot tables whose filename stem starts with `infested_` (the 7: stone, cobblestone, stone_bricks, mossy/cracked/chiseled_stone_bricks, deepslate). Implemented by splitting `minecraft:block` into its own branch that short-circuits to an empty-`producedItems` source, which the existing post-parse filter already drops — no new filtering infrastructure, no `SelectionScorer`/`PathSuggestionScorer`/graph changes.

`ExtractionVersion.CURRENT` bumped 1 → 2 (+ History line), which triggers the one-time production re-ingest via the daily ingest machine.

## Verified
- Confirmed the phantom against real vanilla loot tables (all 7 gated on Silk Touch, dropping the base block).
- New unit test (`isPhantomInfestedBlockLoot` + inline-JSON extraction: infested dropped, normal block retained); existing 31-case E2E `ExtractLootTablesTest` still green.
- Re-ingested locally + score-diagnostics CLI: `stone_bricks` now selects **Crafting from Stone** (▶ 80), no infested candidate remains; all 7 base blocks resolve to legitimate paths; `infested_*` items correctly bucketed as naturally-generated (unchanged).
- `mvn clean compile` clean; 221 mc-data + 667 unit tests pass.

**Note:** takes effect in prod after merge + deploy, when the next ingest run re-extracts under ExtractionVersion 2.

Closes MCO-248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)