### PR TITLE
MCO-244: Gathering Planner UI polish (empty-state, upload feedback, drill scroll)

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -12,6 +12,7 @@ import app.mcorg.engine.plan.PlanNodeStatus
 import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.presentation.hxDelete
 import app.mcorg.presentation.hxGet
+import app.mcorg.presentation.hxIndicator
 import app.mcorg.presentation.hxOutOfBands
 import app.mcorg.presentation.hxPatch
 import app.mcorg.presentation.hxPost
@@ -671,6 +672,9 @@ private fun FlowContent.drillButton(worldId: Int, projectId: Int, encodedItemId:
         attributes["hx-swap"] = "outerHTML"
         attributes["hx-push-url"] = pushUrl
         attributes["aria-label"] = "View source chain"
+        // Marks the drill entry point so plan-view.js can remember the page's scroll
+        // position and restore it when "< Back to plan" (DrillView.kt) returns here.
+        attributes["data-drill-nav"] = "in"
         +"⇄"
     }
 }
@@ -840,6 +844,7 @@ fun FlowContent.resourceSchematicModal(worldId: Int, projectId: Int, existingRes
                     hxTarget("#plan-resource-table")
                     hxSwap("outerHTML")
                     hxTargetError(".form-error")
+                    hxIndicator("#resource-schematic-progress")
                     attributes["hx-encoding"] = "multipart/form-data"
                     attributes["hx-on::after-request"] =
                         "if(event.detail.successful) { this.reset(); this.closest('dialog')?.close() }"
@@ -858,6 +863,15 @@ fun FlowContent.resourceSchematicModal(worldId: Int, projectId: Int, existingRes
                     }
                     p("form-error") {
                         id = "validation-error-schematicFile"
+                    }
+
+                    // Upload/parse feedback: hidden until the request is in flight (see
+                    // .htmx-indicator in modal.css) — large schematics can take a while to
+                    // parse and there's otherwise no visible sign of progress.
+                    div("modal__progress htmx-indicator") {
+                        id = "resource-schematic-progress"
+                        div("modal__progress-spinner") {}
+                        span { +"Parsing schematic…" }
                     }
 
                     div("modal__actions") {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectListPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectListPage.kt
@@ -6,6 +6,7 @@ import app.mcorg.domain.model.project.ProjectResourceEdge
 import app.mcorg.domain.model.project.ProjectType
 import app.mcorg.domain.model.user.TokenProfile
 import app.mcorg.domain.model.world.World
+import app.mcorg.presentation.hxIndicator
 import app.mcorg.presentation.hxPost
 import app.mcorg.presentation.hxSwap
 import app.mcorg.presentation.hxTarget
@@ -228,12 +229,30 @@ fun kotlinx.html.FlowContent.projectsEmptyState(worldId: Int) {
         div("empty-state-card") {
             h2("empty-state-card__heading") { +"Plan your own project" }
             p("empty-state-card__body") { +"Create a new project and start tracking your builds and resources." }
-            div("empty-state-card__actions") {
-                button {
-                    classes = setOf("btn", "btn--primary")
+            // Same "pick a door" affordance as the populated state's "+ New project" menu
+            // (NewProjectMenu.kt) — reuses .np-menu__door so the empty and populated create
+            // entry points read as the same control, and adds the schematic door that was
+            // previously only reachable after creating an empty project.
+            div("empty-state-card__doors") {
+                button(classes = "np-menu__door") {
+                    type = ButtonType.button
+                    attributes["onclick"] =
+                        "document.getElementById('schematic-project-modal')?.showModal()"
+                    span("np-menu__door-glyph") { +"⤓" }
+                    span("np-menu__door-text") {
+                        span("np-menu__door-title") { +"From a schematic" }
+                        span("np-menu__door-sub") { +".litematic" }
+                    }
+                }
+                button(classes = "np-menu__door") {
+                    type = ButtonType.button
                     attributes["onclick"] =
                         "document.getElementById('first-project-flag').value='true'; document.getElementById('create-project-modal')?.showModal()"
-                    +"Create Project"
+                    span("np-menu__door-glyph") { +"+" }
+                    span("np-menu__door-text") {
+                        span("np-menu__door-title") { +"Blank project" }
+                        span("np-menu__door-sub") { +"name it, fill it later" }
+                    }
                 }
             }
         }
@@ -260,6 +279,7 @@ private fun kotlinx.html.FlowContent.schematicProjectModal(worldId: Int) {
                     form {
                         hxPost("/worlds/$worldId/projects/from-schematic")
                         hxTargetError(".form-error")
+                        hxIndicator("#schematic-project-progress")
                         attributes["hx-encoding"] = "multipart/form-data"
                         attributes["hx-on::after-request"] =
                             "if(event.detail.successful) { this.reset(); this.closest('dialog')?.close() }"
@@ -293,6 +313,15 @@ private fun kotlinx.html.FlowContent.schematicProjectModal(worldId: Int) {
                         }
                         p("form-error") {
                             id = "validation-error-name-schematic"
+                        }
+
+                        // Upload/parse feedback: hidden until the request is in flight
+                        // (see .htmx-indicator in modal.css) — large schematics can take a
+                        // while to parse and there's otherwise no visible sign of progress.
+                        div("modal__progress htmx-indicator") {
+                            id = "schematic-project-progress"
+                            div("modal__progress-spinner") {}
+                            span { +"Parsing schematic…" }
                         }
 
                         div("modal__actions") {

--- a/webapp/mc-web/src/main/resources/static/scripts/plan-view.js
+++ b/webapp/mc-web/src/main/resources/static/scripts/plan-view.js
@@ -380,6 +380,50 @@
     }
 
     // -------------------------------------------------------------------------
+    // Drill scroll restoration (MCO-244): drilling into a target's source chain
+    // (DrillView.kt) and "< Back to plan" both outerHTML-swap #project-content, which
+    // otherwise leaves the page scrolled wherever the new (usually shorter) content
+    // happens to land. Remember the scroll position on the way in — via the
+    // `data-drill-nav="in"` marker on every drill trigger (ProjectDetailPage.kt) — and
+    // restore it once #project-content settles back on a non-drill view (no
+    // `.drill-header`, see DrillView.kt). Scoped per-project via sessionStorage so it
+    // survives the swap and multiple drill round-trips.
+    // -------------------------------------------------------------------------
+
+    function drillScrollKey() {
+        var projectId = getProjectIdFromUrl();
+        return projectId ? 'drillScroll:' + projectId : null;
+    }
+
+    function initDrillScrollRestore() {
+        if (document.body.dataset.drillScrollInit) return;
+        document.body.dataset.drillScrollInit = 'true';
+
+        document.body.addEventListener('click', function (e) {
+            var trigger = e.target.closest('[data-drill-nav="in"]');
+            if (!trigger) return;
+            var key = drillScrollKey();
+            if (!key) return;
+            try {
+                window.sessionStorage.setItem(key, String(window.scrollY));
+            } catch (err) { /* storage unavailable — non-fatal, scroll just won't restore */ }
+        });
+
+        document.body.addEventListener('htmx:afterSettle', function (e) {
+            if (!e.target || e.target.id !== 'project-content') return;
+            if (e.target.querySelector('.drill-header')) return; // still in the drill chain
+            var key = drillScrollKey();
+            if (!key) return;
+            try {
+                var saved = window.sessionStorage.getItem(key);
+                if (saved === null) return;
+                window.sessionStorage.removeItem(key);
+                window.scrollTo(0, parseInt(saved, 10));
+            } catch (err) { /* storage unavailable */ }
+        });
+    }
+
+    // -------------------------------------------------------------------------
     // URL parsing helpers
     // -------------------------------------------------------------------------
 
@@ -404,6 +448,7 @@
         initItemSearchKeyNav();
         initPlanCountEdit();
         initResolutionToggle();
+        initDrillScrollRestore();
     }
 
     document.addEventListener('DOMContentLoaded', init);

--- a/webapp/mc-web/src/main/resources/static/styles/components/modal.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/modal.css
@@ -146,3 +146,42 @@ dialog.modal-backdrop::backdrop {
     from { opacity: 0; }
     to   { opacity: 1; }
 }
+
+/* --- HTMX indicator (generic — hx-indicator="#id") ---
+   htmx toggles the "htmx-request" class on the indicator element while its request is
+   in flight; it does not ship default visibility CSS, so this is the one utility that
+   defines it. Hidden by default, faded in during the request. */
+.htmx-indicator {
+    opacity: 0;
+    transition: opacity 150ms ease-in-out;
+}
+
+.htmx-indicator.htmx-request,
+.htmx-request .htmx-indicator {
+    opacity: 1;
+}
+
+/* Schematic-upload progress affordance — spinner + label shown inside the modal
+   body while the upload/parse request is in flight (see .htmx-indicator above). */
+.modal__progress {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    color: var(--text-muted);
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+}
+
+.modal__progress-spinner {
+    width: 16px;
+    height: 16px;
+    flex: none;
+    border: 2px solid var(--border);
+    border-top-color: var(--accent);
+    border-radius: 50%;
+    animation: modal-progress-spin 700ms linear infinite;
+}
+
+@keyframes modal-progress-spin {
+    to { transform: rotate(360deg); }
+}

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-list.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-list.css
@@ -60,6 +60,18 @@
     margin-top: var(--space-2);
 }
 
+/* Reuses .np-menu__door (see the "+ New project" door menu below) so the empty state's
+   create entry points look identical to the populated state's. Unlike .np-menu__panel this
+   sits inline in the card (no absolute positioning/box-shadow), just a bordered door list. */
+.empty-state-card__doors {
+    display: flex;
+    flex-direction: column;
+    margin-top: var(--space-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
 /* --- Mobile --- */
 
 @media (max-width: 768px) {
@@ -184,16 +196,21 @@
 
 /* --- Chips (pending / paused) --- */
 
+/* Full-width stacked rows, not a wrapped cluster of pills — an empty pending/paused
+   project should read as a project row (like .fl-row), just a simpler one. */
 .fl-chips {
     display: flex;
-    flex-wrap: wrap;
-    gap: var(--space-3);
+    flex-direction: column;
+    gap: var(--space-2);
 }
 
 .fl-chip {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: var(--space-3);
+    width: 100%;
+    min-height: 44px;
     padding: var(--space-3) var(--space-4);
     background: var(--bg-surface);
     border: 1px solid var(--border);


### PR DESCRIPTION
Four small, independent UI/UX polish items from the gathering-planner walkthrough (notes 1, 2, 3, 9). Template/CSS/JS only — no engine, pipeline, migration, or handler changes.

## Items
1. **Empty-state create-from-schematic door.** The empty state's lone "Create Project" button is replaced with two doors reusing the *exact* `.np-menu__door` markup/classes from the populated state's `NewProjectMenu` — "From a schematic" (opens the existing schematic modal) and "Blank project". Reuse (not approximation) guarantees the two states match.
2. **Empty/pending project row presence.** `.fl-chip` goes full-width stacked with `space-between` and a 44px min tap-target, so pending/paused projects read as rows, not pills. Pure CSS.
3. **Upload feedback.** Added an `.htmx-indicator` utility + `.modal__progress` spinner, wired `hxIndicator` into both schematic-upload forms (create-from-schematic and replace-resources). Template + CSS only.
4. **Drill scroll restoration.** `data-drill-nav="in"` on the drill trigger; `plan-view.js` captures `scrollY` to per-project `sessionStorage` on drill-in and restores it on the next `#project-content` settle back on a non-drill view. Idempotent init, graceful storage-unavailable fallback. Plain JS (no hyperscript exists in this codebase).

## Tests
Template-only tier: `mvn clean compile` clean; 667 unit tests pass; `GetProjectListIT` 10/10 (empty-state assertions intact). No new tests required. Note: surfaced a **pre-existing** unrelated failure (`CreateProjectFromSchematicIT` resource-count 15 vs 13) — confirmed red on baseline via `git stash`, out of scope here.

**Reviewing the visuals:** add the `preview` label to get an ephemeral Fly deploy — the four items (doors, row presence, upload spinner, scroll restore) are best eyeballed, and the JS behavior isn't covered by the test suite.

Closes MCO-244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)