### PR TITLE
MCO-247: Ignore/exclude blocks from a material list (+ close IDOR across the world subtree)

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ResourceGatheringItem.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ResourceGatheringItem.kt
@@ -9,4 +9,5 @@ data class ResourceGatheringItem(
     val collected: Int,
     val solvedByProject: Pair<Int, String>? = null,
     val sourceType: String? = null,
+    val ignored: Boolean = false,
 )

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/resources/AddResourcesFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/resources/AddResourcesFromSchematicPipeline.kt
@@ -47,7 +47,10 @@ suspend fun ApplicationCall.handleAddResourcesFromSchematic() {
         onSuccess = { resources ->
             respondHtml(
                 planResourceTableFragment(worldId, projectId, resources) +
-                    createHTML().div { hxOutOfBands("delete:#plan-empty-state") }
+                    createHTML().div { hxOutOfBands("delete:#plan-empty-state") } +
+                    // A schematic replace deletes every resource_gathering row (MCO-247: including
+                    // any previously ignored ones), so drop a stale ignored section from the DOM.
+                    createHTML().div { hxOutOfBands("delete:#plan-ignored-section") }
             )
         }
     ) {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStep.kt
@@ -36,11 +36,13 @@ data class GatheringPlanInput(
  * 1. Load the world's Minecraft version string.
  * 2. Obtain the cached [ItemSourceGraph] for that version.
  * 3. Load all resource_gathering rows for the project.
- * 4. Build [PlanTarget]s: amount = max(0, required − collected); skip fully-collected rows.
- * 5. Build the [SupplySource] map: rows linked to another project become
+ * 4. Exclude rows marked `ignored` (MCO-247) — kept in storage for reversibility, but
+ *    excluded from the derivation input so shared intermediates recompute without them.
+ * 5. Build [PlanTarget]s: amount = max(0, required − collected); skip fully-collected rows.
+ * 6. Build the [SupplySource] map: rows linked to another project become
  *    [SupplySource.LinkedProject] terminals.
- * 6. Load persisted [PlanOverrides] for the project.
- * 7. Run [GatheringPlanner.plan] and return the result.
+ * 7. Load persisted [PlanOverrides] for the project.
+ * 8. Run [GatheringPlanner.plan] and return the result.
  *
  * Fails with:
  * - [AppFailure.DatabaseError.NotFound] when the world or its version graph is not found.
@@ -76,8 +78,13 @@ object GenerateGatheringPlanStep : Step<GatheringPlanInput, AppFailure, Gatherin
                 is Result.Failure -> return r
             }
 
-        // 4. Build targets — net of collected; skip fully-collected items
-        val targets: List<PlanTarget> = items.mapNotNull { item ->
+        // 4. Exclude ignored rows (MCO-247) before deriving targets/supply — an ignored
+        // row stays in resource_gathering (reversible) but must not feed the plan, so its
+        // share of any shared intermediates recomputes as if it were never a target.
+        val activeItems = items.filterNot { it.ignored }
+
+        // 5. Build targets — net of collected; skip fully-collected items
+        val targets: List<PlanTarget> = activeItems.mapNotNull { item ->
             val net = (item.required - item.collected).toLong()
             if (net <= 0) null
             else PlanTarget(Item(item.itemId, item.name), net)
@@ -92,21 +99,21 @@ object GenerateGatheringPlanStep : Step<GatheringPlanInput, AppFailure, Gatherin
             )
         }
 
-        // 5. Build supplied map: rows linked to another project become supply terminals
-        val supplied: Map<String, SupplySource> = items
+        // 6. Build supplied map: rows linked to another project become supply terminals
+        val supplied: Map<String, SupplySource> = activeItems
             .mapNotNull { item ->
                 val (solvedId, solvedName) = item.solvedByProject ?: return@mapNotNull null
                 item.itemId to SupplySource.LinkedProject(solvedId, solvedName)
             }
             .toMap()
 
-        // 6. Load persisted overrides for this project
+        // 7. Load persisted overrides for this project
         val overrides: PlanOverrides = when (val r = GetPlanOverridesStep.process(input.projectId)) {
             is Result.Success -> r.value
             is Result.Failure -> return r
         }
 
-        // 7. Run the engine
+        // 8. Run the engine
         return Result.success(GatheringPlanner.plan(graph, targets, supplied, overrides))
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/ToggleResourceGatheringIgnoredPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/ToggleResourceGatheringIgnoredPipeline.kt
@@ -1,0 +1,48 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
+import app.mcorg.presentation.handler.handlePipeline
+import app.mcorg.presentation.templated.dsl.pages.planResourcesAreaFragment
+import app.mcorg.presentation.utils.getProjectId
+import app.mcorg.presentation.utils.getResourceGatheringId
+import app.mcorg.presentation.utils.getWorldId
+import app.mcorg.presentation.utils.respondHtml
+import io.ktor.server.application.ApplicationCall
+
+/**
+ * MCO-247: toggles a resource_gathering row's `ignored` flag. Ignoring keeps the row
+ * (reversible — the same endpoint un-ignores it) but excludes it from the derived
+ * gathering plan (see [GenerateGatheringPlanStep]), so its share of any shared
+ * intermediates recomputes without it.
+ *
+ * Responds with the whole `#plan-resources-area` fragment (active table + ignored
+ * section) since a toggle moves the row between the two.
+ */
+suspend fun ApplicationCall.handleToggleResourceGatheringIgnored() {
+    val worldId = this.getWorldId()
+    val projectId = this.getProjectId()
+    val resourceGatheringId = this.getResourceGatheringId()
+
+    handlePipeline(
+        onSuccess = { resources ->
+            respondHtml(planResourcesAreaFragment(worldId, projectId, resources))
+        }
+    ) {
+        ToggleResourceGatheringIgnoredStep.run(resourceGatheringId)
+        GetAllResourceGatheringItemsStep.run(projectId)
+    }
+}
+
+private object ToggleResourceGatheringIgnoredStep : Step<Int, AppFailure.DatabaseError, Unit> {
+    override suspend fun process(input: Int): Result<AppFailure.DatabaseError, Unit> {
+        return DatabaseSteps.update<Int>(
+            sql = SafeSQL.update("UPDATE resource_gathering SET ignored = NOT ignored WHERE id = ?"),
+            parameterSetter = { statement, id -> statement.setInt(1, id) }
+        ).process(input).map { }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetAllResourceGatheringItemsStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetAllResourceGatheringItemsStep.kt
@@ -10,7 +10,7 @@ val GetAllResourceGatheringItemsStep = DatabaseSteps.query<Int, List<ResourceGat
         """
         SELECT rg.id, rg.project_id, rg.item_id, rg.name, rg.required,
                COALESCE(rgp.collected, 0) AS collected,
-               rg.source_type,
+               rg.source_type, rg.ignored,
                p.id AS solved_project_id, p.name AS solved_project_name
         FROM resource_gathering rg
         LEFT JOIN resource_gathering_progress rgp

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetResourceGatheringItemStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetResourceGatheringItemStep.kt
@@ -10,7 +10,7 @@ val GetResourceGatheringItemStep = DatabaseSteps.query<Int, ResourceGatheringIte
         """
         SELECT rg.id, rg.project_id, rg.item_id, rg.name, rg.required,
                COALESCE(rgp.collected, 0) AS collected,
-               rg.source_type,
+               rg.source_type, rg.ignored,
                p.id AS solved_project_id, p.name AS solved_project_name
         FROM resource_gathering rg
         LEFT JOIN resource_gathering_progress rgp

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/extractors/ResourceGatheringItemExtractors.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/extractors/ResourceGatheringItemExtractors.kt
@@ -29,5 +29,6 @@ fun ResultSet.toResourceGatheringItem(): ResourceGatheringItem {
         collected = getInt("collected"),
         solvedByProject = solvedByProject,
         sourceType = sourceType,
+        ignored = getBoolean("ignored"),
     )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -64,6 +64,7 @@ import app.mcorg.presentation.plugins.WorldAdminPlugin
 import app.mcorg.presentation.plugins.WorldMemberParamPlugin
 import app.mcorg.presentation.plugins.WorldOwnerPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.presentation.templated.dsl.pages.worldListPage
 import app.mcorg.presentation.utils.getUser
 import app.mcorg.presentation.utils.respondHtml
@@ -143,6 +144,12 @@ class WorldHandler {
                             call.handleGetFieldLogSliceItems()
                         }
                         route("/resources") {
+                            // World-membership gate (MCO-247): ParamPlugins above only check
+                            // world/project *existence*, not that the caller belongs to the
+                            // world — closing that IDOR gap for the whole resource-mutation
+                            // family (schematic upload, gathering create, and every
+                            // /{resourceGatheringId} mutation below, incl. ignore).
+                            install(WorldParticipantPlugin)
                             post("/from-schematic") {
                                 call.handleAddResourcesFromSchematic()
                             }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -20,6 +20,7 @@ import app.mcorg.pipeline.resources.handleCreateResourceGatheringItem
 import app.mcorg.pipeline.resources.handleDeleteResourceGatheringItem
 import app.mcorg.pipeline.resources.handleGetResourceDetailPanel
 import app.mcorg.pipeline.resources.handleSetResourceSource
+import app.mcorg.pipeline.resources.handleToggleResourceGatheringIgnored
 import app.mcorg.pipeline.resources.handleUpdateResourceRequiredAmount
 import app.mcorg.pipeline.resources.handleSetCollectedValue
 import app.mcorg.pipeline.resources.handleUpdateRequirementProgress
@@ -156,6 +157,9 @@ class WorldHandler {
                                     }
                                     patch("/required") {
                                         call.handleUpdateResourceRequiredAmount()
+                                    }
+                                    patch("/ignore") {
+                                        call.handleToggleResourceGatheringIgnored()
                                     }
                                     put("/collected") {
                                         call.handleSetCollectedValue()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -94,6 +94,14 @@ class WorldHandler {
             }
             route("/{worldId}") {
                 install(WorldParamPlugin)
+                // World-membership gate (MCO-247): WorldParamPlugin above only checks the
+                // world *exists*, not that the caller belongs to it — closing that IDOR gap
+                // for the entire /{worldId} subtree (projects, resources, tasks, plan, meta,
+                // field-log, view-preference). Must run before UpdateActiveWorldPlugin so a
+                // non-member's session never gets its activeWorldId cookie pointed at a world
+                // they can't access. /settings below is already WorldAdmin/Owner-gated; this
+                // member check is just a harmless, correct precondition for it too.
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 get {
                     val worldId = call.parameters["worldId"]!!.toInt()
@@ -144,12 +152,8 @@ class WorldHandler {
                             call.handleGetFieldLogSliceItems()
                         }
                         route("/resources") {
-                            // World-membership gate (MCO-247): ParamPlugins above only check
-                            // world/project *existence*, not that the caller belongs to the
-                            // world — closing that IDOR gap for the whole resource-mutation
-                            // family (schematic upload, gathering create, and every
-                            // /{resourceGatheringId} mutation below, incl. ignore).
-                            install(WorldParticipantPlugin)
+                            // World-membership gate (MCO-247) now lives at the /{worldId}
+                            // level above, covering this whole resource-mutation family too.
                             post("/from-schematic") {
                                 call.handleAddResourcesFromSchematic()
                             }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/plugins/RolePlugins.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/plugins/RolePlugins.kt
@@ -44,6 +44,26 @@ val WorldAdminPlugin = createRouteScopedPlugin("WorldAdminPlugin") {
     }
 }
 
+/**
+ * Verifies the authenticated user is a member of the path world — ANY role (owner, admin,
+ * or plain member), just not banned from it. `Role.MEMBER` is the lowest non-banned role
+ * level, so `world_role <= MEMBER.level` in [ValidateWorldMemberRole] admits every
+ * membership row and rejects both non-members and banned members. Use this to close IDOR
+ * gaps on routes that only need "is a participant in this world", not a specific privilege
+ * tier (compare [WorldAdminPlugin] / [WorldOwnerPlugin] for elevated-role gates).
+ */
+val WorldParticipantPlugin = createRouteScopedPlugin("WorldParticipantPlugin") {
+    onCall {
+        val user = it.getUser()
+        val worldId = it.getWorldId()
+
+        val result = ValidateWorldMemberRole<Unit>(user, Role.MEMBER, worldId).process(Unit)
+        if (result is Result.Failure && result.error is AppFailure.AuthError.NotAuthorized) {
+            it.respond(HttpStatusCode.Forbidden, "You don't have permission to access this world.")
+        }
+    }
+}
+
 val WorldOwnerPlugin = createRouteScopedPlugin("WorldOwnerPlugin") {
     onCall {
         val user = it.getUser()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -348,11 +348,11 @@ private fun FlowContent.listLensContent(
                 }
             }
 
-            // Resource table — always rendered as HTMX swap target
-            planResourceTable(project.worldId, project.id, resources)
+            // Resource table + ignored section — always rendered as HTMX swap target
+            planResourcesArea(project.worldId, project.id, resources)
 
             // Schematic upload modal
-            resourceSchematicModal(project.worldId, project.id, resources.filter { it.required > 0 }.size)
+            resourceSchematicModal(project.worldId, project.id, resources.count { it.required > 0 && !it.ignored })
         }
     }
 
@@ -753,12 +753,51 @@ fun TR.planResourceRow(worldId: Int, projectId: Int, item: ResourceGatheringItem
         }
     }
     td("plan-resource-table__action") {
-        button(classes = "btn btn--ghost btn--sm plan-resource-table__delete-btn") {
+        div("plan-resource-table__action-group") {
+            button(classes = "btn btn--ghost btn--sm plan-resource-table__ignore-btn") {
+                type = ButtonType.button
+                attributes["title"] = "Ignore — exclude from the material list and gathering plan"
+                attributes["aria-label"] = "Ignore ${item.name}"
+                hxPatch("/worlds/$worldId/projects/$projectId/resources/gathering/${item.id}/ignore")
+                hxTarget("#plan-resources-area")
+                hxSwap("outerHTML")
+                +"⊘"
+            }
+            button(classes = "btn btn--ghost btn--sm plan-resource-table__delete-btn") {
+                type = ButtonType.button
+                hxDelete("/worlds/$worldId/projects/$projectId/resources/gathering/${item.id}?context=plan")
+                hxTarget("#plan-row-${item.id}")
+                hxSwap("outerHTML")
+                +"×"
+            }
+        }
+    }
+}
+
+/** Un-ignore action row: shown in the ignored section (MCO-247), reverses the ignore toggle. */
+fun TR.ignoredResourceRow(worldId: Int, projectId: Int, item: ResourceGatheringItem) {
+    id = "plan-ignored-row-${item.id}"
+    attributes["data-resource-id"] = item.id.toString()
+
+    td("plan-resource-table__status") {
+        span("status-dot status-dot--unset") {}
+    }
+    td("plan-resource-table__item") {
+        +item.name
+    }
+    td("plan-resource-table__qty") {
+        span("plan-resource-table__qty-display") {
+            +item.required.toString()
+        }
+    }
+    td("plan-resource-table__action") {
+        button(classes = "btn btn--ghost btn--sm plan-resource-table__unignore-btn") {
             type = ButtonType.button
-            hxDelete("/worlds/$worldId/projects/$projectId/resources/gathering/${item.id}?context=plan")
-            hxTarget("#plan-row-${item.id}")
+            attributes["title"] = "Un-ignore — include back in the material list and gathering plan"
+            hxPatch("/worlds/$worldId/projects/$projectId/resources/gathering/${item.id}/ignore")
+            hxTarget("#plan-resources-area")
             hxSwap("outerHTML")
-            +"×"
+            +"Un-ignore"
         }
     }
 }
@@ -768,7 +807,7 @@ fun TR.planResourceRow(worldId: Int, projectId: Int, item: ResourceGatheringItem
  * the schematic-upload flow (`outerHTML` swap of `#plan-resource-table`).
  */
 fun FlowContent.planResourceTable(worldId: Int, projectId: Int, resources: List<ResourceGatheringItem>) {
-    val filteredResources = resources.filter { it.required > 0 }
+    val filteredResources = resources.filter { it.required > 0 && !it.ignored }
     table("data-table plan-resource-table") {
         id = "plan-resource-table"
         if (filteredResources.isNotEmpty()) {
@@ -796,7 +835,7 @@ fun FlowContent.planResourceTable(worldId: Int, projectId: Int, resources: List<
 fun planResourceTableFragment(worldId: Int, projectId: Int, resources: List<ResourceGatheringItem>): String =
     createHTML().table("data-table plan-resource-table") {
         id = "plan-resource-table"
-        val filteredResources = resources.filter { it.required > 0 }
+        val filteredResources = resources.filter { it.required > 0 && !it.ignored }
         if (filteredResources.isNotEmpty()) {
             thead {
                 tr {
@@ -816,6 +855,55 @@ fun planResourceTableFragment(worldId: Int, projectId: Int, resources: List<Reso
             }
         }
     }
+
+/**
+ * Wraps the active resource table and the ignored-items section (MCO-247) in a single
+ * HTMX swap target — an ignore/un-ignore toggle moves a row between the two, so both
+ * are re-rendered together.
+ */
+fun FlowContent.planResourcesArea(worldId: Int, projectId: Int, resources: List<ResourceGatheringItem>) {
+    div {
+        id = "plan-resources-area"
+        planResourceTable(worldId, projectId, resources)
+        ignoredResourcesSection(worldId, projectId, resources)
+    }
+}
+
+/** Standalone HTML fragment version of [planResourcesArea] (HTMX swap response for the ignore toggle). */
+fun planResourcesAreaFragment(worldId: Int, projectId: Int, resources: List<ResourceGatheringItem>): String =
+    createHTML().div {
+        id = "plan-resources-area"
+        planResourceTable(worldId, projectId, resources)
+        ignoredResourcesSection(worldId, projectId, resources)
+    }
+
+/**
+ * Ignored-items section (MCO-247): items the user excluded from the material list and
+ * gathering plan, kept visible and reversible via an "Un-ignore" action. Renders nothing
+ * when there are no ignored items, so it doesn't clutter the page for the common case.
+ */
+fun FlowContent.ignoredResourcesSection(worldId: Int, projectId: Int, resources: List<ResourceGatheringItem>) {
+    val ignoredResources = resources.filter { it.ignored }
+    if (ignoredResources.isEmpty()) return
+
+    div("project-detail__section plan-ignored-section") {
+        id = "plan-ignored-section"
+        div("project-detail__section-header") {
+            span("project-detail__section-title section-label") { +"Ignored (${ignoredResources.size})" }
+        }
+        table("data-table plan-resource-table plan-resource-table--ignored") {
+            id = "plan-ignored-table"
+            tbody {
+                id = "plan-ignored-table-body"
+                ignoredResources.forEach { item ->
+                    tr {
+                        ignoredResourceRow(worldId, projectId, item)
+                    }
+                }
+            }
+        }
+    }
+}
 
 /**
  * Modal that uploads a Litematica file and replaces the project's resource list with the

--- a/webapp/mc-web/src/main/resources/db/migration/V2_46_0__add_ignored_to_resource_gathering.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_46_0__add_ignored_to_resource_gathering.sql
@@ -1,0 +1,5 @@
+-- MCO-247: let users ignore/exclude an imported build's material from the
+-- "What I need" list and the derived gathering plan, without deleting it.
+-- The row is kept (reversible) but is filtered out of plan derivation input.
+ALTER TABLE resource_gathering
+    ADD COLUMN ignored BOOLEAN NOT NULL DEFAULT FALSE;

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
@@ -309,7 +309,13 @@
 }
 
 .plan-resource-table__col-action {
-    width: 40px;
+    width: 72px;
+}
+
+.plan-resource-table__action-group {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
 }
 
 /* Status dot */
@@ -372,6 +378,35 @@
 .plan-resource-table__delete-btn:hover {
     color: var(--red);
     background: var(--red-bg);
+}
+
+/* Ignore / un-ignore buttons (MCO-247) */
+.plan-resource-table__ignore-btn {
+    color: var(--text-muted);
+    border: none;
+    background: none;
+    cursor: pointer;
+    padding: var(--space-1) var(--space-2);
+    font-size: var(--text-sm);
+    border-radius: var(--radius);
+}
+
+.plan-resource-table__ignore-btn:hover {
+    color: var(--accent);
+    background: var(--accent-muted);
+}
+
+.plan-resource-table__unignore-btn {
+    font-size: var(--text-xs);
+}
+
+/* Ignored resources section (MCO-247) */
+.plan-ignored-section {
+    margin-top: var(--space-4);
+}
+
+.plan-resource-table--ignored .plan-resource-table__item {
+    color: var(--text-muted);
 }
 
 /* Add resource form */

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStepTest.kt
@@ -48,6 +48,7 @@ class GenerateGatheringPlanStepTest : WithUser() {
     private val oakPlanks = Item("minecraft:oak_planks", "Oak Planks")
     private val birchPlanks = Item("minecraft:birch_planks", "Birch Planks")
     private val chest = Item("minecraft:chest", "Chest")
+    private val door = Item("minecraft:oak_door", "Oak Door")
     private val planksTag = MinecraftTag("#minecraft:planks", "Planks", listOf(oakPlanks, birchPlanks))
 
     private var worldId: Int = 0
@@ -59,7 +60,7 @@ class GenerateGatheringPlanStepTest : WithUser() {
         // Store a small but realistic graph for version 1.99.0 (test-only)
         val serverData = ServerData(
             version = version,
-            items = listOf(log, oakPlanks, birchPlanks, chest, planksTag),
+            items = listOf(log, oakPlanks, birchPlanks, chest, door, planksTag),
             sources = listOf(
                 ResourceSource(
                     type = ResourceSource.SourceType.LootTypes.BLOCK,
@@ -77,6 +78,14 @@ class GenerateGatheringPlanStepTest : WithUser() {
                     filename = "chest.json",
                     requiredItems = listOf(planksTag to ResourceQuantity.ItemQuantity(8)),
                     producedItems = listOf(chest to ResourceQuantity.ItemQuantity(1))
+                ),
+                // Second consumer of the shared #minecraft:planks tag, used to prove an
+                // ignored target's share of the shared intermediate recomputes (MCO-247).
+                ResourceSource(
+                    type = ResourceSource.SourceType.RecipeTypes.CRAFTING_SHAPED,
+                    filename = "oak_door.json",
+                    requiredItems = listOf(planksTag to ResourceQuantity.ItemQuantity(6)),
+                    producedItems = listOf(door to ResourceQuantity.ItemQuantity(3))
                 )
             )
         )
@@ -216,6 +225,86 @@ class GenerateGatheringPlanStepTest : WithUser() {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
+    // MCO-247: ignored targets drop out of the derived plan, and a shared
+    // intermediate's quantity recomputes without them (reversible via un-ignore).
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `ignored target is excluded from the derived plan`() {
+        val projectId = createProject(worldId)
+        val rgId = insertGatheringItem(projectId, chest.id, chest.name, required = 4)
+
+        // Baseline: chest is a target in the derived plan.
+        val before = runBlocking {
+            GenerateGatheringPlanStep.process(GatheringPlanInput(projectId, worldId))
+        }
+        assertIs<Result.Success<*>>(before)
+        assertNotNull((before as Result.Success).value.nodes[chest.id], "chest must be a target before ignoring")
+
+        // Ignore the row — it must be excluded from the derivation input entirely.
+        setIgnored(rgId, ignored = true)
+        val afterIgnore = runBlocking {
+            GenerateGatheringPlanStep.process(GatheringPlanInput(projectId, worldId))
+        }
+        // No other (non-ignored) targets remain, so derivation fails with ValidationError —
+        // exactly like "all items fully collected": nothing left to plan.
+        assertIs<Result.Failure<*>>(afterIgnore)
+        assertTrue(
+            (afterIgnore as Result.Failure).error is app.mcorg.pipeline.failure.AppFailure.ValidationError,
+            "Expected ValidationError once the only target is ignored"
+        )
+
+        // Un-ignore — the target (and its dependency chain) is restored.
+        setIgnored(rgId, ignored = false)
+        val afterUnignore = runBlocking {
+            GenerateGatheringPlanStep.process(GatheringPlanInput(projectId, worldId))
+        }
+        assertIs<Result.Success<*>>(afterUnignore)
+        val restoredChestNode = (afterUnignore as Result.Success).value.nodes[chest.id]
+        assertNotNull(restoredChestNode, "chest must be restored as a target after un-ignoring")
+        assertEquals(4L, restoredChestNode.quantity)
+    }
+
+    @Test
+    fun `ignoring one of two targets recomputes their shared intermediate's quantity`() {
+        val projectId = createProject(worldId)
+        insertGatheringItem(projectId, chest.id, chest.name, required = 4)
+        val doorRgId = insertGatheringItem(projectId, door.id, door.name, required = 3)
+
+        // Baseline: both chest (32 planks) and door (6 planks) feed the shared #minecraft:planks tag.
+        val before = runBlocking {
+            GenerateGatheringPlanStep.process(GatheringPlanInput(projectId, worldId))
+        }
+        assertIs<Result.Success<*>>(before)
+        val planksBefore = (before as Result.Success).value.nodes[planksTag.id]
+        assertNotNull(planksBefore, "#minecraft:planks must be in the plan")
+        assertEquals(38L, planksBefore.quantity, "32 (chest) + 6 (door) planks expected before ignoring")
+
+        // Ignore the door target — its share of the shared planks tag must disappear.
+        setIgnored(doorRgId, ignored = true)
+        val afterIgnore = runBlocking {
+            GenerateGatheringPlanStep.process(GatheringPlanInput(projectId, worldId))
+        }
+        assertIs<Result.Success<*>>(afterIgnore)
+        val planIgnored = (afterIgnore as Result.Success).value
+        assertNotNull(planIgnored.nodes[chest.id], "chest must still be a target")
+        assertEquals(null, planIgnored.nodes[door.id], "door must be excluded from the plan while ignored")
+        val planksAfterIgnore = planIgnored.nodes[planksTag.id]
+        assertNotNull(planksAfterIgnore, "#minecraft:planks must still be in the plan (chest still needs it)")
+        assertEquals(32L, planksAfterIgnore.quantity, "only chest's 32 planks remain once door is ignored")
+
+        // Un-ignore — the door's share of the shared intermediate is restored.
+        setIgnored(doorRgId, ignored = false)
+        val afterUnignore = runBlocking {
+            GenerateGatheringPlanStep.process(GatheringPlanInput(projectId, worldId))
+        }
+        assertIs<Result.Success<*>>(afterUnignore)
+        val planksRestored = (afterUnignore as Result.Success).value.nodes[planksTag.id]
+        assertNotNull(planksRestored)
+        assertEquals(38L, planksRestored.quantity, "planks quantity restored once door is un-ignored")
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // Fixture helpers
     // ─────────────────────────────────────────────────────────────────────────
 
@@ -266,6 +355,18 @@ class GenerateGatheringPlanStepTest : WithUser() {
     private fun setProgress(resourceGatheringId: Int, collected: Int) {
         runBlocking {
             UpsertProgressStep.process(UpsertProgressByRgIdInput(resourceGatheringId, collected))
+        }
+    }
+
+    private fun setIgnored(resourceGatheringId: Int, ignored: Boolean) {
+        runBlocking {
+            DatabaseSteps.update<Unit>(
+                sql = SafeSQL.update("UPDATE resource_gathering SET ignored = ? WHERE id = ?"),
+                parameterSetter = { stmt, _ ->
+                    stmt.setBoolean(1, ignored)
+                    stmt.setInt(2, resourceGatheringId)
+                }
+            ).process(Unit)
         }
     }
 

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/AcceptInvitationIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/AcceptInvitationIT.kt
@@ -1,0 +1,114 @@
+package app.mcorg.presentation.handler
+
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.invitation.handleAcceptInvitation
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.InviteParamPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.patch
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.patch
+import io.ktor.server.routing.route
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+
+/**
+ * MCO-247: the world-membership gate (`WorldParticipantPlugin`) was hoisted to the whole
+ * `/{worldId}` subtree in `WorldHandler`. Invite acceptance is intentionally routed
+ * *outside* that subtree — at `/invites/{inviteId}/accept` in `InviteHandler` — precisely
+ * so a non-member (the invitee) can still join. This test proves the hoist didn't
+ * accidentally break that join flow.
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class AcceptInvitationIT : WithUser() {
+
+    @Test
+    fun `an invitee who is not yet a world member can accept their invite`() = testApplication {
+        val worldId = createWorld()
+        val invitee = createExtraUser()
+        val inviteId = createPendingInvite(worldId, fromUserId = user.id, toUserId = invitee.id)
+
+        installRoutes()
+
+        val response = client.patch("/invites/$inviteId/accept") {
+            addAuthCookie(this, invitee)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(1, memberCount(worldId, invitee.id), "invitee must now be a world member")
+        assertEquals("ACCEPTED", inviteStatus(inviteId))
+    }
+
+    private fun io.ktor.server.testing.ApplicationTestBuilder.installRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/invites/{inviteId}") {
+                install(InviteParamPlugin)
+                patch("/accept") { call.handleAcceptInvitation() }
+            }
+        }
+    }
+
+    private fun createWorld(): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(
+                name = "AcceptInvitation IT World",
+                description = "test",
+                version = MinecraftVersion.fromString("1.21.4")
+            )
+        )
+        (result as Result.Success).value
+    }
+
+    private fun createPendingInvite(worldId: Int, fromUserId: Int, toUserId: Int): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                """
+                INSERT INTO invites (world_id, from_user_id, to_user_id, role, created_at, status, status_reached_at)
+                VALUES (?, ?, ?, 'MEMBER', CURRENT_TIMESTAMP, 'PENDING', CURRENT_TIMESTAMP)
+                RETURNING id
+                """.trimIndent()
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, worldId)
+                stmt.setInt(2, fromUserId)
+                stmt.setInt(3, toUserId)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun memberCount(worldId: Int, userId: Int): Int = runBlocking {
+        val result = DatabaseSteps.query<Unit, Int>(
+            sql = SafeSQL.select("SELECT COUNT(*) AS c FROM world_members WHERE world_id = ? AND user_id = ?"),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, worldId)
+                stmt.setInt(2, userId)
+            },
+            resultMapper = { rs -> rs.next(); rs.getInt("c") }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun inviteStatus(inviteId: Int): String = runBlocking {
+        val result = DatabaseSteps.query<Unit, String>(
+            sql = SafeSQL.select("SELECT status FROM invites WHERE id = ?"),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, inviteId) },
+            resultMapper = { rs -> rs.next(); rs.getString("status") }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/AddResourcesFromSchematicIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/AddResourcesFromSchematicIT.kt
@@ -13,6 +13,7 @@ import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.ProjectParamPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.forms.MultiPartFormDataContent
@@ -172,7 +173,10 @@ class AddResourcesFromSchematicIT : WithUser() {
                 install(UpdateActiveWorldPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)
-                    post("/resources/from-schematic") { call.handleAddResourcesFromSchematic() }
+                    route("/resources") {
+                        install(WorldParticipantPlugin)
+                        post("/from-schematic") { call.handleAddResourcesFromSchematic() }
+                    }
                 }
             }
         }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/AddResourcesFromSchematicIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/AddResourcesFromSchematicIT.kt
@@ -170,11 +170,11 @@ class AddResourcesFromSchematicIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)
                     route("/resources") {
-                        install(WorldParticipantPlugin)
                         post("/from-schematic") { call.handleAddResourcesFromSchematic() }
                     }
                 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/CreateProjectFromSchematicIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/CreateProjectFromSchematicIT.kt
@@ -11,6 +11,7 @@ import app.mcorg.pipeline.world.CreateWorldStep
 import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.forms.MultiPartFormDataContent
@@ -161,6 +162,7 @@ class CreateProjectFromSchematicIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     post("/from-schematic") { call.handleCreateProjectFromSchematic() }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FieldLogSliceIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FieldLogSliceIT.kt
@@ -12,6 +12,7 @@ import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.ProjectParamPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.get
@@ -128,11 +129,24 @@ class FieldLogSliceIT : WithUser() {
         assertEquals(HttpStatusCode.Found, response.status)
     }
 
+    @Test
+    fun `non-member of the world is rejected with 403`() = testApplication {
+        setupRoutes()
+        val nonMember = createExtraUser()
+
+        val response = client.get("/worlds/$worldId/projects/$blockedId/field-log-row?expanded=true") {
+            addAuthCookie(this, nonMember)
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
     private fun ApplicationTestBuilder.setupRoutes() {
         routing {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/GatheringPlannerIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/GatheringPlannerIT.kt
@@ -13,6 +13,7 @@ import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.ProjectParamPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.get
@@ -90,6 +91,20 @@ class GatheringPlannerIT : WithUser() {
         assertEquals(HttpStatusCode.OK, response.status)
         val body = response.bodyAsText()
         assertContains(body, "plan-resource-table")
+    }
+
+    @Test
+    fun `GET detail-content by a non-member of the world returns 403`() = testApplication {
+        setupRoutes()
+        val nonMember = createExtraUser()
+
+        val response = client.get(
+            "/worlds/$worldId/projects/$projectId/detail-content?lens=list"
+        ) {
+            addAuthCookie(this, nonMember)
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
     }
 
     @Test
@@ -346,6 +361,22 @@ class GatheringPlannerIT : WithUser() {
         assertEquals(HttpStatusCode.Found, response.status)
     }
 
+    @Test
+    fun `PATCH plan progress by a non-member of the world returns 403`() = testApplication {
+        setupRoutesWithProgress()
+        val nonMember = createExtraUser()
+
+        val response = client.patch(
+            "/worlds/$worldId/projects/$projectId/plan/progress"
+        ) {
+            addAuthCookie(this, nonMember)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("itemId=minecraft:iron_ingot&amount=1&required=64")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
     // -------------------------------------------------------------------------
     // Fix 1 — derived activity progress persists and row reflects it
     // -------------------------------------------------------------------------
@@ -416,6 +447,7 @@ class GatheringPlannerIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)
@@ -431,6 +463,7 @@ class GatheringPlannerIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/GetProjectListFragmentIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/GetProjectListFragmentIT.kt
@@ -10,6 +10,7 @@ import app.mcorg.pipeline.world.CreateWorldStep
 import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.get
@@ -65,6 +66,7 @@ class GetProjectListFragmentIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get("/list-fragment") {
@@ -94,6 +96,7 @@ class GetProjectListFragmentIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get("/list-fragment") {
@@ -124,6 +127,7 @@ class GetProjectListFragmentIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get("/list-fragment") {
@@ -153,6 +157,7 @@ class GetProjectListFragmentIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get("/list-fragment") {
@@ -180,6 +185,7 @@ class GetProjectListFragmentIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get("/list-fragment") {
@@ -192,5 +198,32 @@ class GetProjectListFragmentIT : WithUser() {
         val response = client.get("/worlds/$worldId/projects/list-fragment")
 
         assertEquals(HttpStatusCode.Found, response.status)
+    }
+
+    @Test
+    fun `non-member of the world is rejected with 403`() = testApplication {
+        val worldId = createWorld("Fragment IT Non-member World")
+        createProject(worldId, "Non-member Fragment Project")
+        val nonMember = createExtraUser()
+
+        routing {
+            install(AuthPlugin)
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
+                install(UpdateActiveWorldPlugin)
+                route("/projects") {
+                    get("/list-fragment") {
+                        call.handleGetProjectListFragment()
+                    }
+                }
+            }
+        }
+
+        val response = client.get("/worlds/$worldId/projects/list-fragment") {
+            addAuthCookie(this, nonMember)
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
     }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/GetProjectListIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/GetProjectListIT.kt
@@ -11,6 +11,7 @@ import app.mcorg.pipeline.world.CreateWorldStep
 import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.get
@@ -51,6 +52,7 @@ class GetProjectListIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get { call.handleGetProjectList() }
@@ -78,6 +80,7 @@ class GetProjectListIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get { call.handleGetProjectList() }
@@ -104,6 +107,7 @@ class GetProjectListIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get { call.handleGetProjectList() }
@@ -132,6 +136,7 @@ class GetProjectListIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get { call.handleGetProjectList() }
@@ -158,6 +163,7 @@ class GetProjectListIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get { call.handleGetProjectList() }
@@ -184,6 +190,7 @@ class GetProjectListIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get { call.handleGetProjectList() }
@@ -218,6 +225,7 @@ class GetProjectListIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get { call.handleGetProjectList() }
@@ -251,6 +259,7 @@ class GetProjectListIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get { call.handleGetProjectList() }
@@ -281,6 +290,7 @@ class GetProjectListIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get { call.handleGetProjectList() }
@@ -307,6 +317,7 @@ class GetProjectListIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects") {
                     get("/resume-rows") { call.handleGetResumeRows() }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanChainIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanChainIT.kt
@@ -16,6 +16,7 @@ import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.ProjectParamPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.delete
@@ -488,6 +489,7 @@ class PlanChainIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanViewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanViewIT.kt
@@ -17,6 +17,7 @@ import app.mcorg.presentation.plugins.ProjectParamPlugin
 import app.mcorg.presentation.plugins.ResourceGatheringIdParamPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.get
@@ -212,6 +213,42 @@ class PlanViewIT : WithUser() {
     }
 
     // -------------------------------------------------------------------------
+    // Test 7: non-member (authenticated, but not a world_members row) is rejected
+    // by WorldParticipantPlugin — MCO-247 IDOR closure on the resource-mutation family.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `PATCH ignore by a non-member of the world returns 403`() = testApplication {
+        val rgId = createResourceGathering(projectId, required = 9)
+        setupRoutes()
+
+        val nonMember = createExtraUser()
+        val response = client.patch(
+            "/worlds/$worldId/projects/$projectId/resources/gathering/$rgId/ignore"
+        ) {
+            addAuthCookie(this, nonMember)
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    @Test
+    fun `PATCH required by a non-member of the world returns 403`() = testApplication {
+        setupRoutes()
+
+        val nonMember = createExtraUser()
+        val response = client.patch(
+            "/worlds/$worldId/projects/$projectId/resources/gathering/$resourceGatheringId/required"
+        ) {
+            addAuthCookie(this, nonMember)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("required=5")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    // -------------------------------------------------------------------------
     // Routing setup
     // -------------------------------------------------------------------------
 
@@ -226,6 +263,7 @@ class PlanViewIT : WithUser() {
                     get { call.handleGetProject() }
                     get("/detail-content") { call.handleGetDetailContent() }
                     route("/resources/gathering/{resourceGatheringId}") {
+                        install(WorldParticipantPlugin)
                         install(ResourceGatheringIdParamPlugin)
                         patch("/required") { call.handleUpdateResourceRequiredAmount() }
                         patch("/ignore") { call.handleToggleResourceGatheringIgnored() }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanViewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanViewIT.kt
@@ -8,6 +8,7 @@ import app.mcorg.pipeline.project.handleGetDetailContent
 import app.mcorg.pipeline.project.handleGetProject
 import app.mcorg.pipeline.resources.handleCreateResourceGatheringItem
 import app.mcorg.pipeline.resources.handleDeleteResourceGatheringItem
+import app.mcorg.pipeline.resources.handleToggleResourceGatheringIgnored
 import app.mcorg.pipeline.resources.handleUpdateResourceRequiredAmount
 import app.mcorg.pipeline.world.CreateWorldInput
 import app.mcorg.pipeline.world.CreateWorldStep
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 @Tag("database")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -152,6 +154,64 @@ class PlanViewIT : WithUser() {
     }
 
     // -------------------------------------------------------------------------
+    // Test 6: PATCH ignore — toggles the ignored flag and re-renders the resources area
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `PATCH ignore moves the target into the ignored section`() = testApplication {
+        val rgId = createResourceGathering(projectId, required = 15)
+        setupRoutes()
+
+        val response = client.patch(
+            "/worlds/$worldId/projects/$projectId/resources/gathering/$rgId/ignore"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertContains(body, "id=\"plan-resources-area\"")
+        // Ignored row appears in the ignored section, not the active table.
+        assertContains(body, "plan-ignored-row-$rgId")
+        assertContains(body, "Ignored (1)")
+        assertFalse(body.contains("plan-row-$rgId\""))
+    }
+
+    @Test
+    fun `PATCH ignore twice restores the target to the active table`() = testApplication {
+        val rgId = createResourceGathering(projectId, required = 12)
+        setupRoutes()
+
+        client.patch("/worlds/$worldId/projects/$projectId/resources/gathering/$rgId/ignore") {
+            addAuthCookie(this)
+        }
+        val response = client.patch(
+            "/worlds/$worldId/projects/$projectId/resources/gathering/$rgId/ignore"
+        ) {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        // Back in the active table, no longer in the ignored section.
+        assertContains(body, "plan-row-$rgId")
+        assertFalse(body.contains("plan-ignored-row-$rgId"))
+    }
+
+    @Test
+    fun `PATCH ignore without auth returns redirect`() = testApplication {
+        val rgId = createResourceGathering(projectId, required = 8)
+        setupRoutes()
+
+        val unauthClient = createClient { followRedirects = false }
+        val response = unauthClient.patch(
+            "/worlds/$worldId/projects/$projectId/resources/gathering/$rgId/ignore"
+        ) {}
+
+        assertEquals(HttpStatusCode.Found, response.status)
+    }
+
+    // -------------------------------------------------------------------------
     // Routing setup
     // -------------------------------------------------------------------------
 
@@ -168,6 +228,7 @@ class PlanViewIT : WithUser() {
                     route("/resources/gathering/{resourceGatheringId}") {
                         install(ResourceGatheringIdParamPlugin)
                         patch("/required") { call.handleUpdateResourceRequiredAmount() }
+                        patch("/ignore") { call.handleToggleResourceGatheringIgnored() }
                     }
                 }
             }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanViewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/PlanViewIT.kt
@@ -257,13 +257,13 @@ class PlanViewIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)
                     get { call.handleGetProject() }
                     get("/detail-content") { call.handleGetDetailContent() }
                     route("/resources/gathering/{resourceGatheringId}") {
-                        install(WorldParticipantPlugin)
                         install(ResourceGatheringIdParamPlugin)
                         patch("/required") { call.handleUpdateResourceRequiredAmount() }
                         patch("/ignore") { call.handleToggleResourceGatheringIgnored() }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ProjectDetailIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ProjectDetailIT.kt
@@ -19,6 +19,7 @@ import app.mcorg.presentation.plugins.ProjectParamPlugin
 import app.mcorg.presentation.plugins.ResourceGatheringIdParamPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.get
@@ -250,6 +251,7 @@ class ProjectDetailIT : WithUser() {
                     get { call.handleGetProject() }
                     get("/detail-content") { call.handleGetDetailContent() }
                     route("/resources/gathering/{resourceGatheringId}") {
+                        install(WorldParticipantPlugin)
                         install(ResourceGatheringIdParamPlugin)
                         patch("/edit-done") { call.handleUpdateRequirementProgress() }
                         put("/collected") { call.handleSetCollectedValue() }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ProjectDetailIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ProjectDetailIT.kt
@@ -186,6 +186,22 @@ class ProjectDetailIT : WithUser() {
     }
 
     // -------------------------------------------------------------------------
+    // Test 6b: a /tasks mutation by a non-member of the world is rejected
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `task complete by a non-member of the world returns 403`() = testApplication {
+        setupRoutes()
+        val nonMember = createExtraUser()
+
+        val response = client.patch("/worlds/$worldId/projects/$projectId/tasks/$taskId/complete") {
+            addAuthCookie(this, nonMember)
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    // -------------------------------------------------------------------------
     // Test 7: detail-content with legacy ?view= param maps to list lens
     // -------------------------------------------------------------------------
 
@@ -245,13 +261,13 @@ class ProjectDetailIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)
                     get { call.handleGetProject() }
                     get("/detail-content") { call.handleGetDetailContent() }
                     route("/resources/gathering/{resourceGatheringId}") {
-                        install(WorldParticipantPlugin)
                         install(ResourceGatheringIdParamPlugin)
                         patch("/edit-done") { call.handleUpdateRequirementProgress() }
                         put("/collected") { call.handleSetCollectedValue() }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ProjectMetaIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ProjectMetaIT.kt
@@ -14,6 +14,7 @@ import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.ProjectParamPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.get
@@ -213,6 +214,7 @@ class ProjectMetaIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ProjectStateIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ProjectStateIT.kt
@@ -11,6 +11,7 @@ import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.ProjectParamPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.patch
@@ -163,6 +164,7 @@ class ProjectStateIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ResourceDetailPanelIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ResourceDetailPanelIT.kt
@@ -229,11 +229,11 @@ class ResourceDetailPanelIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)
                     route("/resources/gathering/{resourceGatheringId}") {
-                        install(WorldParticipantPlugin)
                         install(ResourceGatheringIdParamPlugin)
                         get("/detail-panel") { call.handleGetResourceDetailPanel() }
                         patch("/source") { call.handleSetResourceSource() }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ResourceDetailPanelIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ResourceDetailPanelIT.kt
@@ -14,6 +14,7 @@ import app.mcorg.presentation.plugins.ProjectParamPlugin
 import app.mcorg.presentation.plugins.ResourceGatheringIdParamPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.delete
@@ -232,6 +233,7 @@ class ResourceDetailPanelIT : WithUser() {
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)
                     route("/resources/gathering/{resourceGatheringId}") {
+                        install(WorldParticipantPlugin)
                         install(ResourceGatheringIdParamPlugin)
                         get("/detail-panel") { call.handleGetResourceDetailPanel() }
                         patch("/source") { call.handleSetResourceSource() }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/SetViewPreferenceIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/SetViewPreferenceIT.kt
@@ -10,6 +10,7 @@ import app.mcorg.pipeline.world.CreateWorldStep
 import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.ProjectParamPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.post
@@ -65,6 +66,7 @@ class SetViewPreferenceIT : WithUser() {
             route("/worlds/{worldId}") {
                 install(AuthPlugin)
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)
                     post("/view-preference") {
@@ -90,6 +92,7 @@ class SetViewPreferenceIT : WithUser() {
             route("/worlds/{worldId}") {
                 install(AuthPlugin)
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 route("/projects/{projectId}") {
                     install(ProjectParamPlugin)
                     post("/view-preference") {

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/ConnectDiscordIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/ConnectDiscordIT.kt
@@ -15,6 +15,7 @@ import app.mcorg.pipeline.world.settings.handleDisconnectDiscord
 import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.WorldAdminPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import app.mcorg.webhook.CreateWebhookSubscriptionInput
@@ -192,6 +193,7 @@ class ConnectDiscordIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 route("/settings") {
                     install(WorldAdminPlugin)
                     route("/discord") {

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/UpdateActiveWorldIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/UpdateActiveWorldIT.kt
@@ -8,6 +8,7 @@ import app.mcorg.presentation.consts.AUTH_COOKIE
 import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
 import app.mcorg.test.WithUser
 import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.get
@@ -55,6 +56,7 @@ class UpdateActiveWorldIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 get { call.respond(HttpStatusCode.OK) }
             }
@@ -74,6 +76,7 @@ class UpdateActiveWorldIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 get { call.respond(HttpStatusCode.OK) }
             }
@@ -93,6 +96,7 @@ class UpdateActiveWorldIT : WithUser() {
             install(AuthPlugin)
             route("/worlds/{worldId}") {
                 install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
                 install(UpdateActiveWorldPlugin)
                 get { call.respond(HttpStatusCode.OK) }
             }


### PR DESCRIPTION
Lets a user mark an imported block as **ignored** — it drops out of the material list and the derived gathering plan (shared intermediates recompute without it), reversibly and visibly. **Also closes a pre-existing IDOR gap across the entire world subtree** (expanded from the initial `/resources`-only fix at Even's request).

## Feature (ignore blocks)
- Migration `V2_46_0`: `resource_gathering.ignored boolean not null default false`.
- `GenerateGatheringPlanStep` filters ignored rows out of both target and supply inputs before `GatheringPlanner.plan(...)` re-derives — shared intermediates recompute for free. No engine/scoring code touched.
- `PATCH /.../gathering/{id}/ignore` toggles the flag (parameterized `SafeSQL`, no auth-in-pipeline), returns the `#plan-resources-area` fragment.
- UI: active table + visible **"Ignored (N)"** section with un-ignore; toggling moves a row between them. OOB cleanup on the schematic re-upload path.

## Security: close IDOR across `/{worldId}`
Audit found the world subtree gated only by *existence* plugins (`WorldParamPlugin`/`ProjectParamPlugin` check the world/project exist, never membership). Only `/settings` (WorldAdmin/Owner) was protected — so any authenticated user could read/mutate any world's projects, resources, tasks, plan, meta, etc. by guessing sequential integer IDs.

- New `WorldParticipantPlugin` (mirrors `WorldAdminPlugin`/`WorldOwnerPlugin`; `ValidateWorldMemberRole(user, Role.MEMBER, worldId)` — `MEMBER`=100 is the lowest non-banned level, so it admits OWNER/ADMIN/MEMBER, rejects non-members + BANNED; 403 on failure).
- **Installed once** at `route("/{worldId}")`, after `WorldParamPlugin` (sets `worldId`) and before `UpdateActiveWorldPlugin` (so a rejected non-member's session never points at a world they can't access). One install gates the whole subtree: project listing/creation, all project sub-routes (`/detail-content`, `/state`, `/meta/*`, `/field-log-*`, `/tasks/*`, `/view-preference`, `/plan/*`), and `/settings` (redundant with its stricter admin/owner gates — harmless precondition).
- **Join flow preserved:** invite acceptance is routed outside the subtree at `/invites/{inviteId}/accept` — proven by a new `AcceptInvitationIT` (non-member invitee accepts → 200, becomes a member).

## Tests
- Ignore feature: `GenerateGatheringPlanStepTest` (derivation excludes ignored, shared-tag recompute 38→32, un-ignore restores); `PlanViewIT` toggle round-trip.
- IDOR: non-member→403 tests across each newly-gated block (`/projects/list-fragment`, `/detail-content`, `/state`, `/tasks/complete`, `/plan/progress`, `/field-log-row`) + the resource-family ones; `AcceptInvitationIT` for the invitee path. All world/project ITs swept to install the gate in their local routing trees.
- `mvn clean compile` clean; 667 unit pass; targeted DB sweep 155/155 across 19 IT/Test classes.
- **Two pre-existing failures, not caused by this change** (verified by reverting the added lines — identical failures; symptoms unrelated to auth): `CreateProjectFromSchematicIT` resource-count 15-vs-13 (untouched `/from-schematic` route) and `ConnectDiscordIT` (AppConfig mutable-singleton test pollution under the full sweep). CI is the arbiter for both.

Closes MCO-247. (MCO-254 folded in here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)