### PR TITLE
MCO-246: Swap a target item in the material list (free picker + variant suggestions)

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/ResourceDetailPanelPipelines.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/ResourceDetailPanelPipelines.kt
@@ -26,13 +26,15 @@ suspend fun ApplicationCall.handleGetResourceDetailPanel() {
     val resourceGatheringId = getResourceGatheringId()
 
     handlePipeline(
-        onSuccess = { (resource, projects) ->
-            respondHtml(resourceDetailPanelFragment(worldId, projectId, resource, projects))
+        onSuccess = { (resource, projects, candidates) ->
+            respondHtml(resourceDetailPanelFragment(worldId, projectId, resource, projects, candidates))
         }
     ) {
         val resource = GetResourceGatheringItemStep.run(resourceGatheringId)
         val projects = GetProjectsInWorldStep(projectId).run(worldId)
-        resource to projects
+        val graph = getGraphForWorld(worldId)
+        val candidates = findVariantCandidates(graph, resource.itemId)
+        Triple(resource, projects, candidates)
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/ResourceDetailPanelPipelines.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/ResourceDetailPanelPipelines.kt
@@ -25,16 +25,21 @@ suspend fun ApplicationCall.handleGetResourceDetailPanel() {
     val projectId = getProjectId()
     val resourceGatheringId = getResourceGatheringId()
 
+    // Version scopes the "Replace item" search combo (see resourcePanelVariantSection) to the
+    // project's Minecraft version; null falls back to an unscoped search (validation still
+    // enforces the version catalog server-side).
+    val version = GetWorldVersionStep.process(worldId).getOrNull()
+
     handlePipeline(
-        onSuccess = { (resource, projects, candidates) ->
-            respondHtml(resourceDetailPanelFragment(worldId, projectId, resource, projects, candidates))
+        onSuccess = { (resource, projects, suggestions) ->
+            respondHtml(resourceDetailPanelFragment(worldId, projectId, resource, projects, suggestions, version))
         }
     ) {
         val resource = GetResourceGatheringItemStep.run(resourceGatheringId)
         val projects = GetProjectsInWorldStep(projectId).run(worldId)
         val graph = getGraphForWorld(worldId)
-        val candidates = findVariantCandidates(graph, resource.itemId)
-        Triple(resource, projects, candidates)
+        val suggestions = findVariantCandidates(graph, resource.itemId)
+        Triple(resource, projects, suggestions)
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/SwapResourceGatheringVariantPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/SwapResourceGatheringVariantPipeline.kt
@@ -1,0 +1,99 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.pipeline.Quadruple
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.failure.ValidationFailure
+import app.mcorg.pipeline.project.commonsteps.GetProjectsInWorldStep
+import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
+import app.mcorg.pipeline.resources.commonsteps.GetResourceGatheringItemStep
+import app.mcorg.presentation.handler.handlePipeline
+import app.mcorg.presentation.templated.dsl.pages.planResourcesAreaFragment
+import app.mcorg.presentation.templated.dsl.pages.resourceDetailPanelOobFragment
+import app.mcorg.presentation.utils.getProjectId
+import app.mcorg.presentation.utils.getResourceGatheringId
+import app.mcorg.presentation.utils.getWorldId
+import app.mcorg.presentation.utils.respondHtml
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveParameters
+
+/**
+ * MCO-246: swaps a target's item to a chosen variant — another member of a tag family the
+ * current item belongs to (e.g. birch planks -> spruce planks via `#minecraft:planks`; see
+ * [findVariantCandidates]). Updates the `resource_gathering` row's `item_id` and `name` in
+ * place; the gathering plan re-derives from the new item on the next read
+ * ([GenerateGatheringPlanStep] — nothing is persisted beyond the swap itself).
+ *
+ * Candidates are recomputed server-side from the item's *current* value (not trusted from the
+ * client), so a `itemId` outside that set — including the item's own current id, an id from an
+ * unrelated tag family, or a non-existent item — is rejected as a validation failure.
+ *
+ * Responds with the whole `#plan-resources-area` fragment (its row's name/qty display changes)
+ * plus an out-of-band refresh of the open resource-detail panel, if any, so a swap made from
+ * within the panel reflects the new item/variant list without needing to reopen it.
+ */
+suspend fun ApplicationCall.handleSwapResourceGatheringVariant() {
+    val worldId = getWorldId()
+    val projectId = getProjectId()
+    val resourceGatheringId = getResourceGatheringId()
+    val parameters = receiveParameters()
+
+    handlePipeline(
+        onSuccess = { (resources, panelResource, projectsInWorld, panelCandidates) ->
+            respondHtml(
+                planResourcesAreaFragment(worldId, projectId, resources) +
+                    resourceDetailPanelOobFragment(worldId, projectId, panelResource, projectsInWorld, panelCandidates)
+            )
+        }
+    ) {
+        val current = GetResourceGatheringItemStep.run(resourceGatheringId)
+        val graph = getGraphForWorld(worldId)
+        val candidates = findVariantCandidates(graph, current.itemId)
+        val chosen = ValidateSwapVariantInputStep(candidates).run(parameters)
+        SwapResourceGatheringVariantStep(resourceGatheringId).run(chosen)
+
+        val updated = GetResourceGatheringItemStep.run(resourceGatheringId)
+        val updatedCandidates = findVariantCandidates(graph, updated.itemId)
+        val resources = GetAllResourceGatheringItemsStep.run(projectId)
+        val projectsInWorld = GetProjectsInWorldStep(projectId).run(worldId)
+        Quadruple(resources, updated, projectsInWorld, updatedCandidates)
+    }
+}
+
+internal data class ValidateSwapVariantInputStep(
+    val candidates: List<Item>,
+) : Step<Parameters, AppFailure.ValidationError, Item> {
+    override suspend fun process(input: Parameters): Result<AppFailure.ValidationError, Item> {
+        val itemId = input["itemId"]
+        return when {
+            itemId.isNullOrBlank() -> Result.failure(
+                AppFailure.ValidationError(listOf(ValidationFailure.MissingParameter("itemId")))
+            )
+            candidates.none { it.id == itemId } -> Result.failure(
+                AppFailure.ValidationError(
+                    listOf(ValidationFailure.InvalidValue("itemId", candidates.map { it.id }))
+                )
+            )
+            else -> Result.success(candidates.first { it.id == itemId })
+        }
+    }
+}
+
+private data class SwapResourceGatheringVariantStep(val resourceGatheringId: Int) :
+    Step<Item, AppFailure.DatabaseError, Unit> {
+    override suspend fun process(input: Item): Result<AppFailure.DatabaseError, Unit> {
+        return DatabaseSteps.update<Item>(
+            sql = SafeSQL.update("UPDATE resource_gathering SET item_id = ?, name = ? WHERE id = ?"),
+            parameterSetter = { statement, item ->
+                statement.setString(1, item.id)
+                statement.setString(2, item.name)
+                statement.setInt(3, resourceGatheringId)
+            }
+        ).process(input).map { }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/SwapResourceGatheringVariantPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/SwapResourceGatheringVariantPipeline.kt
@@ -1,7 +1,7 @@
 package app.mcorg.pipeline.resources
 
 import app.mcorg.domain.model.minecraft.Item
-import app.mcorg.domain.pipeline.Quadruple
+import app.mcorg.domain.model.resources.ResourceGatheringItem
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
@@ -9,6 +9,7 @@ import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.failure.ValidationFailure
 import app.mcorg.pipeline.project.commonsteps.GetProjectsInWorldStep
+import app.mcorg.pipeline.project.resources.GetItemsInWorldVersionStep
 import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
 import app.mcorg.pipeline.resources.commonsteps.GetResourceGatheringItemStep
 import app.mcorg.presentation.handler.handlePipeline
@@ -23,19 +24,22 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveParameters
 
 /**
- * MCO-246: swaps a target's item to a chosen variant — another member of a tag family the
- * current item belongs to (e.g. birch planks -> spruce planks via `#minecraft:planks`; see
- * [findVariantCandidates]). Updates the `resource_gathering` row's `item_id` and `name` in
- * place; the gathering plan re-derives from the new item on the next read
- * ([GenerateGatheringPlanStep] — nothing is persisted beyond the swap itself).
+ * MCO-246: swaps a target's item to ANY chosen item valid for the project's Minecraft version —
+ * not just a same-tag-family sibling. The user picks either from the tag-family quick-swap
+ * suggestions ([findVariantCandidates]) or by free-text search over the whole catalog
+ * (`/items/search`, wired in the resource-detail panel). Updates the `resource_gathering`
+ * row's `item_id` and `name` in place; the gathering plan re-derives from the new item on the
+ * next read ([GenerateGatheringPlanStep] — nothing is persisted beyond the swap itself).
  *
- * Candidates are recomputed server-side from the item's *current* value (not trusted from the
- * client), so a `itemId` outside that set — including the item's own current id, an id from an
- * unrelated tag family, or a non-existent item — is rejected as a validation failure.
+ * The chosen `itemId` is validated server-side against the project's world-version item catalog
+ * ([GetItemsInWorldVersionStep] — the same source [handleCreateResourceGatheringItem] validates
+ * against), so an unknown/nonexistent id, or an id not present in this version, is rejected. A
+ * missing id is a 400; a present-but-unknown id is a 422. The name is taken from the catalog,
+ * never trusted from the client.
  *
- * Responds with the whole `#plan-resources-area` fragment (its row's name/qty display changes)
- * plus an out-of-band refresh of the open resource-detail panel, if any, so a swap made from
- * within the panel reflects the new item/variant list without needing to reopen it.
+ * Responds with the whole `#plan-resources-area` fragment (its row's name display changes) plus
+ * an out-of-band refresh of the open resource-detail panel, if any, so a swap made from within
+ * the panel reflects the new item and its refreshed suggestions without needing to reopen it.
  */
 suspend fun ApplicationCall.handleSwapResourceGatheringVariant() {
     val worldId = getWorldId()
@@ -43,30 +47,44 @@ suspend fun ApplicationCall.handleSwapResourceGatheringVariant() {
     val resourceGatheringId = getResourceGatheringId()
     val parameters = receiveParameters()
 
+    val version = GetWorldVersionStep.process(worldId).getOrNull()
+
     handlePipeline(
-        onSuccess = { (resources, panelResource, projectsInWorld, panelCandidates) ->
+        onSuccess = { (resources, panelResource, projectsInWorld, panelSuggestions) ->
             respondHtml(
                 planResourcesAreaFragment(worldId, projectId, resources) +
-                    resourceDetailPanelOobFragment(worldId, projectId, panelResource, projectsInWorld, panelCandidates)
+                    resourceDetailPanelOobFragment(worldId, projectId, panelResource, projectsInWorld, panelSuggestions, version)
             )
         }
     ) {
-        val current = GetResourceGatheringItemStep.run(resourceGatheringId)
-        val graph = getGraphForWorld(worldId)
-        val candidates = findVariantCandidates(graph, current.itemId)
-        val chosen = ValidateSwapVariantInputStep(candidates).run(parameters)
+        val validItems = GetItemsInWorldVersionStep.run(worldId)
+        val chosen = ValidateSwapVariantInputStep(validItems).run(parameters)
         SwapResourceGatheringVariantStep(resourceGatheringId).run(chosen)
 
         val updated = GetResourceGatheringItemStep.run(resourceGatheringId)
-        val updatedCandidates = findVariantCandidates(graph, updated.itemId)
+        val graph = getGraphForWorld(worldId)
+        val suggestions = findVariantCandidates(graph, updated.itemId)
         val resources = GetAllResourceGatheringItemsStep.run(projectId)
         val projectsInWorld = GetProjectsInWorldStep(projectId).run(worldId)
-        Quadruple(resources, updated, projectsInWorld, updatedCandidates)
+        SwapResult(resources, updated, projectsInWorld, suggestions)
     }
 }
 
+private data class SwapResult(
+    val resources: List<ResourceGatheringItem>,
+    val updated: ResourceGatheringItem,
+    val projectsInWorld: List<Pair<Int, String>>,
+    val suggestions: List<Item>,
+)
+
+/**
+ * Validates the chosen `itemId` against [validItems] — the item catalog for the project's
+ * Minecraft version. A missing id is a [ValidationFailure.MissingParameter] (400); a present but
+ * unknown id (not in this version's catalog) is a [ValidationFailure.InvalidValue] (422). On
+ * success returns the catalog [Item] so the row's name is authoritative, not client-supplied.
+ */
 internal data class ValidateSwapVariantInputStep(
-    val candidates: List<Item>,
+    val validItems: List<Item>,
 ) : Step<Parameters, AppFailure.ValidationError, Item> {
     override suspend fun process(input: Parameters): Result<AppFailure.ValidationError, Item> {
         val itemId = input["itemId"]
@@ -74,12 +92,13 @@ internal data class ValidateSwapVariantInputStep(
             itemId.isNullOrBlank() -> Result.failure(
                 AppFailure.ValidationError(listOf(ValidationFailure.MissingParameter("itemId")))
             )
-            candidates.none { it.id == itemId } -> Result.failure(
-                AppFailure.ValidationError(
-                    listOf(ValidationFailure.InvalidValue("itemId", candidates.map { it.id }))
+            else -> validItems.firstOrNull { it.id == itemId }
+                ?.let { Result.success(it) }
+                ?: Result.failure(
+                    AppFailure.ValidationError(
+                        listOf(ValidationFailure.InvalidValue("itemId", validItems.map { it.id }))
+                    )
                 )
-            )
-            else -> Result.success(candidates.first { it.id == itemId })
         }
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/VariantDiscovery.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/VariantDiscovery.kt
@@ -1,0 +1,38 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftTag
+import app.mcorg.engine.model.ItemSourceGraph
+
+/**
+ * MCO-246: variant candidates for a concrete item id — the other members of any tag the item
+ * belongs to (e.g. `minecraft:oak_planks` -> the rest of `#minecraft:planks`). This is a
+ * read-only reuse of the tag/member data already loaded into the graph (`MinecraftTag.content`
+ * on an `ItemNode`) — the same data structure the tag-member picker in `DrillView.kt` renders
+ * from. No graph construction or scoring logic is touched here.
+ *
+ * Coverage is bounded by which tags happen to be graph nodes: a tag only becomes a node when
+ * some recipe/loot source references it as a choice ingredient (see `mc-engine/CLAUDE.md` +
+ * `ItemSourceGraphBuilder`). Real per-species tags (`#minecraft:planks`, `#minecraft:wool`,
+ * `#minecraft:logs`, tool-material tags, ...) and synthetic multi-choice recipe tags (colour
+ * families for wool/beds/carpets from recolouring recipes) are covered this way. Families with
+ * no covering tag anywhere in the recipe/loot data — e.g. door species, since vanilla has no
+ * "any door" recipe ingredient — are not, and this returns an empty list for them.
+ *
+ * @return candidates de-duplicated by id, sorted by name, excluding [itemId] itself. Empty
+ *   when [graph] is null or the item belongs to no tag family present in the graph.
+ */
+fun findVariantCandidates(graph: ItemSourceGraph?, itemId: String): List<Item> {
+    if (graph == null) return emptyList()
+
+    val candidates = linkedMapOf<String, Item>()
+    for (node in graph.getAllItems()) {
+        val tag = node.item as? MinecraftTag ?: continue
+        if (tag.content.none { it.id == itemId }) continue
+        for (member in tag.content) {
+            if (member.id == itemId) continue
+            candidates.putIfAbsent(member.id, member)
+        }
+    }
+    return candidates.values.sortedBy { it.name }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -20,6 +20,7 @@ import app.mcorg.pipeline.resources.handleCreateResourceGatheringItem
 import app.mcorg.pipeline.resources.handleDeleteResourceGatheringItem
 import app.mcorg.pipeline.resources.handleGetResourceDetailPanel
 import app.mcorg.pipeline.resources.handleSetResourceSource
+import app.mcorg.pipeline.resources.handleSwapResourceGatheringVariant
 import app.mcorg.pipeline.resources.handleToggleResourceGatheringIgnored
 import app.mcorg.pipeline.resources.handleUpdateResourceRequiredAmount
 import app.mcorg.pipeline.resources.handleSetCollectedValue
@@ -174,6 +175,9 @@ class WorldHandler {
                                     }
                                     patch("/ignore") {
                                         call.handleToggleResourceGatheringIgnored()
+                                    }
+                                    patch("/variant") {
+                                        call.handleSwapResourceGatheringVariant()
                                     }
                                     put("/collected") {
                                         call.handleSetCollectedValue()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ResourceDetailPanel.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ResourceDetailPanel.kt
@@ -1,8 +1,10 @@
 package app.mcorg.presentation.templated.dsl.pages
 
+import app.mcorg.domain.model.minecraft.Item
 import app.mcorg.domain.model.resources.ResourceGatheringItem
 import app.mcorg.presentation.hxDelete
 import app.mcorg.presentation.hxDeleteWithConfirm
+import app.mcorg.presentation.hxOutOfBands
 import app.mcorg.presentation.hxPatch
 import app.mcorg.presentation.hxSwap
 import app.mcorg.presentation.hxTarget
@@ -33,6 +35,7 @@ fun FlowContent.resourceDetailPanel(
     projectId: Int,
     resource: ResourceGatheringItem,
     projectsInWorld: List<Pair<Int, String>>,
+    variantCandidates: List<Item> = emptyList(),
 ) {
     div("resource-panel__header") {
         button(classes = "resource-panel__close-btn") {
@@ -74,6 +77,11 @@ fun FlowContent.resourceDetailPanel(
     div("resource-panel__source") {
         id = "resource-panel-source"
         resourcePanelSourceSection(worldId, projectId, resource, projectsInWorld)
+    }
+    div("resource-panel__divider") { +"Variant" }
+    div("resource-panel__variant") {
+        id = "resource-panel-variant"
+        resourcePanelVariantSection(worldId, projectId, resource, variantCandidates)
     }
     div("resource-panel__footer") {
         button(classes = "btn btn--danger resource-panel__remove-btn") {
@@ -177,6 +185,37 @@ fun FlowContent.resourcePanelSourceSection(
 }
 
 /**
+ * Variant section (MCO-246): lists other members of any tag family [resource]'s item belongs
+ * to (see [app.mcorg.pipeline.resources.findVariantCandidates]), each a clickable option that
+ * PATCHes `/variant` to swap the target's item in place. Empty [variantCandidates] renders an
+ * explanatory empty state rather than hiding the section, since coverage is data-dependent
+ * (only tag families the recipe/loot data actually references are known) and a user shouldn't
+ * be left wondering whether the control is broken.
+ */
+fun FlowContent.resourcePanelVariantSection(
+    worldId: Int,
+    projectId: Int,
+    resource: ResourceGatheringItem,
+    variantCandidates: List<Item>,
+) {
+    if (variantCandidates.isEmpty()) {
+        p("resource-panel__source-empty") { +"No known variants for this item." }
+        return
+    }
+    div("stack--xs") {
+        for (candidate in variantCandidates) {
+            div("picker-opt") {
+                attributes["hx-patch"] = "/worlds/$worldId/projects/$projectId/resources/gathering/${resource.id}/variant"
+                attributes["hx-vals"] = """{"itemId":"${candidate.id}"}"""
+                attributes["hx-target"] = "#plan-resources-area"
+                attributes["hx-swap"] = "outerHTML"
+                span("picker-opt__name") { +candidate.name }
+            }
+        }
+    }
+}
+
+/**
  * Full-fragment response for GET .../detail-panel — returns the inner content of #resource-panel-content.
  */
 fun resourceDetailPanelFragment(
@@ -184,8 +223,26 @@ fun resourceDetailPanelFragment(
     projectId: Int,
     resource: ResourceGatheringItem,
     projectsInWorld: List<Pair<Int, String>>,
+    variantCandidates: List<Item> = emptyList(),
 ): String = createHTML().div {
-    resourceDetailPanel(worldId, projectId, resource, projectsInWorld)
+    resourceDetailPanel(worldId, projectId, resource, projectsInWorld, variantCandidates)
+}
+
+/**
+ * Out-of-band refresh of the whole panel (MCO-246) — used by the `/variant` swap response so an
+ * open resource-detail panel reflects the new item/name/variant list without needing to be
+ * reopened. The main response target for a swap is `#plan-resources-area` (the row's name/qty
+ * live there); this is the sidecar that keeps the panel in sync alongside it.
+ */
+fun resourceDetailPanelOobFragment(
+    worldId: Int,
+    projectId: Int,
+    resource: ResourceGatheringItem,
+    projectsInWorld: List<Pair<Int, String>>,
+    variantCandidates: List<Item> = emptyList(),
+): String = createHTML().div {
+    hxOutOfBands("innerHTML:#resource-panel-content")
+    resourceDetailPanel(worldId, projectId, resource, projectsInWorld, variantCandidates)
 }
 
 /**

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ResourceDetailPanel.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ResourceDetailPanel.kt
@@ -35,7 +35,8 @@ fun FlowContent.resourceDetailPanel(
     projectId: Int,
     resource: ResourceGatheringItem,
     projectsInWorld: List<Pair<Int, String>>,
-    variantCandidates: List<Item> = emptyList(),
+    variantSuggestions: List<Item> = emptyList(),
+    version: String? = null,
 ) {
     div("resource-panel__header") {
         button(classes = "resource-panel__close-btn") {
@@ -78,10 +79,10 @@ fun FlowContent.resourceDetailPanel(
         id = "resource-panel-source"
         resourcePanelSourceSection(worldId, projectId, resource, projectsInWorld)
     }
-    div("resource-panel__divider") { +"Variant" }
+    div("resource-panel__divider") { +"Replace item" }
     div("resource-panel__variant") {
         id = "resource-panel-variant"
-        resourcePanelVariantSection(worldId, projectId, resource, variantCandidates)
+        resourcePanelVariantSection(worldId, projectId, resource, variantSuggestions, version)
     }
     div("resource-panel__footer") {
         button(classes = "btn btn--danger resource-panel__remove-btn") {
@@ -185,31 +186,70 @@ fun FlowContent.resourcePanelSourceSection(
 }
 
 /**
- * Variant section (MCO-246): lists other members of any tag family [resource]'s item belongs
- * to (see [app.mcorg.pipeline.resources.findVariantCandidates]), each a clickable option that
- * PATCHes `/variant` to swap the target's item in place. Empty [variantCandidates] renders an
- * explanatory empty state rather than hiding the section, since coverage is data-dependent
- * (only tag families the recipe/loot data actually references are known) and a user shouldn't
- * be left wondering whether the control is broken.
+ * "Replace item" section (MCO-246): swaps the target to ANY item valid for the project's
+ * Minecraft version. Two ways to pick:
+ *
+ * 1. **Suggested** quick-swap chips — the same-tag-family siblings from
+ *    [app.mcorg.pipeline.resources.findVariantCandidates] (wood/wool/log/colour families).
+ *    Each chip PATCHes `/variant` directly via HTMX. Omitted entirely when there are no
+ *    suggestions (coverage is data-dependent), so the section never shows a dead-end.
+ * 2. **Free-text search** over the whole version catalog via the shared `/items/search` combo
+ *    — for swaps with no shared tag (e.g. Stone -> Concrete). Selecting a result triggers the
+ *    swap; the wiring lives in `resource-panel.js` (a capture-phase click handler on
+ *    `#resource-panel-variant-results` options), which reuses the search endpoint without the
+ *    page-global `selectSearchedItem` (that one targets the add-resource form's fields).
+ *
+ * [version] scopes the search to the project's Minecraft version when known; the server
+ * validates the chosen id against that catalog regardless.
  */
 fun FlowContent.resourcePanelVariantSection(
     worldId: Int,
     projectId: Int,
     resource: ResourceGatheringItem,
-    variantCandidates: List<Item>,
+    variantSuggestions: List<Item>,
+    version: String?,
 ) {
-    if (variantCandidates.isEmpty()) {
-        p("resource-panel__source-empty") { +"No known variants for this item." }
-        return
+    val swapUrl = "/worlds/$worldId/projects/$projectId/resources/gathering/${resource.id}/variant"
+
+    if (variantSuggestions.isNotEmpty()) {
+        span("section-label resource-panel__variant-label") { +"Suggested" }
+        div("stack--xs resource-panel__variant-suggestions") {
+            for (suggestion in variantSuggestions) {
+                div("picker-opt") {
+                    attributes["hx-patch"] = swapUrl
+                    attributes["hx-vals"] = """{"itemId":"${suggestion.id}"}"""
+                    attributes["hx-target"] = "#plan-resources-area"
+                    attributes["hx-swap"] = "outerHTML"
+                    span("picker-opt__name") { +suggestion.name }
+                }
+            }
+        }
     }
-    div("stack--xs") {
-        for (candidate in variantCandidates) {
-            div("picker-opt") {
-                attributes["hx-patch"] = "/worlds/$worldId/projects/$projectId/resources/gathering/${resource.id}/variant"
-                attributes["hx-vals"] = """{"itemId":"${candidate.id}"}"""
-                attributes["hx-target"] = "#plan-resources-area"
-                attributes["hx-swap"] = "outerHTML"
-                span("picker-opt__name") { +candidate.name }
+
+    // Free-text search over the whole version catalog. The results container carries the swap
+    // URL on a data attribute so resource-panel.js knows where to PATCH the selected item.
+    div("item-search-combo resource-panel__variant-search") {
+        span("section-label resource-panel__variant-label") {
+            +(if (variantSuggestions.isEmpty()) "Swap to any item" else "Or search any item")
+        }
+        div("item-search-field") {
+            input(type = InputType.text, classes = "form-control") {
+                id = "resource-panel-variant-input"
+                placeholder = "Search items by name..."
+                autoComplete = "off"
+                attributes["hx-get"] = "/items/search"
+                attributes["hx-trigger"] = "input changed delay:300ms"
+                attributes["hx-target"] = "#resource-panel-variant-results"
+                attributes["hx-swap"] = "innerHTML"
+                attributes["hx-vals"] = if (version != null) {
+                    "js:{q: this.value, versionRangeType: 'bounded', versionFrom: '$version', versionTo: '$version'}"
+                } else {
+                    "js:{q: this.value}"
+                }
+            }
+            div("item-search-results") {
+                id = "resource-panel-variant-results"
+                attributes["data-swap-url"] = swapUrl
             }
         }
     }
@@ -223,26 +263,28 @@ fun resourceDetailPanelFragment(
     projectId: Int,
     resource: ResourceGatheringItem,
     projectsInWorld: List<Pair<Int, String>>,
-    variantCandidates: List<Item> = emptyList(),
+    variantSuggestions: List<Item> = emptyList(),
+    version: String? = null,
 ): String = createHTML().div {
-    resourceDetailPanel(worldId, projectId, resource, projectsInWorld, variantCandidates)
+    resourceDetailPanel(worldId, projectId, resource, projectsInWorld, variantSuggestions, version)
 }
 
 /**
  * Out-of-band refresh of the whole panel (MCO-246) — used by the `/variant` swap response so an
- * open resource-detail panel reflects the new item/name/variant list without needing to be
- * reopened. The main response target for a swap is `#plan-resources-area` (the row's name/qty
- * live there); this is the sidecar that keeps the panel in sync alongside it.
+ * open resource-detail panel reflects the new item/name and its refreshed suggestions without
+ * needing to be reopened. The main response target for a swap is `#plan-resources-area` (the
+ * row's name lives there); this is the sidecar that keeps the panel in sync alongside it.
  */
 fun resourceDetailPanelOobFragment(
     worldId: Int,
     projectId: Int,
     resource: ResourceGatheringItem,
     projectsInWorld: List<Pair<Int, String>>,
-    variantCandidates: List<Item> = emptyList(),
+    variantSuggestions: List<Item> = emptyList(),
+    version: String? = null,
 ): String = createHTML().div {
     hxOutOfBands("innerHTML:#resource-panel-content")
-    resourceDetailPanel(worldId, projectId, resource, projectsInWorld, variantCandidates)
+    resourceDetailPanel(worldId, projectId, resource, projectsInWorld, variantSuggestions, version)
 }
 
 /**

--- a/webapp/mc-web/src/main/resources/static/scripts/resource-panel.js
+++ b/webapp/mc-web/src/main/resources/static/scripts/resource-panel.js
@@ -195,6 +195,46 @@
     }
 
     // -------------------------------------------------------------------------
+    // "Replace item" search selection (MCO-246)
+    //
+    // The /items/search results reused in the panel's "Replace item" section carry a
+    // hardcoded inline onclick="selectSearchedItem(this)" — but the page-global
+    // selectSearchedItem (plan-view.js) targets the ADD-resource form's fields, which is
+    // wrong here. We intercept clicks on options inside #resource-panel-variant-results in
+    // the CAPTURE phase and stopPropagation, which prevents the event from reaching the
+    // option's own inline onclick, then perform the swap PATCH ourselves. The swap URL is
+    // read from the results container's data-swap-url (rendered by resourcePanelVariantSection).
+    // -------------------------------------------------------------------------
+
+    function initVariantSearch() {
+        var dialog = getDialog();
+        if (!dialog) return;
+        if (dialog.dataset.variantSearchInitialized) return;
+        dialog.dataset.variantSearchInitialized = 'true';
+
+        dialog.addEventListener('click', function (e) {
+            var results = e.target.closest('#resource-panel-variant-results');
+            if (!results) return;
+            var option = e.target.closest('.item-search-option');
+            if (!option) return;
+
+            // Stop the option's inline onclick (plan-view's selectSearchedItem) from firing.
+            e.stopPropagation();
+            e.preventDefault();
+
+            var itemId = option.dataset.itemId;
+            var swapUrl = results.dataset.swapUrl;
+            if (!itemId || !swapUrl) return;
+
+            htmx.ajax('PATCH', swapUrl, {
+                target: '#plan-resources-area',
+                swap: 'outerHTML',
+                values: { itemId: itemId }
+            });
+        }, true); // capture phase — runs before the option's own inline handler
+    }
+
+    // -------------------------------------------------------------------------
     // Init
     // -------------------------------------------------------------------------
 
@@ -203,6 +243,7 @@
         initRowClicks();
         initViewToggleCleanup();
         initPanelQtyEdit();
+        initVariantSearch();
     }
 
     document.addEventListener('DOMContentLoaded', init);

--- a/webapp/mc-web/src/main/resources/static/styles/components/resource-panel.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/resource-panel.css
@@ -175,6 +175,28 @@ dialog#resource-panel::backdrop {
     color: var(--text-primary);
 }
 
+/* "Replace item" section (MCO-246) — suggestions chips + free-text search */
+.resource-panel__variant {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding-top: var(--space-2);
+}
+
+.resource-panel__variant-label {
+    display: block;
+}
+
+.resource-panel__variant-suggestions {
+    margin-top: var(--space-1);
+}
+
+.resource-panel__variant-search {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
 .resource-panel__footer {
     margin-top: auto;
     padding-top: var(--space-5);

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/VariantDiscoveryTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/VariantDiscoveryTest.kt
@@ -1,0 +1,88 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftTag
+import app.mcorg.engine.model.ItemSourceGraph
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class VariantDiscoveryTest {
+
+    private fun item(id: String, name: String) = Item("minecraft:$id", name)
+
+    @Test
+    fun `returns the other members of a tag family sorted by name`() {
+        val builder = ItemSourceGraph.builder()
+        builder.addItemNode(
+            MinecraftTag(
+                "#minecraft:planks", "Planks",
+                listOf(item("oak_planks", "Oak Planks"), item("spruce_planks", "Spruce Planks"), item("birch_planks", "Birch Planks"))
+            )
+        )
+        val graph = builder.build()
+
+        val candidates = findVariantCandidates(graph, "minecraft:birch_planks")
+
+        assertEquals(listOf("Oak Planks", "Spruce Planks"), candidates.map { it.name })
+    }
+
+    @Test
+    fun `excludes the item itself from its own candidate list`() {
+        val builder = ItemSourceGraph.builder()
+        builder.addItemNode(
+            MinecraftTag("#minecraft:wool", "Wool", listOf(item("white_wool", "White Wool"), item("red_wool", "Red Wool")))
+        )
+        val graph = builder.build()
+
+        val candidates = findVariantCandidates(graph, "minecraft:white_wool")
+
+        assertTrue(candidates.none { it.id == "minecraft:white_wool" })
+    }
+
+    @Test
+    fun `an item with no covering tag in the graph has no candidates`() {
+        val builder = ItemSourceGraph.builder()
+        builder.addItemNode(
+            MinecraftTag("#minecraft:planks", "Planks", listOf(item("oak_planks", "Oak Planks"), item("spruce_planks", "Spruce Planks")))
+        )
+        val graph = builder.build()
+
+        // "birch_door" belongs to no tag present in this graph (vanilla has no "any door"
+        // recipe ingredient, so a #minecraft:doors tag never becomes a graph node — MCO-246).
+        val candidates = findVariantCandidates(graph, "minecraft:birch_door")
+
+        assertTrue(candidates.isEmpty())
+    }
+
+    @Test
+    fun `a null graph yields no candidates`() {
+        assertTrue(findVariantCandidates(null, "minecraft:birch_planks").isEmpty())
+    }
+
+    @Test
+    fun `candidates from multiple containing tags are deduplicated by id`() {
+        val builder = ItemSourceGraph.builder()
+        // Two tags that both happen to include spruce_planks alongside the target item.
+        builder.addItemNode(
+            MinecraftTag("#minecraft:planks", "Planks", listOf(item("oak_planks", "Oak Planks"), item("spruce_planks", "Spruce Planks")))
+        )
+        builder.addItemNode(
+            MinecraftTag("#mcorg:choice/oak_spruce", "Oak or Spruce", listOf(item("oak_planks", "Oak Planks"), item("spruce_planks", "Spruce Planks")))
+        )
+        val graph = builder.build()
+
+        val candidates = findVariantCandidates(graph, "minecraft:oak_planks")
+
+        assertEquals(listOf("minecraft:spruce_planks"), candidates.map { it.id })
+    }
+
+    @Test
+    fun `an item with no tags at all in an otherwise non-empty graph has no candidates`() {
+        val builder = ItemSourceGraph.builder()
+        builder.addItemNode(item("iron_ingot", "Iron Ingot"))
+        val graph = builder.build()
+
+        assertTrue(findVariantCandidates(graph, "minecraft:iron_ingot").isEmpty())
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/SwapResourceGatheringVariantIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/SwapResourceGatheringVariantIT.kt
@@ -48,10 +48,13 @@ import kotlin.test.assertFalse
  * ingestion writes to (see `StoreServerDataSteps.kt`) — giving [GetItemSourceGraphForVersionStep]
  * real tag/member and recipe data to build a graph from, without depending on a real ingest.
  *
- * The fake graph models: a "planks" tag (birch/spruce) usable for sticks, birch planks crafted
- * from an oak log, spruce planks crafted from a spruce log, and raw (source-less-input) log
- * gathering — enough to prove a variant swap re-routes the derived "How to make it" breakdown
- * through a different raw material (oak log -> spruce log).
+ * The fake graph models:
+ * - a "planks" tag (birch/spruce) usable for sticks, birch planks crafted from an oak log,
+ *   spruce planks crafted from a spruce log — so a tag-family swap (birch -> spruce) re-routes
+ *   the derived "How to make it" breakdown through a different raw material (oak log -> spruce
+ *   log), and the tag siblings surface as "Suggested" quick-swap chips.
+ * - stone (raw gather) and white_concrete (crafted from white_concrete_powder) sharing NO tag —
+ *   so an any-item swap (stone -> concrete), the MCO-246 pivot, also succeeds and re-derives.
  */
 @Tag("database")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -103,6 +106,38 @@ class SwapResourceGatheringVariantIT : WithUser() {
     }
 
     @Test
+    fun `swap to an item in no shared tag family (stone to concrete) succeeds and re-derives`() = testApplication {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:stone", "Stone", 4)
+        setupRoutes()
+
+        // Before: Stone is a raw-gather block — the breakdown has no White Concrete Powder.
+        val before = client.get("/worlds/$worldId/projects/$pid/detail-content?lens=list") {
+            addAuthCookie(this)
+        }.bodyAsText()
+        assertContains(before, "Stone")
+        assertFalse(before.contains("White Concrete Powder"))
+
+        // Stone and White Concrete share NO tag, so this is the any-item path (not a suggestion).
+        val response = client.patch("/worlds/$worldId/projects/$pid/resources/gathering/$rgId/variant") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("itemId=minecraft:white_concrete")
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val (itemId, name) = runBlocking { readResource(rgId) }
+        assertEquals("minecraft:white_concrete", itemId)
+        assertEquals("White Concrete", name)
+
+        // After: the breakdown re-derives White Concrete through its White Concrete Powder input.
+        val after = client.get("/worlds/$worldId/projects/$pid/detail-content?lens=list") {
+            addAuthCookie(this)
+        }.bodyAsText()
+        assertContains(after, "White Concrete Powder")
+    }
+
+    @Test
     fun `swap re-derives the plan through the new item's own dependencies`() = testApplication {
         val pid = createProject(worldId)
         val rgId = createResourceGathering(pid, "minecraft:birch_planks", "Birch Planks", 8)
@@ -130,7 +165,7 @@ class SwapResourceGatheringVariantIT : WithUser() {
     }
 
     @Test
-    fun `GET detail-panel lists the same-tag-family variant as a candidate`() = testApplication {
+    fun `GET detail-panel shows tag-family suggestions and the free-text search combo`() = testApplication {
         val pid = createProject(worldId)
         val rgId = createResourceGathering(pid, "minecraft:birch_planks", "Birch Planks", 8)
         setupRoutes()
@@ -140,15 +175,21 @@ class SwapResourceGatheringVariantIT : WithUser() {
         ) { addAuthCookie(this) }
 
         assertEquals(HttpStatusCode.OK, response.status)
-        assertContains(response.bodyAsText(), "Spruce Planks")
+        val body = response.bodyAsText()
+        // Tag-family sibling surfaces as a "Suggested" quick-swap chip.
+        assertContains(body, "Suggested")
+        assertContains(body, "Spruce Planks")
+        // The free-text search combo is present for any-item swaps (reuses /items/search).
+        assertContains(body, "resource-panel-variant-results")
+        assertContains(body, "/items/search")
     }
 
     // -------------------------------------------------------------------------
-    // Validation failure: swapping to a non-variant is rejected
+    // Validation failure: swapping to an unknown item is rejected
     // -------------------------------------------------------------------------
 
     @Test
-    fun `PATCH variant with an itemId outside the tag family returns 422`() = testApplication {
+    fun `PATCH variant with an unknown item id returns 422`() = testApplication {
         val pid = createProject(worldId)
         val rgId = createResourceGathering(pid, "minecraft:birch_planks", "Birch Planks", 8)
         setupRoutes()
@@ -158,7 +199,8 @@ class SwapResourceGatheringVariantIT : WithUser() {
         ) {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("itemId=minecraft:oak_log")
+            // Not present in the version catalog — rejected even though it looks like a real id.
+            setBody("itemId=minecraft:does_not_exist")
         }
 
         assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
@@ -439,5 +481,22 @@ class SwapResourceGatheringVariantIT : WithUser() {
         val sprucePlanksSource = source(version, "minecraft:crafting_shapeless", "spruce_planks_from_spruce_log.json")
         consumedItem(version, sprucePlanksSource, "minecraft:spruce_log", 1)
         producedItem(version, sprucePlanksSource, "minecraft:spruce_planks", 4)
+
+        // Stone and White Concrete share NO tag — the any-item swap (MCO-246 pivot). Stone is a
+        // raw-gather block; white concrete is crafted from white concrete powder (also raw), so a
+        // stone -> white_concrete swap re-derives the breakdown to a new dependency.
+        item(version, "minecraft:stone", "Stone")
+        item(version, "minecraft:white_concrete", "White Concrete")
+        item(version, "minecraft:white_concrete_powder", "White Concrete Powder")
+
+        val stoneSource = source(version, "minecraft:block", "blocks/stone.json")
+        producedItem(version, stoneSource, "minecraft:stone", 1)
+
+        val powderSource = source(version, "minecraft:block", "blocks/white_concrete_powder.json")
+        producedItem(version, powderSource, "minecraft:white_concrete_powder", 1)
+
+        val concreteSource = source(version, "minecraft:crafting_shapeless", "white_concrete_from_powder.json")
+        consumedItem(version, concreteSource, "minecraft:white_concrete_powder", 1)
+        producedItem(version, concreteSource, "minecraft:white_concrete", 1)
     }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/SwapResourceGatheringVariantIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/SwapResourceGatheringVariantIT.kt
@@ -1,0 +1,443 @@
+package app.mcorg.presentation.handler.project
+
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.project.handleGetDetailContent
+import app.mcorg.pipeline.resources.handleGetResourceDetailPanel
+import app.mcorg.pipeline.resources.handleSwapResourceGatheringVariant
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.ProjectParamPlugin
+import app.mcorg.presentation.plugins.ResourceGatheringIdParamPlugin
+import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
+import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.get
+import io.ktor.client.request.patch
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.get
+import io.ktor.server.routing.patch
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Integration tests for MCO-246: PATCH /resources/gathering/{id}/variant.
+ *
+ * The Testcontainers DB carries no ingested Minecraft data (see [PlanChainIT]'s note), so this
+ * class seeds a small, self-contained fake "Minecraft version" graph directly into the
+ * `minecraft_tag`/`minecraft_tag_item`/`resource_source*` tables — the same tables real
+ * ingestion writes to (see `StoreServerDataSteps.kt`) — giving [GetItemSourceGraphForVersionStep]
+ * real tag/member and recipe data to build a graph from, without depending on a real ingest.
+ *
+ * The fake graph models: a "planks" tag (birch/spruce) usable for sticks, birch planks crafted
+ * from an oak log, spruce planks crafted from a spruce log, and raw (source-less-input) log
+ * gathering — enough to prove a variant swap re-routes the derived "How to make it" breakdown
+ * through a different raw material (oak log -> spruce log).
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class SwapResourceGatheringVariantIT : WithUser() {
+
+    // Unique per test class so CacheManager's in-memory graph cache (keyed by version string)
+    // never collides with another test class's version, even if surefire reuses the JVM fork.
+    private val fakeVersion = "246.0.0"
+
+    private var worldId: Int = 0
+
+    @BeforeAll
+    fun setup() {
+        runBlocking { seedFakeGraph(fakeVersion) }
+        worldId = createWorld(fakeVersion)
+    }
+
+    // -------------------------------------------------------------------------
+    // Success: swap changes the row + re-derives the plan with new dependencies
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `PATCH variant swaps the item id and name and persists it`() = testApplication {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:birch_planks", "Birch Planks", 8)
+        setupRoutes()
+
+        val response = client.patch(
+            "/worlds/$worldId/projects/$pid/resources/gathering/$rgId/variant"
+        ) {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("itemId=minecraft:spruce_planks")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertContains(body, "id=\"plan-resources-area\"")
+        // The row's own item cell now reads the new name. (The OOB variant panel legitimately
+        // still mentions "Birch Planks" as the swap-back candidate, so we assert on the row
+        // cell specifically rather than the whole body's absence of the old name.)
+        assertContains(body, "<td class=\"plan-resource-table__item\">Spruce Planks</td>")
+        assertFalse(body.contains("<td class=\"plan-resource-table__item\">Birch Planks</td>"))
+
+        val (itemId, name) = runBlocking { readResource(rgId) }
+        assertEquals("minecraft:spruce_planks", itemId)
+        assertEquals("Spruce Planks", name)
+    }
+
+    @Test
+    fun `swap re-derives the plan through the new item's own dependencies`() = testApplication {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:birch_planks", "Birch Planks", 8)
+        setupRoutes()
+
+        // Before the swap: the breakdown derives birch planks from an oak log.
+        val before = client.get("/worlds/$worldId/projects/$pid/detail-content?lens=list") {
+            addAuthCookie(this)
+        }.bodyAsText()
+        assertContains(before, "Oak Log")
+        assertFalse(before.contains("Spruce Log"))
+
+        client.patch("/worlds/$worldId/projects/$pid/resources/gathering/$rgId/variant") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("itemId=minecraft:spruce_planks")
+        }
+
+        // After the swap: the breakdown derives spruce planks from a spruce log instead.
+        val after = client.get("/worlds/$worldId/projects/$pid/detail-content?lens=list") {
+            addAuthCookie(this)
+        }.bodyAsText()
+        assertContains(after, "Spruce Log")
+        assertFalse(after.contains("Oak Log"))
+    }
+
+    @Test
+    fun `GET detail-panel lists the same-tag-family variant as a candidate`() = testApplication {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:birch_planks", "Birch Planks", 8)
+        setupRoutes()
+
+        val response = client.get(
+            "/worlds/$worldId/projects/$pid/resources/gathering/$rgId/detail-panel"
+        ) { addAuthCookie(this) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertContains(response.bodyAsText(), "Spruce Planks")
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation failure: swapping to a non-variant is rejected
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `PATCH variant with an itemId outside the tag family returns 422`() = testApplication {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:birch_planks", "Birch Planks", 8)
+        setupRoutes()
+
+        val response = client.patch(
+            "/worlds/$worldId/projects/$pid/resources/gathering/$rgId/variant"
+        ) {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("itemId=minecraft:oak_log")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        val (itemId, _) = runBlocking { readResource(rgId) }
+        assertEquals("minecraft:birch_planks", itemId, "item must not change when validation fails")
+    }
+
+    @Test
+    fun `PATCH variant with a missing itemId returns 400`() = testApplication {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:birch_planks", "Birch Planks", 8)
+        setupRoutes()
+
+        val response = client.patch(
+            "/worlds/$worldId/projects/$pid/resources/gathering/$rgId/variant"
+        ) {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("")
+        }
+
+        // A missing (not merely invalid) parameter is a MissingParameter failure -> 400,
+        // distinct from the 422 an out-of-family itemId gets (see the test above).
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    // -------------------------------------------------------------------------
+    // Auth
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `PATCH variant without auth returns redirect`() = testApplication {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:birch_planks", "Birch Planks", 8)
+        setupRoutes()
+
+        val unauthClient = createClient { followRedirects = false }
+        val response = unauthClient.patch(
+            "/worlds/$worldId/projects/$pid/resources/gathering/$rgId/variant"
+        ) {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("itemId=minecraft:spruce_planks")
+        }
+
+        assertEquals(HttpStatusCode.Found, response.status)
+    }
+
+    @Test
+    fun `PATCH variant by a non-member of the world returns 403`() = testApplication {
+        val pid = createProject(worldId)
+        val rgId = createResourceGathering(pid, "minecraft:birch_planks", "Birch Planks", 8)
+        setupRoutes()
+
+        val nonMember = createExtraUser()
+        val response = client.patch(
+            "/worlds/$worldId/projects/$pid/resources/gathering/$rgId/variant"
+        ) {
+            addAuthCookie(this, nonMember)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("itemId=minecraft:spruce_planks")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    // -------------------------------------------------------------------------
+    // Routing setup
+    // -------------------------------------------------------------------------
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
+                install(UpdateActiveWorldPlugin)
+                route("/projects/{projectId}") {
+                    install(ProjectParamPlugin)
+                    get("/detail-content") { call.handleGetDetailContent() }
+                    route("/resources/gathering/{resourceGatheringId}") {
+                        install(ResourceGatheringIdParamPlugin)
+                        get("/detail-panel") { call.handleGetResourceDetailPanel() }
+                        patch("/variant") { call.handleSwapResourceGatheringVariant() }
+                    }
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // DB fixture helpers
+    // -------------------------------------------------------------------------
+
+    private fun createWorld(version: String): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(
+                name = "SwapVariant IT World",
+                description = "test",
+                version = MinecraftVersion.fromString(version)
+            )
+        )
+        (result as Result.Success).value
+    }
+
+    private fun createProject(worldId: Int): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, location_x, location_y, location_z, location_dimension) " +
+                        "VALUES ('SwapVariant IT Project', ?, '', 'BUILDING', 'PLANNING', 0, 0, 0, 'OVERWORLD') RETURNING id"
+            ),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, worldId) }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun createResourceGathering(projectId: Int, itemId: String, name: String, required: Int): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO resource_gathering (project_id, item_id, name, required) VALUES (?, ?, ?, ?) RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+                stmt.setString(3, name)
+                stmt.setInt(4, required)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private suspend fun readResource(rgId: Int): Pair<String, String> {
+        val result = DatabaseSteps.query<Int, Pair<String, String>>(
+            sql = SafeSQL.select("SELECT item_id, name FROM resource_gathering WHERE id = ?"),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) },
+            resultMapper = { rs ->
+                rs.next()
+                rs.getString("item_id") to rs.getString("name")
+            }
+        ).process(rgId)
+        return (result as Result.Success).value
+    }
+
+    private suspend fun item(version: String, itemId: String, name: String) {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO minecraft_items (version, item_id, item_name) VALUES (?, ?, ?) " +
+                        "ON CONFLICT (version, item_id) DO NOTHING"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, version)
+                stmt.setString(2, itemId)
+                stmt.setString(3, name)
+            }
+        ).process(Unit)
+    }
+
+    private suspend fun tag(version: String, tag: String, name: String) {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO minecraft_tag (version, tag, name) VALUES (?, ?, ?) ON CONFLICT (version, tag) DO NOTHING"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, version)
+                stmt.setString(2, tag)
+                stmt.setString(3, name)
+            }
+        ).process(Unit)
+    }
+
+    private suspend fun tagItem(version: String, tag: String, itemId: String) {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO minecraft_tag_item (version, tag, item) VALUES (?, ?, ?) " +
+                        "ON CONFLICT (version, tag, item) DO NOTHING"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, version)
+                stmt.setString(2, tag)
+                stmt.setString(3, itemId)
+            }
+        ).process(Unit)
+    }
+
+    /** Inserts a `resource_source` row and returns its generated id. */
+    private suspend fun source(version: String, sourceType: String, filename: String): Int {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO resource_source (version, source_type, created_from_filename) VALUES (?, ?, ?) RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, version)
+                stmt.setString(2, sourceType)
+                stmt.setString(3, filename)
+            }
+        ).process(Unit)
+        return (result as Result.Success).value
+    }
+
+    private suspend fun consumedItem(version: String, sourceId: Int, itemId: String, count: Int) {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO resource_source_consumed_item (version, resource_source_id, item, count) VALUES (?, ?, ?, ?)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, version)
+                stmt.setInt(2, sourceId)
+                stmt.setString(3, itemId)
+                stmt.setInt(4, count)
+            }
+        ).process(Unit)
+    }
+
+    private suspend fun consumedTag(version: String, sourceId: Int, tag: String, count: Int) {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO resource_source_consumed_tag (version, resource_source_id, tag, count) VALUES (?, ?, ?, ?)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, version)
+                stmt.setInt(2, sourceId)
+                stmt.setString(3, tag)
+                stmt.setInt(4, count)
+            }
+        ).process(Unit)
+    }
+
+    private suspend fun producedItem(version: String, sourceId: Int, itemId: String, count: Int) {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO resource_source_produced_item (version, resource_source_id, item, count) VALUES (?, ?, ?, ?)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, version)
+                stmt.setInt(2, sourceId)
+                stmt.setString(3, itemId)
+                stmt.setInt(4, count)
+            }
+        ).process(Unit)
+    }
+
+    /**
+     * Seeds a small fake graph for [version] directly into the ingestion tables:
+     * - `#test:planks` tag containing birch_planks + spruce_planks (used by a "sticks from any
+     *   planks" recipe, so the tag becomes a graph node — see [findVariantCandidates]'s doc).
+     * - birch_planks crafted from an oak log; spruce_planks crafted from a spruce log.
+     * - oak_log / spruce_log are raw-gather terminals (a source with no inputs).
+     */
+    private suspend fun seedFakeGraph(version: String) {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert("INSERT INTO minecraft_version (version) VALUES (?) ON CONFLICT (version) DO NOTHING"),
+            parameterSetter = { stmt, _ -> stmt.setString(1, version) }
+        ).process(Unit)
+
+        item(version, "minecraft:oak_log", "Oak Log")
+        item(version, "minecraft:spruce_log", "Spruce Log")
+        item(version, "minecraft:birch_planks", "Birch Planks")
+        item(version, "minecraft:spruce_planks", "Spruce Planks")
+        item(version, "minecraft:stick", "Stick")
+
+        tag(version, "#test:planks", "Planks")
+        tagItem(version, "#test:planks", "minecraft:birch_planks")
+        tagItem(version, "#test:planks", "minecraft:spruce_planks")
+
+        val stickSource = source(version, "minecraft:crafting_shapeless", "stick_from_planks.json")
+        consumedTag(version, stickSource, "#test:planks", 2)
+        producedItem(version, stickSource, "minecraft:stick", 4)
+
+        val oakLogSource = source(version, "minecraft:block", "blocks/oak_log.json")
+        producedItem(version, oakLogSource, "minecraft:oak_log", 1)
+
+        val spruceLogSource = source(version, "minecraft:block", "blocks/spruce_log.json")
+        producedItem(version, spruceLogSource, "minecraft:spruce_log", 1)
+
+        val birchPlanksSource = source(version, "minecraft:crafting_shapeless", "birch_planks_from_oak_log.json")
+        consumedItem(version, birchPlanksSource, "minecraft:oak_log", 1)
+        producedItem(version, birchPlanksSource, "minecraft:birch_planks", 4)
+
+        val sprucePlanksSource = source(version, "minecraft:crafting_shapeless", "spruce_planks_from_spruce_log.json")
+        consumedItem(version, sprucePlanksSource, "minecraft:spruce_log", 1)
+        producedItem(version, sprucePlanksSource, "minecraft:spruce_planks", 4)
+    }
+}


### PR DESCRIPTION
Lets a user swap an end-item in the "What I need" list to **any other item** without re-importing — the gathering plan re-derives from the new target. Covers both tag-family variants (birch → spruce planks) and unrelated swaps (Stone → Concrete, which share no tag).

## Design (per owner's "let the user decide")
- **Free item picker.** The resource-detail panel's "Replace item" section reuses the existing `/items/search` combo (the same one the idea create-wizard uses) — search the full catalog, scoped to the project's Minecraft version, and pick any item.
- **Tag-family as suggestions.** `findVariantCandidates` (siblings of any tag the item belongs to) is demoted to a one-click "Suggested" chip row above the search; omitted entirely when there are none (no dead-end). So common wood/wool/log/colour swaps are one click, everything else via search.
- **Swap = target-list edit, no engine change.** `PATCH /.../gathering/{id}/variant` updates the `resource_gathering` row's `item_id` + `name`; the plan re-derives on read (`GenerateGatheringPlanStep`). No migration, no `mc-engine`/`mc-data` change. `resource_gathering_progress` is keyed by `(project_id, item_id)`, so a swap correctly starts the new item at 0 collected.

## Validation & safety
- Chosen `itemId` validated server-side against `GetItemsInWorldVersionStep(worldId)` — the exact catalog for the project's version (same source `handleCreateResourceGatheringItem` uses). Missing id → 400; present-but-unknown id → 422. The stored name is taken from the catalog, never the client.
- Auth inherited from the `/{worldId}` membership gate (MCO-247) — no auth in route or pipeline.
- JS: `/items/search` results carry a page-global inline `onclick` meant for the add-resource form; the panel intercepts option clicks in the **capture phase** (`stopPropagation`) and issues the swap itself, so the shared search JS isn't forked or touched.

## Tests
- `SwapResourceGatheringVariantIT`: a no-shared-tag **Stone → White Concrete** swap succeeds and the "How to make it" breakdown re-derives to gain White Concrete Powder (proves the any-item path); panel shows both suggestions + search; unknown catalog item (`minecraft:does_not_exist`) → 422.
- `VariantDiscoveryTest`: suggestion logic (unchanged).
- `mvn clean compile` clean; 680 unit pass; database ITs 26/26.

## Known minor gap
The panel search has no arrow-key nav (mouse/tap selection only) — `plan-view.js`'s key-nav is bound to the add-resource input specifically. Left out to keep scope tight; easy to add if wanted.

Closes MCO-246. `preview` label applied — ephemeral Fly app will deploy for eyeballing the picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)