### PR TITLE
Redesign the Worlds page (empty state, hero, roster, create flow)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,8 @@ mvn clean compile                   # Compile (must pass with zero errors)
 ./webapp/scripts/test.sh            # Run tests — see "Running Tests" below (NOT bare `mvn test`)
 sudo service docker start           # Start Docker if not running (passwordless)
 ./webapp/scripts/start-db.sh        # Start the database
-./webapp/scripts/migrate-locally.sh # Apply database migrations
+./webapp/scripts/migrate-locally.sh # Apply migrations to the localhost Docker DB (main checkout)
+./webapp/scripts/migrate-worktree.sh # Apply migrations to the DB local.env points at (worktree Neon branch)
 ./webapp/scripts/run.sh             # Start development server
 ./webapp/scripts/ingest-locally.sh  # Ingest Minecraft data into the local/worktree DB
 ```
@@ -186,6 +187,10 @@ the real ingested Minecraft data instantly (no re-ingestion) and matches CI exac
 - `webapp/scripts/worktree-db.sh` — fork Neon branch + point `local.env` at it + migrate
 - `webapp/scripts/worktree-db-cleanup.sh` — delete the current worktree's branch
 - `webapp/scripts/worktree-db-cleanup.sh --prune` — delete all orphaned `wt/*` branches
+- `webapp/scripts/migrate-worktree.sh` — apply Flyway migrations to the DB `local.env`
+  points at (the worktree's Neon branch), reading its `DB_*` creds. Use this after
+  adding a migration in a worktree — `migrate-locally.sh` hardcodes the localhost
+  Docker DB and will not touch the branch.
 
 ## Issue Tracking
 

--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/world/World.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/world/World.kt
@@ -11,5 +11,7 @@ data class World(
     val completedProjects: Int,
     val totalProjects: Int,
     val createdAt: ZonedDateTime,
-    val updatedAt: ZonedDateTime
+    val updatedAt: ZonedDateTime,
+    val pinned: Boolean = false,
+    val lastOpenedAt: ZonedDateTime? = null
 )

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectListPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectListPipeline.kt
@@ -9,6 +9,7 @@ import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
 import app.mcorg.pipeline.project.commonsteps.GetProjectPlanListStep
 import app.mcorg.pipeline.world.commonsteps.GetWorldMemberStep
 import app.mcorg.pipeline.world.commonsteps.GetWorldStep
+import app.mcorg.pipeline.world.commonsteps.UpdateWorldLastOpenedStep
 import app.mcorg.presentation.handler.handlePipeline
 import app.mcorg.presentation.templated.dsl.ResumeHeroData
 import app.mcorg.presentation.templated.dsl.pages.projectListPage
@@ -34,6 +35,10 @@ suspend fun ApplicationCall.handleGetProjectList() {
     val user = getUser()
     val worldId = getWorldId()
     val view = request.queryParameters["view"]?.takeIf { it == "plan" } ?: "execute"
+
+    // Best-effort: record that this user just opened the world (drives the Worlds-page
+    // "opened Xh ago" line and recency sort). Ignore failures — must not block the page.
+    UpdateWorldLastOpenedStep(user.id).process(worldId)
 
     if (view == "plan") {
         handlePipeline(

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/CreateWorldPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/CreateWorldPipeline.kt
@@ -11,9 +11,11 @@ import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.ValidationSteps
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.failure.ValidationFailure
+import app.mcorg.pipeline.invitation.commonsteps.GetUserInvitationsStep
 import app.mcorg.pipeline.minecraftfiles.GetSupportedVersionsStep
 import app.mcorg.pipeline.world.commonsteps.GetPermittedWorldsInput
 import app.mcorg.pipeline.world.commonsteps.GetPermittedWorldsStep
+import app.mcorg.pipeline.world.commonsteps.GetWorldProjectPeekStep
 import app.mcorg.presentation.handler.handlePipeline
 import app.mcorg.presentation.templated.dsl.pages.worldsContent
 import app.mcorg.presentation.utils.getUser
@@ -30,11 +32,18 @@ suspend fun ApplicationCall.handleCreateWorld() {
     val user = this.getUser()
 
     handlePipeline(
-        onSuccess = { worlds ->
+        onSuccess = { result ->
             val supportedVersions = GetSupportedVersionsStep.getSupportedVersions()
             respondHtml(createHTML().div {
                 id = "worlds-content"
-                worldsContent(user, worlds, supportedVersions)
+                worldsContent(
+                    user,
+                    result.worlds,
+                    supportedVersions,
+                    result.invitations,
+                    result.heroPeek,
+                    result.createdWorldId,
+                )
             })
         }
     ) {
@@ -42,9 +51,21 @@ suspend fun ApplicationCall.handleCreateWorld() {
         val worldId = CreateWorldStep(user).run(input)
         CacheManager.onWorldCreated(worldId)
         CacheManager.onMemberAdded(user.id, worldId)
-        GetPermittedWorldsStep.run(GetPermittedWorldsInput(userId = user.id))
+        val worlds = GetPermittedWorldsStep.run(GetPermittedWorldsInput(userId = user.id))
+        val invitations = GetUserInvitationsStep.run(user.id)
+        val heroPeek = worlds.firstOrNull()
+            ?.let { GetWorldProjectPeekStep().run(it.id) }
+            ?: emptyList()
+        CreatedWorldResult(worlds, worldId, invitations, heroPeek)
     }
 }
+
+private data class CreatedWorldResult(
+    val worlds: List<app.mcorg.domain.model.world.World>,
+    val createdWorldId: Int,
+    val invitations: List<app.mcorg.domain.model.invite.Invite>,
+    val heroPeek: List<app.mcorg.pipeline.world.commonsteps.WorldProjectPeek>,
+)
 
 object ValidateWorldInputStep : Step<Parameters, AppFailure.ValidationError, CreateWorldInput> {
     override suspend fun process(input: Parameters): Result<AppFailure.ValidationError, CreateWorldInput> {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/ToggleWorldPinPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/ToggleWorldPinPipeline.kt
@@ -1,0 +1,63 @@
+package app.mcorg.pipeline.world
+
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.invitation.commonsteps.GetUserInvitationsStep
+import app.mcorg.pipeline.minecraftfiles.GetSupportedVersionsStep
+import app.mcorg.pipeline.world.commonsteps.GetPermittedWorldsInput
+import app.mcorg.pipeline.world.commonsteps.GetPermittedWorldsStep
+import app.mcorg.pipeline.world.commonsteps.GetWorldProjectPeekStep
+import app.mcorg.presentation.handler.handlePipeline
+import app.mcorg.presentation.templated.dsl.pages.worldsContent
+import app.mcorg.presentation.utils.getUser
+import app.mcorg.presentation.utils.getWorldId
+import app.mcorg.presentation.utils.respondHtml
+import io.ktor.server.application.ApplicationCall
+import kotlinx.html.div
+import kotlinx.html.id
+import kotlinx.html.stream.createHTML
+
+/**
+ * Flips this user's pin on a world. Pin is per (user, world), stored on world_members;
+ * pinned worlds sort above the rest on the Worlds page. Re-renders #worlds-content so
+ * the newly (un)pinned world moves to/from the top and the hero updates.
+ */
+data class ToggleWorldPinStep(val userId: Int) : Step<Int, AppFailure.DatabaseError, Int> {
+    override suspend fun process(input: Int): Result<AppFailure.DatabaseError, Int> {
+        return DatabaseSteps.update<Int>(
+            SafeSQL.update(
+                "UPDATE world_members SET pinned = NOT pinned WHERE user_id = ? AND world_id = ?"
+            ),
+            parameterSetter = { statement, worldId ->
+                statement.setInt(1, userId)
+                statement.setInt(2, worldId)
+            }
+        ).process(input)
+    }
+}
+
+suspend fun ApplicationCall.handleTogglePin() {
+    val user = getUser()
+    val worldId = getWorldId()
+
+    handlePipeline(
+        onSuccess = { (worlds, invitations, heroPeek) ->
+            val supportedVersions = GetSupportedVersionsStep.getSupportedVersions()
+            respondHtml(createHTML().div {
+                id = "worlds-content"
+                worldsContent(user, worlds, supportedVersions, invitations, heroPeek)
+            })
+        }
+    ) {
+        ToggleWorldPinStep(user.id).run(worldId)
+        val worlds = GetPermittedWorldsStep.run(GetPermittedWorldsInput(userId = user.id))
+        val invitations = GetUserInvitationsStep.run(user.id)
+        val heroPeek = worlds.firstOrNull()
+            ?.let { GetWorldProjectPeekStep().run(it.id) }
+            ?: emptyList()
+        Triple(worlds, invitations, heroPeek)
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/commonsteps/GetPermittedWorldsStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/commonsteps/GetPermittedWorldsStep.kt
@@ -16,28 +16,31 @@ data class GetPermittedWorldsInput(
 
 object GetPermittedWorldsStep : Step<GetPermittedWorldsInput, AppFailure.DatabaseError, List<World>> {
     override suspend fun process(input: GetPermittedWorldsInput): Result<AppFailure.DatabaseError, List<World>> {
+        // Redesigned Worlds page ordering: a user's pinned worlds first, then the
+        // most-recently-opened. `name_asc` still respects the pin, for the search API.
         val sortByValue = when(input.sortBy) {
-            "name_asc" -> "w.name ASC, w.updated_at DESC"
-            "lastModified_desc" -> "w.updated_at DESC, w.name ASC"
-            else -> "w.updated_at DESC, w.name ASC"
+            "name_asc" -> "wm.pinned DESC, w.name ASC"
+            else -> "wm.pinned DESC, wm.last_opened_at DESC NULLS LAST, w.updated_at DESC, w.name ASC"
         }
 
         return DatabaseSteps.query<GetPermittedWorldsInput, List<World>>(
             sql = SafeSQL.select("""
-                SELECT 
-                    w.id, 
-                    w.name, 
-                    w.description, 
-                    w.version, 
-                    w.created_at, 
+                SELECT
+                    w.id,
+                    w.name,
+                    w.description,
+                    w.version,
+                    w.created_at,
                     w.updated_at,
+                    wm.pinned,
+                    wm.last_opened_at,
                     COALESCE(COUNT(DISTINCT p.id), 0) as total_projects,
                     COALESCE(COUNT(DISTINCT CASE WHEN p.stage = 'COMPLETED' THEN p.id END), 0) as completed_projects
                 FROM world w
                 INNER JOIN world_members wm ON w.id = wm.world_id
                 LEFT JOIN projects p ON w.id = p.world_id
                 WHERE wm.user_id = ? AND (? = '' OR LOWER(w.name) ILIKE '%' || ? || '%' OR LOWER(w.description) ILIKE '%' || ? || '%')
-                GROUP BY w.id, w.name, w.description, w.version, w.created_at, w.updated_at
+                GROUP BY w.id, w.name, w.description, w.version, w.created_at, w.updated_at, wm.pinned, wm.last_opened_at
                 ORDER BY $sortByValue
             """.trimIndent()),
             parameterSetter = { statement, inputData ->
@@ -51,7 +54,13 @@ object GetPermittedWorldsStep : Step<GetPermittedWorldsInput, AppFailure.Databas
             resultMapper = { resultSet ->
                 buildList {
                     while (resultSet.next()) {
-                        add(resultSet.toWorld())
+                        add(
+                            resultSet.toWorld().copy(
+                                pinned = resultSet.getBoolean("pinned"),
+                                lastOpenedAt = resultSet.getTimestamp("last_opened_at")
+                                    ?.toInstant()?.atZone(java.time.ZoneOffset.UTC)
+                            )
+                        )
                     }
                 }
             }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/commonsteps/GetWorldProjectPeekStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/commonsteps/GetWorldProjectPeekStep.kt
@@ -1,0 +1,53 @@
+package app.mcorg.pipeline.world.commonsteps
+
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.domain.pipeline.Step
+
+/** A single project in the Worlds-page hero "active projects" peek. */
+data class WorldProjectPeek(
+    val name: String,
+    val state: ProjectState
+)
+
+/**
+ * Top non-terminal projects for a world's hero peek: active work first, then paused,
+ * then pending, most-recently-updated within each. Terminal projects (done/cancelled/
+ * archived) are excluded. Limited to a handful — the hero only shows a glance.
+ */
+data class GetWorldProjectPeekStep(val limit: Int = 3) : Step<Int, AppFailure.DatabaseError, List<WorldProjectPeek>> {
+    override suspend fun process(input: Int): Result<AppFailure.DatabaseError, List<WorldProjectPeek>> {
+        return DatabaseSteps.query<Int, List<WorldProjectPeek>>(
+            sql = SafeSQL.select(
+                """
+                SELECT name, state
+                FROM projects
+                WHERE world_id = ? AND state IN ('ACTIVE', 'PAUSED', 'PENDING')
+                ORDER BY
+                    CASE state WHEN 'ACTIVE' THEN 0 WHEN 'PAUSED' THEN 1 ELSE 2 END,
+                    updated_at DESC
+                LIMIT ?
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, worldId ->
+                statement.setInt(1, worldId)
+                statement.setInt(2, limit)
+            },
+            resultMapper = { resultSet ->
+                buildList {
+                    while (resultSet.next()) {
+                        add(
+                            WorldProjectPeek(
+                                name = resultSet.getString("name"),
+                                state = ProjectState.valueOf(resultSet.getString("state"))
+                            )
+                        )
+                    }
+                }
+            }
+        ).process(input)
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/commonsteps/UpdateWorldLastOpenedStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/commonsteps/UpdateWorldLastOpenedStep.kt
@@ -1,0 +1,26 @@
+package app.mcorg.pipeline.world.commonsteps
+
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+
+/**
+ * Stamps when this user last opened a world, driving the "opened Xh ago" hero line and
+ * the most-recently-opened-first sort on the Worlds page. Per (user, world), on
+ * world_members. Called best-effort on world entry — a failure must not block the page.
+ */
+data class UpdateWorldLastOpenedStep(val userId: Int) : Step<Int, AppFailure.DatabaseError, Int> {
+    override suspend fun process(input: Int): Result<AppFailure.DatabaseError, Int> {
+        return DatabaseSteps.update<Int>(
+            SafeSQL.update(
+                "UPDATE world_members SET last_opened_at = CURRENT_TIMESTAMP WHERE user_id = ? AND world_id = ?"
+            ),
+            parameterSetter = { statement, worldId ->
+                statement.setInt(1, userId)
+                statement.setInt(2, worldId)
+            }
+        ).process(input)
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -43,6 +43,7 @@ import app.mcorg.pipeline.project.handleUpdateProjectLocation
 import app.mcorg.pipeline.world.handleCreateWorld
 import app.mcorg.pipeline.world.handleDeleteWorld
 import app.mcorg.pipeline.world.handleSearchWorlds
+import app.mcorg.pipeline.world.handleTogglePin
 import app.mcorg.pipeline.world.settings.general.handleUpdateWorldDescription
 import app.mcorg.pipeline.world.settings.general.handleUpdateWorldName
 import app.mcorg.pipeline.world.settings.general.handleUpdateWorldVersion
@@ -54,6 +55,7 @@ import app.mcorg.pipeline.world.settings.invitations.handleCreateInvitation
 import app.mcorg.pipeline.world.settings.invitations.handleGetInvitationListFragment
 import app.mcorg.pipeline.world.commonsteps.GetPermittedWorldsInput
 import app.mcorg.pipeline.world.commonsteps.GetPermittedWorldsStep
+import app.mcorg.pipeline.world.commonsteps.GetWorldProjectPeekStep
 import app.mcorg.pipeline.world.settings.members.handleRemoveWorldMember
 import app.mcorg.pipeline.world.settings.members.handleUpdateWorldMemberRole
 import app.mcorg.presentation.plugins.ActionTaskParamPlugin
@@ -92,6 +94,16 @@ class WorldHandler {
             }
             get("/search") {
                 call.handleSearchWorlds()
+            }
+            // Pin toggle lives on its own /pin/{worldId} subtree (static `pin` beats the
+            // `{worldId}` param branch) so it does NOT inherit UpdateActiveWorldPlugin —
+            // pinning a world must not hijack the user's active world. Still membership-gated.
+            route("/pin/{worldId}") {
+                install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
+                post {
+                    call.handleTogglePin()
+                }
             }
             route("/{worldId}") {
                 install(WorldParamPlugin)
@@ -291,13 +303,16 @@ class WorldHandler {
         val supportedVersions = GetSupportedVersionsStep.getSupportedVersions()
 
         handlePipeline(
-            onSuccess = { (worlds, invitations) ->
-                respondHtml(worldListPage(user, worlds, supportedVersions, invitations))
+            onSuccess = { (worlds, invitations, heroPeek) ->
+                respondHtml(worldListPage(user, worlds, supportedVersions, invitations, heroPeek))
             }
         ) {
             val worlds = GetPermittedWorldsStep.run(GetPermittedWorldsInput(userId = user.id))
             val invitations = GetUserInvitationsStep.run(user.id)
-            worlds to invitations
+            val heroPeek = worlds.firstOrNull()
+                ?.let { GetWorldProjectPeekStep().run(it.id) }
+                ?: emptyList()
+            Triple(worlds, invitations, heroPeek)
         }
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/Lucide.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/Lucide.kt
@@ -1,0 +1,45 @@
+package app.mcorg.presentation.templated.dsl
+
+import kotlinx.html.FlowContent
+
+/**
+ * Inline [Lucide](https://lucide.dev) line icon, emitted as a bare `<svg class="icon">`
+ * (no wrapper) so it sits directly as a flex child where the layout CSS expects it.
+ * Colour/stroke come from the `.icon` class (see pages/worlds.css); `filled = true` adds
+ * `.icon--fill` for solid glyphs (e.g. a pinned star). Sized in px per call because the
+ * design uses fine-grained icon sizes (13–34px) that the fixed IconSize enum can't express.
+ *
+ * This is deliberately separate from [Icons]/[iconComponent], which render the app's own
+ * Material-style SVG assets wrapped in a `div.icon`.
+ */
+fun FlowContent.lucide(
+    name: String,
+    size: Int = 16,
+    filled: Boolean = false,
+    vararg extraClasses: String,
+) {
+    val classes = buildList {
+        add("icon")
+        if (filled) add("icon--fill")
+        addAll(extraClasses)
+    }.joinToString(" ")
+
+    val body = lucidePath(name)
+    consumer.onTagContentUnsafe {
+        +"""<svg class="$classes" width="${size}px" height="${size}px" viewBox="0 0 24 24" aria-hidden="true">$body</svg>"""
+    }
+}
+
+private fun lucidePath(name: String): String = when (name) {
+    "box" -> """<path d="M21 8v8a2 2 0 0 1-1 1.73l-7 4a2 2 0 0 1-2 0l-7-4A2 2 0 0 1 3 16V8a2 2 0 0 1 1-1.73l7-4a2 2 0 0 1 2 0l7 4A2 2 0 0 1 21 8z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/>"""
+    "plus" -> """<path d="M12 5v14M5 12h14"/>"""
+    "arrow-right" -> """<path d="M5 12h14M13 6l6 6-6 6"/>"""
+    "layers" -> """<path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="m2 12 10 5 10-5"/><path d="m2 17 10 5 10-5"/>"""
+    "route" -> """<circle cx="6" cy="19" r="3"/><circle cx="18" cy="5" r="3"/><path d="M9 19h4a4 4 0 0 0 4-4V8"/>"""
+    "lightbulb" -> """<path d="M9 18h6M10 22h4"/><path d="M12 2a6 6 0 0 0-4 10.5c.8.8 1.2 1.3 1.4 2.2l.1.3h5l.1-.3c.2-.9.6-1.4 1.4-2.2A6 6 0 0 0 12 2z"/>"""
+    "star" -> """<path d="M12 3l2.6 5.3 5.9.9-4.3 4.1 1 5.8L12 16.9 6.8 19.2l1-5.8L3.5 9.2l5.9-.9z"/>"""
+    "chevron-down" -> """<path d="m6 9 6 6 6-6"/>"""
+    "check" -> """<path d="M20 6 9 17l-5-5"/>"""
+    "clock" -> """<circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>"""
+    else -> ""
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/WorldListPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/WorldListPage.kt
@@ -5,205 +5,405 @@ import app.mcorg.domain.model.invite.Invite
 import app.mcorg.domain.model.minecraft.MinecraftVersion
 import app.mcorg.domain.model.user.TokenProfile
 import app.mcorg.domain.model.world.World
-import app.mcorg.presentation.hxGet
-import app.mcorg.presentation.hxSwap
-import app.mcorg.presentation.hxTarget
-import app.mcorg.presentation.hxTrigger
+import app.mcorg.pipeline.world.commonsteps.WorldProjectPeek
+import app.mcorg.presentation.templated.dsl.Link
 import app.mcorg.presentation.templated.dsl.appHeader
+import app.mcorg.presentation.templated.dsl.badgeModifier
 import app.mcorg.presentation.templated.dsl.container
-import app.mcorg.presentation.templated.dsl.emptyState
+import app.mcorg.presentation.templated.dsl.label
+import app.mcorg.presentation.templated.dsl.lucide
 import app.mcorg.presentation.templated.dsl.modalForm
+import app.mcorg.presentation.templated.dsl.pageHeading
 import app.mcorg.presentation.templated.dsl.pageShell
-import app.mcorg.presentation.templated.dsl.worldCardList
+import app.mcorg.presentation.templated.dsl.progressBar
 import app.mcorg.presentation.templated.dsl.components.pendingInvitationsSection
+import app.mcorg.presentation.templated.utils.formatAsCompactRelative
+import kotlinx.html.ButtonType
+import kotlinx.html.FlowContent
 import kotlinx.html.InputType
+import kotlinx.html.a
+import kotlinx.html.b
 import kotlinx.html.button
-import kotlinx.html.classes
 import kotlinx.html.div
+import kotlinx.html.h1
 import kotlinx.html.id
 import kotlinx.html.input
 import kotlinx.html.label
+import kotlinx.html.li
 import kotlinx.html.main
-import kotlinx.html.option
 import kotlinx.html.p
-import kotlinx.html.select
 import kotlinx.html.span
 import kotlinx.html.textArea
+import kotlinx.html.ul
+
+private fun World.progressPercent(): Int =
+    if (totalProjects > 0) (completedProjects.coerceAtMost(totalProjects) * 100) / totalProjects else 0
 
 fun worldListPage(
     user: TokenProfile,
     worlds: List<World>,
     supportedVersions: List<MinecraftVersion.Release>,
-    pendingInvitations: List<Invite> = emptyList()
+    pendingInvitations: List<Invite> = emptyList(),
+    heroPeek: List<WorldProjectPeek> = emptyList(),
 ): String = pageShell(
     pageTitle = "Seam — Worlds",
     user = user,
     stylesheets = listOf(
         "/static/styles/components/common.css",
-        "/static/styles/components/world-card.css",
-        "/static/styles/components/empty-state.css",
-        "/static/styles/components/btn.css",
-        "/static/styles/components/modal.css",
+        "/static/styles/components/callout.css",
+        "/static/styles/components/progress.css",
+        "/static/styles/components/form.css",
         "/static/styles/components/pending-invitations.css",
-    )
+        "/static/styles/pages/worlds.css",
+    ),
+    scripts = listOf("/static/scripts/worlds.js"),
 ) {
     appHeader(user = user)
     main {
         container {
-            div {
-                id = "notice-container"
-            }
+            div { id = "notice-container" }
             div {
                 id = "worlds-content"
-                worldsContent(user, worlds, supportedVersions, pendingInvitations)
+                worldsContent(user, worlds, supportedVersions, pendingInvitations, heroPeek)
             }
         }
     }
 }
 
-fun kotlinx.html.FlowContent.worldsContent(
+fun FlowContent.worldsContent(
     user: TokenProfile,
     worlds: List<World>,
     supportedVersions: List<MinecraftVersion.Release>,
-    pendingInvitations: List<Invite> = emptyList()
+    pendingInvitations: List<Invite> = emptyList(),
+    heroPeek: List<WorldProjectPeek> = emptyList(),
+    justCreatedWorldId: Int? = null,
 ) {
-    pendingInvitationsSection(pendingInvitations)
+    div("worlds-main") {
+        pendingInvitationsSection(pendingInvitations)
 
-    if (worlds.isEmpty()) {
-        emptyState(
-            heading = "No worlds yet",
-            body = "Get started by creating your first Minecraft world to organize your projects."
-        ) {
-            createWorldModalButton(user, supportedVersions)
-        }
-    } else {
-        div("worlds-toolbar") {
-            input(classes = "form-control") {
-                id = "worlds-search-input"
-                type = InputType.search
-                name = "query"
-                placeholder = "Search worlds..."
-                hxGet("/worlds/search")
-                hxTarget("#world-card-list")
-                hxSwap("outerHTML")
-                hxTrigger("input changed delay:300ms, search")
+        if (worlds.isEmpty()) {
+            worldsEmptyState(user, supportedVersions)
+        } else {
+            val justCreated = justCreatedWorldId?.let { id -> worlds.firstOrNull { it.id == id } }
+            if (justCreated != null) {
+                div("callout callout--success worlds-callout") {
+                    attributes["role"] = "note"
+                    span("callout__icon") {
+                        attributes["aria-hidden"] = "true"
+                        +"✓"
+                    }
+                    div("callout__body") {
+                        span("callout__lead") { +"${justCreated.name} is ready." }
+                        +" Open it to plan your first project."
+                    }
+                }
             }
-            createWorldModalButton(user, supportedVersions)
-        }
-        worldCardList(worlds)
-    }
 
-    createWorldModal(user, supportedVersions)
+            div("worlds-head") {
+                pageHeading("Worlds", "${worlds.size} world${if (worlds.size == 1) "" else "s"}")
+                newWorldButton(user, primary = false, label = "New world")
+            }
+
+            val hero = worlds.first()
+            worldHero(
+                world = hero,
+                peek = heroPeek,
+                fresh = hero.id == justCreatedWorldId,
+                lead = worlds.size > 1,
+            )
+
+            val others = worlds.drop(1)
+            if (others.isNotEmpty()) {
+                div("section-label worlds-subsection") { +"Other worlds" }
+                div("worlds-roster") {
+                    others.forEach { worldRow(it) }
+                }
+            }
+        }
+
+        createWorldModal(user, supportedVersions)
+    }
 }
 
-private fun kotlinx.html.FlowContent.createWorldModalButton(
+private fun FlowContent.worldsEmptyState(
     user: TokenProfile,
-    supportedVersions: List<MinecraftVersion.Release>
+    supportedVersions: List<MinecraftVersion.Release>,
 ) {
+    div("worlds-empty") {
+        div("world-glyph") { lucide("box", 34) }
+        h1("worlds-empty__title") { +"No worlds yet" }
+        p("worlds-empty__text") {
+            +"A "
+            b { +"world" }
+            +" in Seam mirrors one of your Minecraft worlds — a singleplayer save or a server."
+        }
+        newWorldButton(user, primary = true, label = "Create world")
+        div("worlds-features") {
+            worldsFeature("layers", "Plan projects & tasks")
+            worldsFeature("route", "Generate resource paths")
+            worldsFeature("lightbulb", "Bank ideas for later")
+        }
+    }
+}
+
+private fun FlowContent.worldsFeature(icon: String, text: String) {
+    div("worlds-feature") {
+        lucide(icon, 20)
+        span { +text }
+    }
+}
+
+private fun FlowContent.newWorldButton(user: TokenProfile, primary: Boolean, label: String) {
     if (user.isDemoUserInProduction()) {
-        button {
-            classes = setOf("btn", "btn--primary")
+        button(classes = "btn ${if (primary) "btn--primary" else "btn--secondary"}") {
+            type = ButtonType.button
             disabled = true
-            +"Create World"
+            +label
         }
         p("worlds-demo-notice") {
             +"Demo users cannot create worlds. Please register for a full account."
         }
     } else {
-        button {
-            classes = setOf("btn", "btn--primary")
+        button(classes = "btn ${if (primary) "btn--primary" else "btn--secondary"}") {
+            type = ButtonType.button
             attributes["onclick"] = "document.getElementById('create-world-modal')?.showModal()"
-            +"Create World"
+            lucide("plus", 15)
+            +label
         }
     }
 }
 
-private fun kotlinx.html.FlowContent.createWorldModal(
+private fun FlowContent.worldHero(world: World, peek: List<WorldProjectPeek>, fresh: Boolean, lead: Boolean) {
+    val classes = buildString {
+        append("world-hero")
+        if (fresh) append(" world-hero--fresh")
+        if (lead) append(" world-hero--lead")
+    }
+    div(classes) {
+        div("world-hero__main") {
+            div("world-identity") {
+                if (!fresh) pinButton(world)
+                span("world-name") { +world.name }
+                span("badge badge--neutral") { +world.version.toString() }
+            }
+
+            if (fresh) {
+                div("world-meta world-hero__submeta") { +"created just now" }
+                div("world-hero__empty") {
+                    lucide("clock", 15)
+                    span { +"No projects yet — plan your first build." }
+                }
+            } else {
+                val opened = world.lastOpenedAt?.formatAsCompactRelative()
+                div("world-hero__meta world-meta") {
+                    +(if (opened != null) "opened $opened" else "not opened yet")
+                }
+                div("world-hero__body") {
+                    if (world.totalProjects == 0) {
+                        div("world-hero__empty") {
+                            lucide("clock", 15)
+                            span { +"No projects yet — plan your first build." }
+                        }
+                        openWorldButton(world)
+                    } else if (lead) {
+                        div("world-hero__body--row") {
+                            div("world-hero__progress-block") {
+                                div("world-stat") {
+                                    span("world-stat__count") { +"${world.totalProjects} projects · ${world.progressPercent()}%" }
+                                }
+                                progressBar(world.completedProjects, world.totalProjects, large = true)
+                            }
+                            openWorldButton(world)
+                        }
+                    } else {
+                        div("world-stat") {
+                            span("world-stat__count") { +"${world.totalProjects} project${if (world.totalProjects == 1) "" else "s"}" }
+                            span("world-stat__pct") { +"· ${world.progressPercent()}% overall" }
+                        }
+                        div("world-progress") {
+                            progressBar(world.completedProjects, world.totalProjects, large = true)
+                        }
+                        openWorldButton(world)
+                    }
+                }
+            }
+        }
+        div("world-hero__aside") {
+            if (fresh) {
+                div("world-hero__actions") {
+                    a(href = Link.Worlds.world(world.id).projects().to, classes = "btn btn--primary") {
+                        lucide("arrow-right", 15)
+                        +"Open & add first project"
+                    }
+                    a(href = Link.Ideas.to, classes = "btn btn--secondary") { +"Open Ideas bank" }
+                }
+            } else {
+                div("section-label") { +"Active projects" }
+                if (peek.isEmpty()) {
+                    div("world-hero__peek-empty") { +"No active projects" }
+                } else {
+                    peek.forEach { item ->
+                        div("world-peek__row") {
+                            span("world-peek__name") { +item.name }
+                            span("badge ${item.state.badgeModifier}") { +item.state.label }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun FlowContent.worldRow(world: World) {
+    div("world-row") {
+        pinButton(world)
+        a(href = Link.Worlds.world(world.id).projects().to, classes = "world-row__link") {
+            div("world-row__id") {
+                div("world-name") { +world.name }
+                div("world-meta") { +world.version.toString() }
+            }
+            div("world-row__progress") {
+                progressBar(world.completedProjects, world.totalProjects, large = false)
+                span("world-row__pct") { +"${world.totalProjects} proj · ${world.progressPercent()}%" }
+            }
+            span("world-row__time") { +(world.lastOpenedAt?.formatAsCompactRelative() ?: "never") }
+            lucide("arrow-right", 16, false, "world-row__go")
+        }
+    }
+}
+
+private fun FlowContent.pinButton(world: World) {
+    button(classes = "pin-btn${if (world.pinned) " pin-btn--on" else ""}") {
+        type = ButtonType.button
+        attributes["hx-post"] = "/worlds/pin/${world.id}"
+        attributes["hx-target"] = "#worlds-content"
+        attributes["hx-swap"] = "outerHTML"
+        attributes["aria-pressed"] = world.pinned.toString()
+        attributes["aria-label"] = if (world.pinned) "Unpin ${world.name}" else "Pin ${world.name}"
+        lucide("star", 16, filled = world.pinned)
+    }
+}
+
+private fun FlowContent.openWorldButton(world: World) {
+    a(href = Link.Worlds.world(world.id).projects().to, classes = "btn btn--primary") {
+        lucide("arrow-right", 15)
+        +"Open world"
+    }
+}
+
+private fun FlowContent.createWorldModal(
     user: TokenProfile,
-    supportedVersions: List<MinecraftVersion.Release>
+    supportedVersions: List<MinecraftVersion.Release>,
 ) {
     modalForm(
         id = "create-world-modal",
-        title = "Create World",
+        title = "Create world",
         action = "/worlds",
         hxTarget = "#worlds-content",
         hxSwap = "outerHTML",
-        errorTarget = ".form-error"
+        errorTarget = ".form-error",
     ) {
+        p("worlds-modal-intro") { +"Match it to a Minecraft save or server. You can rename it later." }
+
         if (user.isDemoUserInProduction()) {
             p("form-error") {
                 +"Demo users cannot create worlds. Please register for a full account."
             }
         }
 
-        label {
+        label("form-label") {
             htmlFor = "create-world-name"
-            +"World Name"
-            span("required-indicator") { +"*" }
+            +"World name"
         }
         input(classes = "form-control") {
             id = "create-world-name"
             type = InputType.text
             name = "name"
-            placeholder = "My survival world"
+            placeholder = "e.g. Survival, SkyBlock SMP"
             maxLength = "100"
             minLength = "3"
             required = true
             if (user.isDemoUserInProduction()) disabled = true
         }
-        p("form-error") {
-            id = "validation-error-name"
-        }
+        p("form-error") { id = "validation-error-name" }
 
-        label {
+        versionField(supportedVersions, disabled = user.isDemoUserInProduction())
+        p("form-error") { id = "validation-error-version" }
+
+        label("form-label form-label--optional") {
             htmlFor = "create-world-description"
-            +"Description"
+            +"Description · optional"
         }
-        textArea(classes = "form-control") {
+        textArea(classes = "form-control form-control--optional") {
             id = "create-world-description"
             name = "description"
             maxLength = "500"
-            placeholder = "A brief description of the world"
+            placeholder = "short note about this world"
             if (user.isDemoUserInProduction()) disabled = true
         }
-        p("form-error") {
-            id = "validation-error-description"
-        }
-
-        label {
-            htmlFor = "create-world-version"
-            +"Minecraft Version"
-            span("required-indicator") { +"*" }
-        }
-        select(classes = "form-control") {
-            id = "create-world-version"
-            name = "version"
-            required = true
-            if (user.isDemoUserInProduction()) disabled = true
-            supportedVersions.forEachIndexed { i, version ->
-                option {
-                    value = version.toString()
-                    +"$version${if (i == 0) " (Latest)" else if (i == supportedVersions.size - 1) " (Earliest compatible)" else ""}"
-                }
-            }
-        }
-        p("form-error") {
-            id = "validation-error-version"
-        }
+        p("form-error") { id = "validation-error-description" }
 
         div("modal__actions") {
-            button {
-                classes = setOf("btn", "btn--primary")
-                type = kotlinx.html.ButtonType.submit
-                if (user.isDemoUserInProduction()) disabled = true
-                +"Create World"
-            }
-            button {
-                classes = setOf("btn", "btn--ghost")
-                type = kotlinx.html.ButtonType.button
+            button(classes = "btn btn--ghost") {
+                type = ButtonType.button
                 attributes["onclick"] = "this.closest('dialog')?.close()"
                 +"Cancel"
             }
+            button(classes = "btn btn--primary") {
+                type = ButtonType.submit
+                if (user.isDemoUserInProduction()) disabled = true
+                +"Create world"
+            }
         }
+    }
+}
+
+/**
+ * Custom dropdown over the fixed set of supported versions. A hidden input carries the
+ * value for the form POST; worlds.js toggles the menu and updates value + label. Falls
+ * back to the first (latest) version as the initial selection.
+ */
+private fun FlowContent.versionField(supportedVersions: List<MinecraftVersion.Release>, disabled: Boolean) {
+    val default = supportedVersions.firstOrNull()?.toString() ?: ""
+    div("version-field") {
+        label("form-label") {
+            id = "ver-label"
+            +"Minecraft version"
+        }
+        div("version-control") {
+            div("form-control version-select") {
+                attributes["role"] = "button"
+                attributes["tabindex"] = if (disabled) "-1" else "0"
+                attributes["aria-haspopup"] = "listbox"
+                attributes["aria-expanded"] = "false"
+                attributes["aria-labelledby"] = "ver-label"
+                attributes["data-version-select"] = ""
+                span("version-select__value") { +default }
+                lucide("chevron-down", 16)
+            }
+            ul("version-menu") {
+                attributes["role"] = "listbox"
+                attributes["aria-labelledby"] = "ver-label"
+                attributes["hidden"] = "true"
+                supportedVersions.forEachIndexed { index, version ->
+                    val v = version.toString()
+                    li("version-menu__row${if (index == 0) " version-menu__row--selected" else ""}") {
+                        attributes["role"] = "option"
+                        attributes["tabindex"] = "-1"
+                        attributes["aria-selected"] = (index == 0).toString()
+                        attributes["data-version"] = v
+                        +v
+                        if (index == 0) lucide("check", 15)
+                    }
+                }
+            }
+        }
+        input(classes = "version-input") {
+            type = InputType.hidden
+            name = "version"
+            value = default
+            attributes["data-version-input"] = ""
+        }
+        p("form-help-text") { +"Required — the path generator uses this to pick valid recipes." }
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/utils/DateTimeFormatting.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/utils/DateTimeFormatting.kt
@@ -42,3 +42,18 @@ fun ZonedDateTime.formatAsRelativeOrDate(): String {
     }
 }
 
+/**
+ * Compact relative time for tight UI (Worlds page hero/roster): "just now", "2h ago",
+ * "1d ago", or a short date past a week. Fits a narrow column where "2 hours ago" would wrap.
+ */
+fun ZonedDateTime.formatAsCompactRelative(): String {
+    val duration = Duration.between(this, ZonedDateTime.now())
+    return when {
+        duration.toDays() >= 7 -> this.formatAsDate()
+        duration.toDays() > 0 -> "${duration.toDays()}d ago"
+        duration.toHours() > 0 -> "${duration.toHours()}h ago"
+        duration.toMinutes() > 0 -> "${duration.toMinutes()}m ago"
+        else -> "just now"
+    }
+}
+

--- a/webapp/mc-web/src/main/resources/db/migration/V2_48_0__add_world_member_pin_and_last_opened.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_48_0__add_world_member_pin_and_last_opened.sql
@@ -1,0 +1,14 @@
+-- Per-user world affordances for the redesigned Worlds page:
+--   * pinned         — user pins a world to sort it above the rest (favourite).
+--   * last_opened_at — when this user last opened the world; drives "opened Xh ago"
+--                      and the default most-recently-opened-first sort.
+-- Both are per (user, world), so they live on world_members, not on world.
+ALTER TABLE world_members ADD COLUMN pinned BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE world_members ADD COLUMN last_opened_at TIMESTAMP WITH TIME ZONE;
+
+-- Seed last_opened_at so existing memberships sort sensibly before the first open.
+UPDATE world_members SET last_opened_at = updated_at;
+
+-- Supports the "pinned first, then most-recently-opened" ordering of a user's worlds.
+CREATE INDEX idx_world_members_user_sort
+    ON world_members(user_id, pinned DESC, last_opened_at DESC);

--- a/webapp/mc-web/src/main/resources/static/scripts/worlds.js
+++ b/webapp/mc-web/src/main/resources/static/scripts/worlds.js
@@ -1,0 +1,121 @@
+// Worlds page — custom Minecraft-version dropdown.
+// Event-delegated on document so it keeps working after HTMX swaps #worlds-content
+// (create / pin re-render the modal, losing any directly-bound listeners).
+(function () {
+    "use strict";
+
+    var CHECK_SVG =
+        '<svg class="icon" width="15px" height="15px" viewBox="0 0 24 24" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>';
+
+    function menuOf(select) {
+        return select.parentElement ? select.parentElement.querySelector(".version-menu") : null;
+    }
+
+    function closeAll(except) {
+        document.querySelectorAll("[data-version-select]").forEach(function (select) {
+            if (select === except) return;
+            var menu = menuOf(select);
+            select.classList.remove("version-select--open");
+            select.setAttribute("aria-expanded", "false");
+            if (menu) menu.setAttribute("hidden", "true");
+        });
+    }
+
+    function toggle(select) {
+        var menu = menuOf(select);
+        if (!menu) return;
+        var isOpen = select.getAttribute("aria-expanded") === "true";
+        closeAll(select);
+        if (isOpen) {
+            select.classList.remove("version-select--open");
+            select.setAttribute("aria-expanded", "false");
+            menu.setAttribute("hidden", "true");
+        } else {
+            select.classList.add("version-select--open");
+            select.setAttribute("aria-expanded", "true");
+            menu.removeAttribute("hidden");
+        }
+    }
+
+    function choose(row) {
+        var field = row.closest(".version-field");
+        if (!field) return;
+        var value = row.getAttribute("data-version");
+        var input = field.querySelector("[data-version-input]");
+        var valueEl = field.querySelector(".version-select__value");
+        var select = field.querySelector("[data-version-select]");
+
+        if (input) input.value = value;
+        if (valueEl) valueEl.textContent = value;
+
+        field.querySelectorAll(".version-menu__row").forEach(function (r) {
+            var selected = r === row;
+            r.classList.toggle("version-menu__row--selected", selected);
+            r.setAttribute("aria-selected", selected ? "true" : "false");
+            var check = r.querySelector("svg.icon");
+            if (selected && !check) {
+                r.insertAdjacentHTML("beforeend", CHECK_SVG);
+            } else if (!selected && check) {
+                check.remove();
+            }
+        });
+
+        if (select) {
+            select.classList.remove("version-select--open");
+            select.setAttribute("aria-expanded", "false");
+            select.focus();
+        }
+        var menu = row.closest(".version-menu");
+        if (menu) menu.setAttribute("hidden", "true");
+    }
+
+    document.addEventListener("click", function (e) {
+        var select = e.target.closest("[data-version-select]");
+        if (select) {
+            toggle(select);
+            return;
+        }
+        var row = e.target.closest(".version-menu__row");
+        if (row) {
+            choose(row);
+            return;
+        }
+        closeAll(null);
+    });
+
+    document.addEventListener("keydown", function (e) {
+        var select = e.target.closest("[data-version-select]");
+        if (select) {
+            if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                toggle(select);
+            } else if (e.key === "Escape") {
+                closeAll(null);
+            } else if (e.key === "ArrowDown") {
+                e.preventDefault();
+                var menu = menuOf(select);
+                if (menu && menu.hasAttribute("hidden")) toggle(select);
+                var first = menu && menu.querySelector(".version-menu__row");
+                if (first) first.focus();
+            }
+            return;
+        }
+        var row = e.target.closest(".version-menu__row");
+        if (row) {
+            if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                choose(row);
+            } else if (e.key === "Escape") {
+                closeAll(null);
+                var sel = row.closest(".version-field").querySelector("[data-version-select]");
+                if (sel) sel.focus();
+            } else if (e.key === "ArrowDown") {
+                e.preventDefault();
+                if (row.nextElementSibling) row.nextElementSibling.focus();
+            } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                if (row.previousElementSibling) row.previousElementSibling.focus();
+            }
+        }
+    });
+})();

--- a/webapp/mc-web/src/main/resources/static/styles/components/modal.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/modal.css
@@ -42,10 +42,14 @@ dialog.modal-backdrop::backdrop {
 }
 
 .modal__body label {
+    display: block;
     font-family: var(--font-ui);
-    font-size: var(--text-ui);
+    font-size: var(--text-label);
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
     color: var(--text-muted);
-    margin-bottom: calc(var(--space-1) * -1);
+    margin-bottom: var(--space-2);
 }
 
 .modal__body label .required-indicator {

--- a/webapp/mc-web/src/main/resources/static/styles/pages/worlds.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/worlds.css
@@ -1,0 +1,203 @@
+/* ══════════════════════════════════════════════════════════════════
+   WORLDS PAGE — page-specific layout (Seam)
+   Built on top of the design-system component layer. Ported from the
+   design handoff; tokens mapped to this app's design-tokens.css. Icon
+   rules are scoped to `svg.icon` so they never touch the app's own
+   `div.icon` (iconComponent) chrome in the header.
+   ══════════════════════════════════════════════════════════════════ */
+
+/* ── Lucide inline icons (2px stroke, inherit text colour) ── */
+svg.icon        { fill: none; stroke: currentColor; stroke-width: 2;
+                  stroke-linecap: round; stroke-linejoin: round;
+                  display: block; flex: none; }
+svg.icon--fill  { fill: currentColor; stroke: none; }
+
+/* ── App main column ── */
+.worlds-main { padding-block: var(--space-5) var(--space-8); }
+
+/* ── Page header row (title + New world) ── */
+.worlds-head { display: flex; align-items: flex-end; justify-content: space-between;
+               gap: var(--space-4); margin-bottom: var(--space-4); }
+.worlds-head .page-heading { margin-bottom: 0; }
+
+/* ── Buttons that carry a leading icon ── */
+.btn svg.icon { margin-right: 6px; }
+.btn--icon-lead { display: inline-flex; align-items: center; }
+
+/* ── Progress bar fill (base .progress lives in components/progress.css;
+      the design wants a slim filled track, so override here page-side) ── */
+.progress    { display: block; height: 4px; background: var(--bg-base);
+               border-radius: 2px; overflow: hidden; }
+.progress--lg { height: 6px; }
+.progress__fill { height: 100%; background: var(--progress); border-radius: 2px;
+                  transition: width 200ms ease; }
+.progress__fill--complete { background: var(--green); }
+
+/* ── Form label + optional control (design-system form.css lacks these) ── */
+/* Modal labels/controls get their base treatment from components/modal.css. These are
+   the extra cues from the new Worlds design that modal.css doesn't carry: a dimmed
+   "optional" label + dashed optional-field border. Scoped through .modal__body to
+   out-specify modal.css's own `.modal__body label` / `textarea` rules. */
+.modal__body .form-label--optional { color: var(--text-disabled); }
+/* Dashed cue for the optional field. Scoped through .modal__body to out-specify
+   components/modal.css's `.modal__body textarea` solid-border rule. */
+.modal__body .form-control--optional { border-style: dashed; }
+/* Create-modal intro line. A plain text class (not the DS .modal__body container,
+   which carries a 24px left padding that would misalign it past the form fields). */
+.worlds-modal-intro { font-family: var(--font-body); font-size: var(--text-sm);
+                      color: var(--text-muted); margin-bottom: var(--space-4); }
+
+/* ════════════════════════════ EMPTY STATE ════════════════════════════ */
+.worlds-empty        { display: flex; flex-direction: column; align-items: center;
+                       text-align: center; padding-block: var(--space-8); }
+.world-glyph         { width: 72px; height: 72px; border-radius: 12px;
+                       background: var(--accent-muted); color: var(--accent);
+                       display: flex; align-items: center; justify-content: center;
+                       margin-bottom: var(--space-4); }
+.world-glyph svg.icon { stroke-width: 1.6; }
+.worlds-empty__title { font-family: var(--font-ui); font-weight: 600; font-size: 22px;
+                       color: var(--text-primary); margin-bottom: var(--space-3); }
+.worlds-empty__text  { max-width: 440px; font-family: var(--font-body);
+                       font-size: var(--text-base); line-height: 1.55;
+                       color: var(--text-muted); margin-bottom: var(--space-5); }
+.worlds-empty__text b { color: var(--text-primary); font-weight: 500; }
+.worlds-demo-notice  { font-family: var(--font-body); font-size: var(--text-xs);
+                       color: var(--text-muted); margin-top: var(--space-3); }
+
+.worlds-features { display: flex; gap: var(--space-6); margin-top: var(--space-8);
+                   flex-wrap: wrap; justify-content: center; }
+.worlds-feature  { display: flex; flex-direction: column; align-items: center;
+                   gap: var(--space-2); width: 130px; color: var(--text-muted); }
+.worlds-feature span { font-family: var(--font-body); font-size: var(--text-xs);
+                       line-height: 1.4; text-align: center; }
+
+/* ════════════════════════ FIRST-RUN SUCCESS ════════════════════════ */
+.worlds-callout { margin-bottom: var(--space-5); }
+.callout__lead  { font-family: var(--font-ui); font-weight: 600; }
+
+/* ════════════════════════════ WORLD HERO ═════════════════════════════ */
+/* Wide lead card: identity + overall progress on the left, a live peek at
+   active projects (or first-run actions) on the right. */
+.world-hero          { display: flex; overflow: hidden;
+                       background: var(--bg-surface); border: 1px solid var(--border);
+                       border-radius: var(--radius);
+                       box-shadow: var(--shadow-card, 0 1px 2px rgba(42, 34, 24, 0.06)); }
+.world-hero__main    { flex: 1; padding: var(--space-5); }
+.world-hero__aside   { width: 300px; flex: none; border-left: 1px solid var(--border);
+                       background: var(--bg-raised); padding: var(--space-4) var(--space-5); }
+.world-hero__aside .section-label { margin-bottom: var(--space-3); }
+/* Just-created highlight ring (first-run only) */
+.world-hero--fresh   { box-shadow: 0 0 0 3px var(--accent-muted),
+                       var(--shadow-card, 0 1px 2px rgba(42, 34, 24, 0.06)); }
+
+.world-identity      { display: flex; align-items: center; gap: var(--space-2);
+                       margin-bottom: var(--space-1); }
+.world-name          { font-family: var(--font-ui); font-weight: 600;
+                       color: var(--text-primary); }
+.world-hero .world-name       { font-size: 22px; }
+.world-hero--lead .world-name { font-size: 20px; }
+.world-hero--fresh .world-name { font-size: 19px; }
+.world-meta          { font-family: var(--font-body); font-size: var(--text-sm);
+                       color: var(--text-muted); }
+/* indent the rows under the name, past the 26px pin + 8px gap */
+.world-hero__meta    { margin-left: 34px; margin-bottom: var(--space-5); }
+.world-hero__body    { margin-left: 34px; }
+/* fresh has no pin, so no indent */
+.world-hero__submeta { margin-bottom: var(--space-5); }
+
+.world-stat          { display: flex; align-items: baseline; gap: var(--space-2);
+                       margin-bottom: var(--space-2); }
+.world-stat__count   { font-family: var(--font-ui); font-size: var(--text-sm);
+                       color: var(--text-primary); }
+.world-stat__pct     { font-family: var(--font-body); font-size: var(--text-xs);
+                       color: var(--text-muted); }
+.world-progress      { max-width: 280px; margin-bottom: var(--space-5); }
+/* multi-world lead hero packs progress + button on one row */
+.world-hero__body--row       { display: flex; align-items: center; gap: var(--space-4); }
+.world-hero__progress-block  { min-width: 180px; }
+
+/* right-hand active-projects peek */
+.world-peek__row     { display: flex; align-items: center; justify-content: space-between;
+                       gap: var(--space-2); padding: var(--space-2) 0;
+                       border-bottom: 1px solid var(--border); }
+.world-peek__row:last-child { border-bottom: none; }
+.world-peek__name    { font-family: var(--font-body); font-size: var(--text-sm);
+                       color: var(--text-primary); }
+.world-hero__peek-empty { font-family: var(--font-body); font-size: var(--text-sm);
+                          color: var(--text-muted); }
+/* first-run: stacked actions instead of a peek */
+.world-hero__actions { display: flex; flex-direction: column; gap: var(--space-3);
+                       justify-content: center; height: 100%; }
+.world-hero__actions .btn { width: 100%; }
+.world-hero__empty   { display: flex; align-items: center; gap: var(--space-2);
+                       color: var(--text-muted); margin-bottom: var(--space-4); }
+.world-hero__empty span { font-family: var(--font-body); font-size: var(--text-sm); }
+
+/* ── Pin / favourite toggle ── */
+.pin-btn        { display: inline-flex; align-items: center; justify-content: center;
+                  width: 26px; height: 26px; border: none; background: transparent;
+                  border-radius: 4px; cursor: pointer;
+                  color: var(--text-disabled);
+                  transition: background 120ms ease, color 120ms ease; }
+.pin-btn:hover  { background: var(--bg-raised); color: var(--text-muted); }
+.pin-btn--on    { color: var(--amber); }
+
+/* ═══════════════════════════ WORLDS ROSTER ═══════════════════════════ */
+/* "Other worlds" — dense rows below the hero; scales toward many worlds. */
+.worlds-subsection   { margin-bottom: var(--space-3); }
+.worlds-roster       { background: var(--bg-surface); border: 1px solid var(--border);
+                       border-radius: var(--radius); overflow: hidden; }
+.world-row           { display: flex; align-items: center; gap: var(--space-4);
+                       padding: var(--space-3) var(--space-4);
+                       border-bottom: 1px solid var(--border);
+                       transition: background 120ms ease; }
+.world-row:last-child { border-bottom: none; }
+.world-row:hover     { background: var(--bg-raised); }
+.world-row__link     { flex: 1; display: flex; align-items: center; gap: var(--space-4);
+                       color: inherit; text-decoration: none; }
+.world-row__id       { width: 230px; flex: none; }
+.world-row__id .world-name { font-size: var(--text-sm); }
+.world-row__name     { display: flex; align-items: center; gap: 6px; }
+.world-row__id .world-meta { font-size: var(--text-xs); margin-top: 2px;
+                             display: flex; align-items: center; gap: 6px; }
+.world-row__progress { flex: 1; display: flex; align-items: center; gap: var(--space-3); }
+.world-row__progress .progress { flex: 1; max-width: 160px; }
+.world-row__pct      { font-family: var(--font-ui); font-size: var(--text-xs);
+                       color: var(--text-muted); white-space: nowrap; }
+.world-row__time     { font-family: var(--font-body); font-size: var(--text-xs);
+                       color: var(--text-muted); width: 64px; text-align: right; flex: none; }
+.world-row__go       { color: var(--text-disabled); flex: none; }
+
+/* ═════════════════════ CREATE MODAL — version select ═════════════════ */
+/* Custom dropdown over the fixed set of supported Minecraft versions. */
+.version-field       { position: relative; }
+.version-control     { position: relative; }
+.version-select      { display: flex; align-items: center; justify-content: space-between;
+                       cursor: pointer; }
+.version-select svg.icon { color: var(--text-muted); }
+.version-select--open { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-muted); }
+.version-menu        { position: absolute; top: calc(100% + 4px); left: 0; right: 0;
+                       background: var(--bg-surface); border: 1px solid var(--border);
+                       border-radius: var(--radius);
+                       box-shadow: var(--shadow-pop, 0 4px 16px rgba(42, 34, 24, 0.16));
+                       padding: var(--space-1); z-index: 5; max-height: 240px; overflow-y: auto; }
+.version-menu[hidden] { display: none; }
+.version-menu__row   { display: flex; align-items: center; justify-content: space-between;
+                       padding: 7px 10px; border-radius: 4px;
+                       font-family: var(--font-ui); font-size: var(--text-sm);
+                       color: var(--text-primary); cursor: pointer; }
+.version-menu__row:hover { background: var(--bg-raised); }
+.version-menu__row--selected { background: var(--accent-muted); color: var(--accent); }
+
+/* ── Responsive: hero stacks under aside below the mobile breakpoint ── */
+@media (max-width: 768px) {
+    .world-hero        { flex-direction: column; }
+    .world-hero__aside { width: auto; border-left: none; border-top: 1px solid var(--border); }
+    /* Roster rows reflow instead of overflowing: identity takes the first line,
+       progress + time + arrow wrap onto the next so nothing is clipped off-canvas. */
+    .world-row__link     { flex-wrap: wrap; column-gap: var(--space-3); row-gap: var(--space-1); }
+    .world-row__id       { width: 100%; }
+    .world-row__progress { flex: 1 1 auto; }
+    .world-row__progress .progress { max-width: none; }
+    .world-row__time     { width: auto; text-align: left; }
+}

--- a/webapp/scripts/migrate-worktree.sh
+++ b/webapp/scripts/migrate-worktree.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Migrate the database that THIS checkout's local.env points at.
+#
+# Unlike migrate-locally.sh (which hardcodes the localhost Docker DB), this reads
+# DB_URL / DB_USER / DB_PASSWORD from webapp/local.env — so in a git worktree it
+# targets that worktree's isolated Neon branch (written by worktree-db.sh), and in
+# the main checkout it targets whatever local.env already points at.
+set -euo pipefail
+
+if [[ -z "${JAVA_HOME:-}" ]]; then
+    echo "Error: JAVA_HOME is not set"
+    exit 1
+fi
+
+cd "$(dirname "$0")/.."   # -> webapp/
+
+ENV_FILE="local.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+    echo "Error: $ENV_FILE not found. In a worktree, run: bash scripts/worktree-db.sh"
+    exit 1
+fi
+
+# Export DB_* so the flyway-maven-plugin picks them up from the environment.
+set -a
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+set +a
+
+: "${DB_URL:?DB_URL missing from $ENV_FILE}"
+: "${DB_USER:?DB_USER missing from $ENV_FILE}"
+: "${DB_PASSWORD:?DB_PASSWORD missing from $ENV_FILE}"
+
+# Redacted host echo so it's obvious which branch is being migrated.
+echo "Migrating: ${DB_URL%%\?*}"
+mvn flyway:migrate -pl mc-web


### PR DESCRIPTION
Recreates the Worlds-page design handoff in the server-rendered stack (Ktor + `kotlinx.html` + HTMX). Replaces the bare "No worlds yet" screen and card grid with a first-run empty state, a wide hero card for the lead world, a dense roster for the rest, a first-world success state, and a create-world modal with a custom supported-version dropdown.

## Backend
- **`V2_47_0`** migration: per-user `pinned` + `last_opened_at` on `world_members` (+ sort index) — both affordances are inherently per-member, not per-world.
- `World` gains `pinned` / `lastOpenedAt`; `GetPermittedWorldsStep` selects them and sorts **pinned-first, then most-recently-opened**.
- `GetWorldProjectPeekStep` feeds the hero's "Active projects" peek (top non-terminal projects).
- `POST /worlds/pin/{id}` toggle — membership-gated, mounted off the `{worldId}` subtree so pinning does **not** touch the user's active world. `last_opened_at` is stamped (best-effort) when a world is opened.

## Frontend
- New `pages/worlds.css`, a Lucide inline-icon helper, `worlds.js` (event-delegated version dropdown that survives HTMX swaps), and a compact relative-time formatter.
- `modal.css`: form labels now use the design's 11px uppercase-mono treatment with proper label→input spacing, replacing a legacy negative margin. This also tidies the **create-project** modal, which shares `modalForm`.

## Scope notes
- **Type** (singleplayer/server + member count) and the **modded** badge are intentionally deferred.
- The old search box / `worldCard` / `/worlds/search` remain in the tree but are no longer wired into the page — a clean-up follow-up if wanted.

## Verification
- `mvn clean compile` ✓ · full unit tier (692) ✓ · database tier (101, incl. `DatabaseMigrationTest`) ✓
- Verified end-to-end over authenticated HTTP: create → first-world success · open → `last_opened_at` stamps + world promotes to hero · pin → sorts to top, `aria-pressed` flips.
- ux-reviewer pass (rendered screenshots) approved; its two blocking findings (mobile roster clipping, dashed optional border) and polish items are fixed.
- Also adds `webapp/scripts/migrate-worktree.sh` (separate commit) for migrating a worktree's Neon branch.

> No `preview` label applied — add it if you want a Fly preview deploy to eyeball the redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)