### PR TITLE
Fix unstyled /link device-linking form

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/link/LinkPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/link/LinkPage.kt
@@ -10,6 +10,7 @@ import kotlinx.html.ButtonType
 import kotlinx.html.FlowContent
 import kotlinx.html.InputType
 import kotlinx.html.button
+import kotlinx.html.div
 import kotlinx.html.form
 import kotlinx.html.id
 import kotlinx.html.input
@@ -30,6 +31,9 @@ fun linkPage(
 ): String = pageShell(
     pageTitle = "Seam — Link a device",
     user = user,
+    // pageShell ships btn.css by default but not form.css — without this the .form-control and
+    // .form-error classes below are dead and the form renders as unstyled inline browser defaults.
+    stylesheets = listOf("/static/styles/components/form.css"),
 ) {
     appHeader(
         user = user,
@@ -55,24 +59,31 @@ fun linkPage(
 }
 
 private fun FlowContent.linkForm(prefillCode: String?) {
-    form {
+    // .stack gives the field and the action a column layout with real spacing; without it the
+    // label, input and button run together inline.
+    form(classes = "stack") {
         method = kotlinx.html.FormMethod.post
         action = "/link"
-        label {
-            htmlFor = "user_code"
-            +"Device code"
+        div {
+            label(classes = "form-label") {
+                htmlFor = "user_code"
+                +"Device code"
+            }
+            input(classes = "form-control") {
+                id = "user_code"
+                name = "user_code"
+                type = InputType.text
+                required = true
+                autoComplete = "off"
+                placeholder = "ABCD-EFGH"
+                value = prefillCode ?: ""
+            }
         }
-        input(classes = "form-control") {
-            id = "user_code"
-            name = "user_code"
-            type = InputType.text
-            required = true
-            autoComplete = "off"
-            placeholder = "ABCD-EFGH"
-            value = prefillCode ?: ""
-        }
-        button(classes = "btn btn--primary", type = ButtonType.submit) {
-            +"Link device"
+        // Wrapped so the button sizes to its content — a direct flex child would stretch full width.
+        div {
+            button(classes = "btn btn--primary", type = ButtonType.submit) {
+                +"Link device"
+            }
         }
     }
 }

--- a/webapp/mc-web/src/main/resources/static/styles/components/form.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/form.css
@@ -87,6 +87,19 @@ select.form-control option {
     margin-bottom: var(--space-1);
 }
 
+/* --- Standalone label ---
+   The scoped rules above only reach labels inside the idea wizard. `.form-label` is the
+   unscoped equivalent, for forms that aren't part of a wizard or a modal. */
+
+.form-label {
+    display: block;
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--text-muted);
+    margin-bottom: var(--space-1);
+}
+
 /* --- Required indicator --- */
 
 .required-indicator {


### PR DESCRIPTION
## What

The `/link` page — where players type the code shown by the Seam Companion mod — rendered as an unstyled inline form: label, input and button running together with no spacing.

## Why

`pageShell` loads `btn.css` by default but **`form.css` is opt-in**, and `linkPage` passed no `stylesheets`. So `.form-control` and `.form-error` were dead classes and the browser fell back to its own defaults.

## Changes

- `LinkPage.kt` — opt into `form.css`; wrap the form in `.stack` for column layout with real spacing; wrap the submit button so it sizes to its content instead of stretching as a flex child.
- `form.css` — add an unscoped `.form-label`. The existing label rules are scoped to `.wizard-stage-form` / `.wizard-fields`, so a form outside a wizard or modal had no label styling. Additive; no existing page uses the class.

## Testing

`mvn compile` clean, `./webapp/scripts/test.sh` green. Verified in a browser against a local instance — this is the page the mod's device-code flow sends players to, and a real link completed through it end to end.

Template + CSS only, so no new tests (per the repo's test expectations for template-only changes). No preview label: nothing here needs a Fly preview beyond a local eyeball.

## Context

Found while implementing MCO-266 / MCO-267 (the mod's API client + device-code auth) and testing the link flow end to end. No Linear issue of its own yet — say the word if you want one filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)