### PR TITLE
MCO-284: stamp progress provenance (mod vs manual) on resource progress

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ProgressSource.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ProgressSource.kt
@@ -1,0 +1,28 @@
+package app.mcorg.domain.model.resources
+
+/**
+ * Which client last set a resource's collected count (MCO-284).
+ *
+ * The Seam Companion mod's snapshot is authoritative while the mod is running; the web app's manual
+ * counters are the fallback when it isn't. Last-write-wins needs both sides to be able to tell
+ * which one wrote the value they're reading.
+ *
+ * Not to be confused with `ResourceGatheringItem.sourceType`, which is the item's *acquisition*
+ * type from the graph (MINED, CRAFTED, …).
+ */
+enum class ProgressSource(val value: String) {
+    /** Set through the web app. */
+    MANUAL("manual"),
+
+    /** Set through the mod-facing sync endpoint. */
+    MOD("mod");
+
+    companion object {
+        /**
+         * Parse a stored value. Anything unrecognised — including null, which is what a LEFT JOIN
+         * yields for an item with no progress row yet — reads as [MANUAL].
+         */
+        fun fromValue(value: String?): ProgressSource =
+            entries.firstOrNull { it.value == value } ?: MANUAL
+    }
+}

--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ResourceGatheringItem.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ResourceGatheringItem.kt
@@ -10,4 +10,6 @@ data class ResourceGatheringItem(
     val solvedByProject: Pair<Int, String>? = null,
     val sourceType: String? = null,
     val ignored: Boolean = false,
+    /** Which client last set [collected]. See [ProgressSource] — unrelated to [sourceType]. */
+    val progressSource: ProgressSource = ProgressSource.MANUAL,
 )

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/api/ApiDtos.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/api/ApiDtos.kt
@@ -69,6 +69,11 @@ data class ResourceDto(
     @SerialName("required") val required: Int,
     @SerialName("collected") val collected: Int,
     @SerialName("source_type") val sourceType: String? = null,
+    /**
+     * Which client last set [collected]: `manual` (web app) or `mod` (this API). Distinct from
+     * [sourceType], which is the item's acquisition type from the graph.
+     */
+    @SerialName("progress_source") val progressSource: String = "manual",
 )
 
 @Serializable

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/api/ApiRoutes.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/api/ApiRoutes.kt
@@ -224,6 +224,7 @@ suspend fun ApplicationCall.handleGetWorldProjects() {
                     required = it.required,
                     collected = it.collected,
                     sourceType = it.sourceType,
+                    progressSource = it.progressSource.value,
                 )
             },
             tasks = tasks.map { TaskDto(id = it.id, name = it.name, completed = it.completed) },
@@ -297,6 +298,7 @@ suspend fun ApplicationCall.handleSyncResources() {
                     required = it.required,
                     collected = it.collected,
                     sourceType = it.sourceType,
+                    progressSource = it.progressSource.value,
                 )
             }
         ),

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetAllResourceGatheringItemsStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetAllResourceGatheringItemsStep.kt
@@ -10,6 +10,7 @@ val GetAllResourceGatheringItemsStep = DatabaseSteps.query<Int, List<ResourceGat
         """
         SELECT rg.id, rg.project_id, rg.item_id, rg.name, rg.required,
                COALESCE(rgp.collected, 0) AS collected,
+               COALESCE(rgp.progress_source, 'manual') AS progress_source,
                rg.source_type, rg.ignored,
                p.id AS solved_project_id, p.name AS solved_project_name
         FROM resource_gathering rg

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetResourceGatheringItemStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/GetResourceGatheringItemStep.kt
@@ -10,6 +10,7 @@ val GetResourceGatheringItemStep = DatabaseSteps.query<Int, ResourceGatheringIte
         """
         SELECT rg.id, rg.project_id, rg.item_id, rg.name, rg.required,
                COALESCE(rgp.collected, 0) AS collected,
+               COALESCE(rgp.progress_source, 'manual') AS progress_source,
                rg.source_type, rg.ignored,
                p.id AS solved_project_id, p.name AS solved_project_name
         FROM resource_gathering rg

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/SetProgressByItemStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/SetProgressByItemStep.kt
@@ -1,5 +1,6 @@
 package app.mcorg.pipeline.resources.commonsteps
 
+import app.mcorg.domain.model.resources.ProgressSource
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
@@ -13,11 +14,14 @@ import app.mcorg.pipeline.failure.AppFailure
  * @param projectId the project that owns this progress entry.
  * @param itemId the Minecraft item id (e.g. "minecraft:iron_ingot").
  * @param collected the absolute value to set (clamped to [0, required]).
+ * @param source which client is writing. Defaults to [ProgressSource.MOD] because this step exists
+ *   for the mod sync endpoint; the web app's write paths are the Upsert* steps.
  */
 data class SetProgressByItemInput(
     val projectId: Int,
     val itemId: String,
     val collected: Int,
+    val source: ProgressSource = ProgressSource.MOD,
 )
 
 /**
@@ -36,22 +40,25 @@ object SetProgressByItemStep : Step<SetProgressByItemInput, AppFailure.DatabaseE
         return DatabaseSteps.update<SetProgressByItemInput>(
             sql = SafeSQL.insert(
                 """
-                INSERT INTO resource_gathering_progress (project_id, item_id, collected, updated_at)
+                INSERT INTO resource_gathering_progress (project_id, item_id, collected, updated_at, progress_source)
                 SELECT rg.project_id,
                        rg.item_id,
                        LEAST(GREATEST(?, 0), rg.required),
-                       CURRENT_TIMESTAMP
+                       CURRENT_TIMESTAMP,
+                       ?
                 FROM resource_gathering rg
                 WHERE rg.project_id = ? AND rg.item_id = ?
                 ON CONFLICT (project_id, item_id) DO UPDATE
-                    SET collected  = EXCLUDED.collected,
-                        updated_at = EXCLUDED.updated_at
+                    SET collected       = EXCLUDED.collected,
+                        updated_at      = EXCLUDED.updated_at,
+                        progress_source = EXCLUDED.progress_source
                 """.trimIndent()
             ),
             parameterSetter = { stmt, inp ->
                 stmt.setInt(1, inp.collected)
-                stmt.setInt(2, inp.projectId)
-                stmt.setString(3, inp.itemId)
+                stmt.setString(2, inp.source.value)
+                stmt.setInt(3, inp.projectId)
+                stmt.setString(4, inp.itemId)
             }
         ).process(input)
     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/UpsertProgressByItemStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/UpsertProgressByItemStep.kt
@@ -37,14 +37,17 @@ object UpsertProgressByItemStep : Step<UpsertProgressByItemInput, AppFailure.Dat
         return DatabaseSteps.update<UpsertProgressByItemInput>(
             sql = SafeSQL.insert(
                 """
-                INSERT INTO resource_gathering_progress (project_id, item_id, collected, updated_at)
-                VALUES (?, ?, GREATEST(LEAST(?, ?), 0), CURRENT_TIMESTAMP)
+                INSERT INTO resource_gathering_progress (project_id, item_id, collected, updated_at, progress_source)
+                VALUES (?, ?, GREATEST(LEAST(?, ?), 0), CURRENT_TIMESTAMP, 'manual')
                 ON CONFLICT (project_id, item_id) DO UPDATE
-                    SET collected  = GREATEST(
+                    SET collected       = GREATEST(
                             LEAST(resource_gathering_progress.collected + ?, ?),
                             0
                         ),
-                        updated_at = CURRENT_TIMESTAMP
+                        updated_at      = CURRENT_TIMESTAMP,
+                        -- Explicit: the column DEFAULT only applies on INSERT, so without this a
+                        -- web edit following a mod sync would keep progress_source = 'mod'.
+                        progress_source = 'manual'
                 """.trimIndent()
             ),
             parameterSetter = { stmt, inp ->

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/UpsertProgressDeltaStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/UpsertProgressDeltaStep.kt
@@ -38,21 +38,25 @@ object UpsertProgressDeltaStep : Step<UpsertProgressDeltaInput, AppFailure.Datab
                     FROM resource_gathering
                     WHERE id = ?
                 )
-                INSERT INTO resource_gathering_progress (project_id, item_id, collected, updated_at)
+                INSERT INTO resource_gathering_progress (project_id, item_id, collected, updated_at, progress_source)
                 -- First write: base is 0, so clamp(delta) is exactly clamp(0 + delta).
                 SELECT rg.project_id,
                        rg.item_id,
                        GREATEST(LEAST(?, rg.required), 0),
-                       CURRENT_TIMESTAMP
+                       CURRENT_TIMESTAMP,
+                       'manual'
                 FROM rg
                 ON CONFLICT (project_id, item_id) DO UPDATE
-                    SET collected  = GREATEST(
+                    SET collected       = GREATEST(
                             LEAST(resource_gathering_progress.collected + ?, (
                                 SELECT required FROM resource_gathering WHERE id = ?
                             )),
                             0
                         ),
-                        updated_at = CURRENT_TIMESTAMP
+                        updated_at      = CURRENT_TIMESTAMP,
+                        -- Explicit: the column DEFAULT only applies on INSERT, so without this a
+                        -- web edit following a mod sync would keep progress_source = 'mod'.
+                        progress_source = 'manual'
                 """.trimIndent()
             ),
             parameterSetter = { stmt, inp ->

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/UpsertProgressStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/UpsertProgressStep.kt
@@ -33,16 +33,20 @@ object UpsertProgressStep : Step<UpsertProgressByRgIdInput, AppFailure.DatabaseE
         return DatabaseSteps.update<UpsertProgressByRgIdInput>(
             sql = SafeSQL.insert(
                 """
-                INSERT INTO resource_gathering_progress (project_id, item_id, collected, updated_at)
+                INSERT INTO resource_gathering_progress (project_id, item_id, collected, updated_at, progress_source)
                 SELECT rg.project_id,
                        rg.item_id,
                        LEAST(GREATEST(?, 0), rg.required),
-                       CURRENT_TIMESTAMP
+                       CURRENT_TIMESTAMP,
+                       'manual'
                 FROM resource_gathering rg
                 WHERE rg.id = ?
                 ON CONFLICT (project_id, item_id) DO UPDATE
-                    SET collected  = EXCLUDED.collected,
-                        updated_at = EXCLUDED.updated_at
+                    SET collected       = EXCLUDED.collected,
+                        updated_at      = EXCLUDED.updated_at,
+                        -- Explicit: the column DEFAULT only applies on INSERT, so without this a
+                        -- web edit following a mod sync would keep progress_source = 'mod'.
+                        progress_source = EXCLUDED.progress_source
                 """.trimIndent()
             ),
             parameterSetter = { stmt, inp ->

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/extractors/ResourceGatheringItemExtractors.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/extractors/ResourceGatheringItemExtractors.kt
@@ -1,5 +1,6 @@
 package app.mcorg.pipeline.resources.extractors
 
+import app.mcorg.domain.model.resources.ProgressSource
 import app.mcorg.domain.model.resources.ResourceGatheringItem
 import java.sql.ResultSet
 
@@ -30,5 +31,6 @@ fun ResultSet.toResourceGatheringItem(): ResourceGatheringItem {
         solvedByProject = solvedByProject,
         sourceType = sourceType,
         ignored = getBoolean("ignored"),
+        progressSource = ProgressSource.fromValue(getString("progress_source")),
     )
 }

--- a/webapp/mc-web/src/main/resources/db/migration/V2_49_0__add_progress_source.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_49_0__add_progress_source.sql
@@ -1,0 +1,20 @@
+-- Provenance for resource progress: which client last set the collected value (MCO-284).
+--
+-- The mod's snapshot is authoritative while the mod is running; the web app's manual counters are
+-- the fallback when it isn't. Last-write-wins needs both sides to be able to tell which wrote the
+-- value they're looking at, and the table only recorded WHAT was collected, never WHO set it.
+--
+-- Named progress_source, not source: resource_gathering already has source_type, which is the
+-- item's acquisition type from the graph (MINED, CRAFTED, ...) and entirely unrelated.
+
+ALTER TABLE resource_gathering_progress
+    ADD COLUMN progress_source VARCHAR NOT NULL DEFAULT 'manual';
+
+-- Every row written before this migration came from the web app, so the DEFAULT is also the
+-- correct backfill; no UPDATE needed.
+
+ALTER TABLE resource_gathering_progress
+    ADD CONSTRAINT chk_rgp_progress_source CHECK (progress_source IN ('manual', 'mod'));
+
+COMMENT ON COLUMN resource_gathering_progress.progress_source IS
+    'Which client last set collected: manual (web app) or mod (Seam Companion sync)';

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/api/ApiReadWriteIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/api/ApiReadWriteIT.kt
@@ -9,6 +9,8 @@ import app.mcorg.domain.model.user.TokenProfile
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressByItemInput
+import app.mcorg.pipeline.resources.commonsteps.UpsertProgressByItemStep
 import app.mcorg.pipeline.world.CreateWorldInput
 import app.mcorg.pipeline.world.CreateWorldStep
 import app.mcorg.presentation.plugins.AuthPlugin
@@ -181,6 +183,81 @@ class ApiReadWriteIT : WithUser() {
         assertEquals(HttpStatusCode.OK, response.status)
         val body = apiJson.decodeFromString(ResourcesResponse.serializer(), response.bodyAsText())
         assertEquals(64, body.resources.single { it.itemId == "minecraft:iron_ingot" }.collected)
+    }
+
+    @Test
+    fun `sync stamps progress_source as mod, and it reads back on the project`() = testApplication {
+        routing { install(AuthPlugin); apiV1Routes() }
+        val token = issueToken()
+        val worldId = createWorld("API IT Sync Source")
+        val projectId = createProject(worldId, "Sync Source Project")
+        createResource(projectId, "minecraft:iron_ingot", "Iron Ingot", 64)
+
+        val response = client.post("/api/v1/projects/$projectId/resources/sync") {
+            header("Authorization", "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody("""{"resources":[{"item_id":"minecraft:iron_ingot","collected":10}]}""")
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val synced = apiJson.decodeFromString(ResourcesResponse.serializer(), response.bodyAsText())
+        assertEquals("mod", synced.resources.single { it.itemId == "minecraft:iron_ingot" }.progressSource)
+
+        // And the read path projects the same value, not just the write path's response.
+        val projects = apiJson.decodeFromString(
+            ListSerializer(ProjectDto.serializer()),
+            getJson("/api/v1/worlds/$worldId/projects", token).bodyAsText(),
+        )
+        val resource = projects.single { it.id == projectId }.resources.single()
+        assertEquals("mod", resource.progressSource)
+    }
+
+    @Test
+    fun `a resource with no progress row reads as manual`() = testApplication {
+        routing { install(AuthPlugin); apiV1Routes() }
+        val token = issueToken()
+        val worldId = createWorld("API IT Untouched Source")
+        val projectId = createProject(worldId, "Untouched Project")
+        createResource(projectId, "minecraft:stone", "Stone", 10)
+
+        val projects = apiJson.decodeFromString(
+            ListSerializer(ProjectDto.serializer()),
+            getJson("/api/v1/worlds/$worldId/projects", token).bodyAsText(),
+        )
+
+        // No progress row exists, so the LEFT JOIN yields null — which must read as manual.
+        assertEquals("manual", projects.single { it.id == projectId }.resources.single().progressSource)
+    }
+
+    @Test
+    fun `a web-side write takes provenance back from the mod`() = testApplication {
+        routing { install(AuthPlugin); apiV1Routes() }
+        val token = issueToken()
+        val worldId = createWorld("API IT Source Handback")
+        val projectId = createProject(worldId, "Handback Project")
+        createResource(projectId, "minecraft:stone", "Stone", 100)
+
+        client.post("/api/v1/projects/$projectId/resources/sync") {
+            header("Authorization", "Bearer $token")
+            contentType(ContentType.Application.Json)
+            setBody("""{"resources":[{"item_id":"minecraft:stone","collected":5}]}""")
+        }
+
+        // The web app's write path. This is the regression that matters: the column DEFAULT only
+        // applies on INSERT, so an UPDATE that forgets progress_source would leave this row 'mod'
+        // forever and the mod would keep believing it owns the value.
+        runBlocking {
+            UpsertProgressByItemStep.process(
+                UpsertProgressByItemInput(projectId = projectId, itemId = "minecraft:stone", delta = 3, required = 100),
+            )
+        }
+
+        val projects = apiJson.decodeFromString(
+            ListSerializer(ProjectDto.serializer()),
+            getJson("/api/v1/worlds/$worldId/projects", token).bodyAsText(),
+        )
+        val resource = projects.single { it.id == projectId }.resources.single()
+        assertEquals("manual", resource.progressSource)
+        assertEquals(8, resource.collected)
     }
 
     @Test


### PR DESCRIPTION
## What

`resource_gathering_progress` records **what** was collected but never **who set it**. This adds `progress_source` (`manual` | `mod`).

## Why

MCO-269 (the mod's resource sync) needs it for last-write-wins: the mod's snapshot is authoritative while the mod is running, the web app's manual counters are the fallback when it isn't — and neither side could tell which one wrote the value it was looking at.

## Changes

- **Migration `V2_49_0`** — `progress_source VARCHAR NOT NULL DEFAULT 'manual'`, CHECK-constrained to `('manual','mod')`. Everything written to date came from the web app, so the default doubles as the backfill.
- **`ProgressSource`** enum in `mc-domain`; `ResourceGatheringItem` carries it.
- **All four write paths stamp it**, not just the new one. The three web `Upsert*` steps set `'manual'` explicitly in their `DO UPDATE` branch — the column DEFAULT only applies on INSERT, so without it a web edit following a mod sync would leave the row reading `mod` forever. `SetProgressByItemStep` takes the source as input, defaulting to `MOD`.
- **Read paths** `COALESCE` to `'manual'` (an item with no progress row yields NULL through the LEFT JOIN), and `ResourceDto` exposes `progress_source`.

## Naming

Deliberately **not** `source`: `resource_gathering` already has `source_type`, the item's *acquisition* type from the graph (MINED, CRAFTED, …). Unrelated concept, confusing name collision avoided.

## Testing

`mvn clean install` + `./webapp/scripts/test.sh --database`: 692 unit + 101 database tests, zero failures. Three new ITs in `ApiReadWriteIT` — the sync stamps `mod` and it survives the read path, an untouched resource reads `manual`, and a web write takes provenance back from the mod. That last one is the regression that actually matters.

No `preview` label: backend/data change with nothing to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)