### PR TITLE
MCO-285: stop the dev scripts running stale classes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ sudo service docker start           # Start Docker if not running (passwordless)
 ./webapp/scripts/start-db.sh        # Start the database
 ./webapp/scripts/migrate-locally.sh # Apply migrations to the localhost Docker DB (main checkout)
 ./webapp/scripts/migrate-worktree.sh # Apply migrations to the DB local.env points at (worktree Neon branch)
-./webapp/scripts/run.sh             # Start development server
+./webapp/scripts/run.sh             # Start development server (clean build; --fast to skip it)
 ./webapp/scripts/ingest-locally.sh  # Ingest Minecraft data into the local/worktree DB
 ```
 
@@ -91,6 +91,27 @@ Notes:
 - It auto-generates JWT signing keys (`mc-web/create-keys.sh`) on first run if missing.
 - `--integration` (failsafe) expects a running server; the `--database` tier is
   self-contained (Testcontainers spins up its own PostgreSQL).
+- `--clean` wipes `target/` first. Reach for it after an `mc-domain` change — see below.
+
+### Stale classes after an `mc-domain` change (MCO-285)
+
+**Symptom:** `NoSuchMethodError` or `NoClassDefFoundError` at *runtime*, naming a class or
+constructor that plainly exists in your working tree, from a file you did not touch. It looks
+like anything but a build problem. Two causes, both local-only (CI does a fresh full-reactor
+build and never sees them):
+
+1. **Kotlin's incremental compilation does not propagate an ABI change across module
+   boundaries.** Change a constructor in `mc-domain` and it rebuilds only the files that
+   textually changed, leaving stale callers in `mc-web/target/classes` — one was five weeks
+   old when this last bit us. `mvn compile` and even `mvn install` will not fix it. Only
+   `mvn clean` does.
+2. **`-pl <module>` resolves siblings from `~/.m2`**, not the reactor, so a module-scoped
+   build runs against the last *installed* jars. Add `-am` to pull the siblings into the
+   reactor.
+
+**Defaults now handle both:** `run.sh` does `mvn clean install -DskipTests` (pass `--fast` to
+reuse an existing build when only `mc-web` changed), and `test.sh`'s module-scoped tiers pass
+`-am`. If you bypass the scripts, remember the two rules yourself.
 
 ## Minecraft Data Ingestion
 

--- a/webapp/scripts/run.sh
+++ b/webapp/scripts/run.sh
@@ -20,6 +20,8 @@ usage() {
     echo "  --debug          Enable JVM remote debug on port 5005"
     echo "  --suspend        Wait for debugger to attach before starting (requires --debug)"
     echo "  --debug-port N   Set debug port (default: 5005)"
+    echo "  --fast           Skip the clean rebuild and reuse whatever is already built."
+    echo "                   Only safe when nothing outside mc-web has changed — see below."
     exit 1
 }
 
@@ -27,6 +29,7 @@ ENV_NAME="local"
 DEBUG=false
 SUSPEND=false
 DEBUG_PORT=5005
+FAST=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -36,6 +39,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --debug)
             DEBUG=true
+            shift
+            ;;
+        --fast)
+            FAST=true
             shift
             ;;
         --suspend)
@@ -97,9 +104,25 @@ if [[ "$DEBUG" == true ]]; then
     echo "Debug enabled on port $DEBUG_PORT (suspend=$SUSPEND_MODE)"
 fi
 
-echo "Compiling..."
+# Why `clean install` and not `compile` (MCO-285):
+#
+#   * `exec:java -pl mc-web` narrows the reactor to one module, so mc-domain and the other
+#     siblings resolve from ~/.m2 — the last INSTALLED jars, which `compile` never updates.
+#   * Kotlin's incremental compilation does not propagate an ABI change across module
+#     boundaries. After an mc-domain change it rebuilds only the files that textually changed
+#     and leaves stale callers in mc-web/target/classes — one was five weeks old when this bit
+#     us. `install` alone does not fix that; only `clean` does.
+#
+# Both failures surface at runtime as NoSuchMethodError / NoClassDefFoundError somewhere that
+# looks unrelated to what you changed, which is why the default is the safe one.
 cd "$WEBAPP_DIR"
-mvn compile -q
+if [[ "$FAST" == true ]]; then
+    echo "Compiling (fast: reusing existing build)..."
+    mvn compile -q
+else
+    echo "Building (clean)... use --fast to skip when only mc-web changed"
+    mvn clean install -DskipTests -q
+fi
 
 echo "Starting application with $ENV_NAME environment..."
 MAVEN_OPTS="$MAVEN_OPTS" exec mvn exec:java -pl mc-web

--- a/webapp/scripts/test.sh
+++ b/webapp/scripts/test.sh
@@ -13,6 +13,8 @@ usage() {
     echo "  --database            Include database tests (requires Docker)"
     echo "  --integration         Include integration tests (requires Docker and the app running)"
     echo "  --exclude-unit-tests  Skip unit tests"
+    echo "  --clean               Wipe target/ first. Needed after an mc-domain change — Kotlin's"
+    echo "                        incremental compilation leaves stale classes across modules."
     echo ""
     echo "Anything after a literal '--' is forwarded verbatim to the underlying 'mvn test' runs,"
     echo "e.g. narrow to one class:  $0 --database -- -Dtest=IngestionLedgerStepsTest"
@@ -22,10 +24,15 @@ usage() {
 DATABASE=false
 INTEGRATION=false
 UNIT=true
+CLEAN=false
 PASSTHROUGH=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --clean)
+            CLEAN=true
+            shift
+            ;;
         --database)
             DATABASE=true
             shift
@@ -60,6 +67,11 @@ if [[ ! -f mc-web/src/main/resources/keys/private_key.pem ]]; then
     (cd mc-web && bash create-keys.sh)
 fi
 
+if [[ "$CLEAN" == true ]]; then
+    echo "Cleaning..."
+    mvn clean -q -B
+fi
+
 echo "Compiling..."
 mvn test-compile -B
 
@@ -70,10 +82,10 @@ fi
 
 if [[ "$DATABASE" == true ]]; then
     echo "Running database tests..."
-    mvn test -pl mc-web -Dsurefire.excludedGroups= -Dgroups=database -B ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}
+    mvn test -pl mc-web -am -Dsurefire.excludedGroups= -Dgroups=database -B ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}
 fi
 
 if [[ "$INTEGRATION" == true ]]; then
     echo "Running integration tests..."
-    mvn failsafe:integration-test failsafe:verify -pl mc-web -B ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}
+    mvn failsafe:integration-test failsafe:verify -pl mc-web -am -B ${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"}
 fi


### PR DESCRIPTION
## Why

Three failures in one session, all the same two root causes, all surfacing at runtime as `NoSuchMethodError` / `NoClassDefFoundError` naming a class that plainly exists in the working tree, from a file nobody touched:

1. `run.sh` → every `/worlds` request died with `NoSuchMethodError: World.<init>` after pulling a `master` that changed the constructor. `mc-web/target/classes/WorldExtractorsKt.class` was **five weeks old**.
2. `test.sh --database -- -pl mc-web` → `NoClassDefFoundError: ProgressSource`.
3. `test.sh` default tier → `NoSuchMethodError: ResourceGatheringItem.<init>` from stale *test* classes.

Two causes:

- **Kotlin's incremental compilation does not propagate an ABI change across module boundaries.** After an `mc-domain` change it rebuilds only the files that textually changed and leaves stale callers in place. `mvn compile` doesn't fix it; neither does `mvn install` (that refreshes the jar, not the caller). Only `clean` does.
- **`-pl <module>` resolves siblings from `~/.m2`**, not the reactor.

## Changes

- `run.sh`: `mvn clean install -DskipTests` instead of `mvn compile`, with `--fast` to reuse an existing build when only `mc-web` changed.
- `test.sh`: `-am` on the module-scoped tiers, plus a `--clean` flag.
- `CLAUDE.md`: a section that leads with the *symptom*, since the whole difficulty is that it doesn't look like a build problem.

## Cost

Slower startup by default. Worth it — each incident above burned far more time than a rebuild, and `--fast` is there for the common case of iterating inside `mc-web`.

CI is unaffected (fresh checkout, full reactor), which is why this only ever bit locally.

## Testing

`run.sh` verified on both paths (clean and `--fast`) — reaches listening state and serves. `test.sh --database` green: 692 unit + 101 database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)