### PR TITLE
MCO-296: wire operational projects' productions into plans as farm supply

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ProgressSource.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ProgressSource.kt
@@ -7,8 +7,8 @@ package app.mcorg.domain.model.resources
  * counters are the fallback when it isn't. Last-write-wins needs both sides to be able to tell
  * which one wrote the value they're reading.
  *
- * Not to be confused with `ResourceGatheringItem.sourceType`, which is the item's *acquisition*
- * type from the graph (MINED, CRAFTED, …).
+ * Not to be confused with `ResourceGatheringItem.sourceType`, which is the row's explicitly
+ * chosen acquisition source ([ResourceSourceType]).
  */
 enum class ProgressSource(val value: String) {
     /** Set through the web app. */

--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ResourceGatheringItem.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ResourceGatheringItem.kt
@@ -8,7 +8,7 @@ data class ResourceGatheringItem(
     val required: Int,
     val collected: Int,
     val solvedByProject: Pair<Int, String>? = null,
-    val sourceType: String? = null,
+    val sourceType: ResourceSourceType? = null,
     val ignored: Boolean = false,
     /** Which client last set [collected]. See [ProgressSource] — unrelated to [sourceType]. */
     val progressSource: ProgressSource = ProgressSource.MANUAL,

--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ResourceSourceType.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/resources/ResourceSourceType.kt
@@ -1,0 +1,26 @@
+package app.mcorg.domain.model.resources
+
+/**
+ * A resource row's explicitly chosen acquisition source (`resource_gathering.source_type`).
+ *
+ * Null on `ResourceGatheringItem.sourceType` means "no explicit choice" — the planner is
+ * free to pick. An explicit choice encodes user intent and beats ambient world supply
+ * (MCO-296): [MANUAL] opts the item out of farm supply entirely; [PROJECT] pins it to a
+ * linked project (`solved_by_project_id`).
+ *
+ * [value] is both the stored DB value and the `type` parameter in the source-picker
+ * requests — the two contracts are the same strings by design.
+ */
+enum class ResourceSourceType(val value: String) {
+    /** User chose "Manual gather" in the source picker. */
+    MANUAL("manual"),
+
+    /** User linked the row to another project. */
+    PROJECT("project");
+
+    companion object {
+        /** Parse a stored or submitted value. Null or unrecognised reads as null (no explicit choice). */
+        fun fromValue(value: String?): ResourceSourceType? =
+            entries.firstOrNull { it.value == value }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/api/ApiRoutes.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/api/ApiRoutes.kt
@@ -223,7 +223,7 @@ suspend fun ApplicationCall.handleGetWorldProjects() {
                     name = it.name,
                     required = it.required,
                     collected = it.collected,
-                    sourceType = it.sourceType,
+                    sourceType = it.sourceType?.value,
                     progressSource = it.progressSource.value,
                 )
             },
@@ -297,7 +297,7 @@ suspend fun ApplicationCall.handleSyncResources() {
                     name = it.name,
                     required = it.required,
                     collected = it.collected,
-                    sourceType = it.sourceType,
+                    sourceType = it.sourceType?.value,
                     progressSource = it.progressSource.value,
                 )
             }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStep.kt
@@ -39,8 +39,11 @@ data class GatheringPlanInput(
  * 4. Exclude rows marked `ignored` (MCO-247) — kept in storage for reversibility, but
  *    excluded from the derivation input so shared intermediates recompute without them.
  * 5. Build [PlanTarget]s: amount = max(0, required − collected); skip fully-collected rows.
- * 6. Build the [SupplySource] map: rows linked to another project become
- *    [SupplySource.LinkedProject] terminals.
+ * 6. Build the [SupplySource] map (MCO-296): operational (DONE) projects' productions
+ *    supply the whole world as [SupplySource.Farm] terminals — targets and engine-derived
+ *    intermediates alike. Explicit row-level choices win over ambient farm supply: a
+ *    `manual` source pick opts that item out, and a project link overlays it as a
+ *    [SupplySource.LinkedProject] terminal.
  * 7. Load persisted [PlanOverrides] for the project.
  * 8. Run [GatheringPlanner.plan] and return the result.
  *
@@ -99,13 +102,32 @@ object GenerateGatheringPlanStep : Step<GatheringPlanInput, AppFailure, Gatherin
             )
         }
 
-        // 6. Build supplied map: rows linked to another project become supply terminals
-        val supplied: Map<String, SupplySource> = activeItems
+        // 6. Build supplied map — world farm supply first, explicit choices on top.
+        // Operational (DONE) projects' productions supply the whole world (MCO-296): any
+        // item they produce terminates as a SUPPLIED leaf wherever it appears in a chain.
+        // An explicit 'manual' source pick opts the item out of farm supply; an explicit
+        // project link replaces the farm entry via the map union below.
+        val farms = when (val r = GetWorldFarmSuppliesStep.process(
+            WorldFarmSuppliesInput(worldId = input.worldId, excludeProjectId = input.projectId)
+        )) {
+            is Result.Success -> r.value
+            is Result.Failure -> return r
+        }
+        val manualItems: Set<String> = activeItems
+            .filter { it.sourceType == "manual" }
+            .map { it.itemId }
+            .toSet()
+        val farmSupplied: Map<String, SupplySource> = farms
+            .filter { it.itemId !in manualItems }
+            .groupBy { it.itemId }
+            .mapValues { (_, producers) -> SupplySource.Farm(producers.first().projectName) }
+        val linkedSupplied: Map<String, SupplySource> = activeItems
             .mapNotNull { item ->
                 val (solvedId, solvedName) = item.solvedByProject ?: return@mapNotNull null
                 item.itemId to SupplySource.LinkedProject(solvedId, solvedName)
             }
             .toMap()
+        val supplied: Map<String, SupplySource> = farmSupplied + linkedSupplied
 
         // 7. Load persisted overrides for this project
         val overrides: PlanOverrides = when (val r = GetPlanOverridesStep.process(input.projectId)) {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStep.kt
@@ -2,6 +2,7 @@ package app.mcorg.pipeline.resources
 
 import app.mcorg.domain.model.minecraft.Item
 import app.mcorg.domain.model.resources.ResourceGatheringItem
+import app.mcorg.domain.model.resources.ResourceSourceType
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.engine.model.ItemSourceGraph
 import app.mcorg.engine.plan.GatheringPlan
@@ -114,7 +115,7 @@ object GenerateGatheringPlanStep : Step<GatheringPlanInput, AppFailure, Gatherin
             is Result.Failure -> return r
         }
         val manualItems: Set<String> = activeItems
-            .filter { it.sourceType == "manual" }
+            .filter { it.sourceType == ResourceSourceType.MANUAL }
             .map { it.itemId }
             .toSet()
         val farmSupplied: Map<String, SupplySource> = farms

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GetWorldFarmSuppliesStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GetWorldFarmSuppliesStep.kt
@@ -1,0 +1,69 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.SafeSQL
+
+/**
+ * Input for [GetWorldFarmSuppliesStep].
+ *
+ * @param worldId the world whose operational projects' productions are collected.
+ * @param excludeProjectId the project being planned — its own productions never
+ *   supply its own plan (a farm's build materials must not be satisfied by the
+ *   farm itself).
+ */
+data class WorldFarmSuppliesInput(
+    val worldId: Int,
+    val excludeProjectId: Int,
+)
+
+/** One produced item of an operational project in the world. */
+data class FarmSupplyRow(
+    val itemId: String,
+    val projectId: Int,
+    val projectName: String,
+)
+
+/**
+ * Loads the produced items of all operational projects in a world (MCO-296).
+ *
+ * A project is operational when its lifecycle state is [ProjectState.DONE] — for a
+ * project with `project_productions` rows that means "built and producing", so its
+ * output supplies every other project's gathering plan. CANCELLED/ARCHIVED projects
+ * are decommissioned and never supply.
+ *
+ * Rows are ordered by project name so callers that reduce multiple producers of the
+ * same item to a single [app.mcorg.engine.plan.SupplySource.Farm] pick deterministically.
+ */
+val GetWorldFarmSuppliesStep = DatabaseSteps.query<WorldFarmSuppliesInput, List<FarmSupplyRow>>(
+    sql = SafeSQL.select("""
+                SELECT
+                    pp.item_id,
+                    p.id AS project_id,
+                    p.name AS project_name
+                FROM project_productions pp
+                JOIN projects p ON p.id = pp.project_id
+                WHERE p.world_id = ?
+                  AND p.state = ?
+                  AND p.id <> ?
+                ORDER BY p.name, pp.item_id
+            """),
+    parameterSetter = { statement, input ->
+        statement.setInt(1, input.worldId)
+        statement.setString(2, ProjectState.DONE.name)
+        statement.setInt(3, input.excludeProjectId)
+    },
+    resultMapper = { resultSet ->
+        val rows = mutableListOf<FarmSupplyRow>()
+        while (resultSet.next()) {
+            rows.add(
+                FarmSupplyRow(
+                    itemId = resultSet.getString("item_id"),
+                    projectId = resultSet.getInt("project_id"),
+                    projectName = resultSet.getString("project_name"),
+                )
+            )
+        }
+        rows
+    }
+)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/ResourceDetailPanelPipelines.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/ResourceDetailPanelPipelines.kt
@@ -1,5 +1,6 @@
 package app.mcorg.pipeline.resources
 
+import app.mcorg.domain.model.resources.ResourceSourceType
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.failure.AppFailure
@@ -85,8 +86,8 @@ internal data class ValidateResourceSourceInputStep(
     override suspend fun process(input: Parameters): Result<AppFailure.ValidationError, ResourceSourceAssignment> {
         val type = input["type"]
         return when (type) {
-            "manual" -> Result.success(ResourceSourceAssignment.Manual)
-            "project" -> {
+            ResourceSourceType.MANUAL.value -> Result.success(ResourceSourceAssignment.Manual)
+            ResourceSourceType.PROJECT.value -> {
                 val projectIdRaw = input["projectId"]
                 val projectId = projectIdRaw?.toIntOrNull()
                     ?: return Result.failure(
@@ -113,7 +114,7 @@ internal data class ValidateResourceSourceInputStep(
             )
             else -> Result.failure(
                 AppFailure.ValidationError(
-                    listOf(ValidationFailure.InvalidValue("type", listOf("manual", "project")))
+                    listOf(ValidationFailure.InvalidValue("type", ResourceSourceType.entries.map { it.value }))
                 )
             )
         }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/SetResourceSourceStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/commonsteps/SetResourceSourceStep.kt
@@ -1,5 +1,6 @@
 package app.mcorg.pipeline.resources.commonsteps
 
+import app.mcorg.domain.model.resources.ResourceSourceType
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
@@ -25,11 +26,11 @@ data class SetResourceSourceStep(val resourceGatheringId: Int) : Step<ResourceSo
             parameterSetter = { stmt, assignment ->
                 when (assignment) {
                     is ResourceSourceAssignment.Manual -> {
-                        stmt.setString(1, "manual")
+                        stmt.setString(1, ResourceSourceType.MANUAL.value)
                         stmt.setNull(2, Types.INTEGER)
                     }
                     is ResourceSourceAssignment.LinkedProject -> {
-                        stmt.setString(1, "project")
+                        stmt.setString(1, ResourceSourceType.PROJECT.value)
                         stmt.setInt(2, assignment.projectId)
                     }
                 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/extractors/ResourceGatheringItemExtractors.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/extractors/ResourceGatheringItemExtractors.kt
@@ -2,6 +2,7 @@ package app.mcorg.pipeline.resources.extractors
 
 import app.mcorg.domain.model.resources.ProgressSource
 import app.mcorg.domain.model.resources.ResourceGatheringItem
+import app.mcorg.domain.model.resources.ResourceSourceType
 import java.sql.ResultSet
 
 fun ResultSet.toResourceGatheringItems(): List<ResourceGatheringItem> {
@@ -13,7 +14,7 @@ fun ResultSet.toResourceGatheringItems(): List<ResourceGatheringItem> {
 }
 
 fun ResultSet.toResourceGatheringItem(): ResourceGatheringItem {
-    val sourceType = getString("source_type")
+    val sourceType = ResourceSourceType.fromValue(getString("source_type"))
     val solvedProjectId = getInt("solved_project_id").takeUnless { wasNull() }
     val solvedProjectName = getString("solved_project_name")
     val solvedByProject = if (solvedProjectId != null && solvedProjectName != null) {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ResourceDetailPanel.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ResourceDetailPanel.kt
@@ -2,6 +2,7 @@ package app.mcorg.presentation.templated.dsl.pages
 
 import app.mcorg.domain.model.minecraft.Item
 import app.mcorg.domain.model.resources.ResourceGatheringItem
+import app.mcorg.domain.model.resources.ResourceSourceType
 import app.mcorg.presentation.hxDelete
 import app.mcorg.presentation.hxDeleteWithConfirm
 import app.mcorg.presentation.hxOutOfBands
@@ -117,7 +118,7 @@ fun FlowContent.resourcePanelSourceSection(
             button(classes = "btn btn--secondary resource-panel__source-btn") {
                 type = ButtonType.button
                 hxPatch(sourceUrl)
-                attributes["hx-vals"] = """{"type":"manual"}"""
+                attributes["hx-vals"] = """{"type":"${ResourceSourceType.MANUAL.value}"}"""
                 hxTarget("#resource-panel-source")
                 hxSwap("innerHTML")
                 +"Manual gather"
@@ -132,7 +133,7 @@ fun FlowContent.resourcePanelSourceSection(
                         id = "resource-panel-project-select"
                         name = "projectId"
                         hxPatch(sourceUrl)
-                        attributes["hx-vals"] = """js:{type:"project",projectId:event.target.value}"""
+                        attributes["hx-vals"] = """js:{type:"${ResourceSourceType.PROJECT.value}",projectId:event.target.value}"""
                         hxTarget("#resource-panel-source")
                         hxSwap("innerHTML")
                         hxTrigger("change")
@@ -152,7 +153,7 @@ fun FlowContent.resourcePanelSourceSection(
                 }
             }
         }
-        "manual" -> {
+        ResourceSourceType.MANUAL -> {
             div("resource-panel__source-set") {
                 span("status-dot status-dot--set") {}
                 span("resource-panel__source-label") { +"Manual gather" }
@@ -165,7 +166,7 @@ fun FlowContent.resourcePanelSourceSection(
                 }
             }
         }
-        "project" -> {
+        ResourceSourceType.PROJECT -> {
             val label = resource.solvedByProject?.second ?: "Unknown project"
             div("resource-panel__source-set") {
                 span("status-dot status-dot--set") {}
@@ -178,9 +179,6 @@ fun FlowContent.resourcePanelSourceSection(
                     +"Change"
                 }
             }
-        }
-        else -> {
-            p("resource-panel__source-empty") { +"No source selected" }
         }
     }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStepTest.kt
@@ -8,6 +8,7 @@ import app.mcorg.domain.model.minecraft.ServerData
 import app.mcorg.domain.model.resources.ResourceQuantity
 import app.mcorg.domain.model.resources.ResourceSource
 import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.SupplySource
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
@@ -225,6 +226,149 @@ class GenerateGatheringPlanStepTest : WithUser() {
     }
 
     // ─────────────────────────────────────────────────────────────────────────
+    // MCO-296: operational (DONE) projects' productions supply the whole world.
+    // Each test uses a fresh world — farm supply is world-scoped and would leak
+    // across tests sharing the class-level world.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `operational project production becomes a Farm SUPPLIED terminal`() {
+        val farmWorldId = createWorld(version)
+        val farmId = createProject(farmWorldId, name = "Oak Farm")
+        insertProduction(farmId, oakPlanks.id, oakPlanks.name)
+        setProjectState(farmId, "DONE")
+
+        val consumerId = createProject(farmWorldId)
+        insertGatheringItem(consumerId, oakPlanks.id, oakPlanks.name, required = 10)
+
+        val result = runBlocking {
+            GenerateGatheringPlanStep.process(GatheringPlanInput(consumerId, farmWorldId))
+        }
+
+        assertIs<Result.Success<*>>(result)
+        val node = (result as Result.Success).value.nodes[oakPlanks.id]
+        assertNotNull(node, "oak_planks must be in the plan")
+        assertEquals(PlanNodeStatus.SUPPLIED, node.status)
+        val supply = node.supply
+        assertIs<SupplySource.Farm>(supply, "supply must be a Farm, not a linked project")
+        assertEquals("Oak Farm", supply.label)
+    }
+
+    @Test
+    fun `farm supply terminates intermediates not just targets`() {
+        val farmWorldId = createWorld(version)
+        val farmId = createProject(farmWorldId, name = "Tree Farm")
+        insertProduction(farmId, log.id, log.name)
+        setProjectState(farmId, "DONE")
+
+        val consumerId = createProject(farmWorldId)
+        // oak_planks is the target; its recipe requires oak_log — the farm-supplied item
+        // only ever appears as an engine-derived intermediate, never as a target row.
+        insertGatheringItem(consumerId, oakPlanks.id, oakPlanks.name, required = 8)
+
+        val result = runBlocking {
+            GenerateGatheringPlanStep.process(GatheringPlanInput(consumerId, farmWorldId))
+        }
+
+        assertIs<Result.Success<*>>(result)
+        val plan = (result as Result.Success).value
+        assertEquals(PlanNodeStatus.RESOLVED, plan.nodes[oakPlanks.id]?.status, "planks still crafted")
+        val logNode = plan.nodes[log.id]
+        assertNotNull(logNode, "oak_log intermediate must be in the plan")
+        assertEquals(PlanNodeStatus.SUPPLIED, logNode.status)
+        assertIs<SupplySource.Farm>(logNode.supply)
+    }
+
+    @Test
+    fun `non-operational project productions do not supply`() {
+        val farmWorldId = createWorld(version)
+        val farmId = createProject(farmWorldId, name = "Unfinished Farm")
+        insertProduction(farmId, oakPlanks.id, oakPlanks.name)
+        // state stays at the default PENDING — declared productions, not yet operational
+
+        val consumerId = createProject(farmWorldId)
+        insertGatheringItem(consumerId, oakPlanks.id, oakPlanks.name, required = 10)
+
+        val result = runBlocking {
+            GenerateGatheringPlanStep.process(GatheringPlanInput(consumerId, farmWorldId))
+        }
+
+        assertIs<Result.Success<*>>(result)
+        val node = (result as Result.Success).value.nodes[oakPlanks.id]
+        assertNotNull(node)
+        assertEquals(PlanNodeStatus.RESOLVED, node.status, "not-yet-operational farm must not supply")
+        assertEquals(null, node.supply)
+    }
+
+    @Test
+    fun `explicit project link wins over ambient farm supply`() {
+        val farmWorldId = createWorld(version)
+        val farmId = createProject(farmWorldId, name = "Oak Farm")
+        insertProduction(farmId, oakPlanks.id, oakPlanks.name)
+        setProjectState(farmId, "DONE")
+        val producerId = createProject(farmWorldId, name = "Chosen Producer")
+
+        val consumerId = createProject(farmWorldId)
+        val rgId = insertGatheringItem(consumerId, oakPlanks.id, oakPlanks.name, required = 10)
+        linkResourceToProject(rgId, producerId)
+
+        val result = runBlocking {
+            GenerateGatheringPlanStep.process(GatheringPlanInput(consumerId, farmWorldId))
+        }
+
+        assertIs<Result.Success<*>>(result)
+        val node = (result as Result.Success).value.nodes[oakPlanks.id]
+        assertNotNull(node)
+        assertEquals(PlanNodeStatus.SUPPLIED, node.status)
+        val supply = node.supply
+        assertIs<SupplySource.LinkedProject>(supply, "explicit link must beat ambient farm supply")
+        assertEquals(producerId, supply.projectId)
+    }
+
+    @Test
+    fun `explicit manual source pick opts the item out of farm supply`() {
+        val farmWorldId = createWorld(version)
+        val farmId = createProject(farmWorldId, name = "Oak Farm")
+        insertProduction(farmId, oakPlanks.id, oakPlanks.name)
+        setProjectState(farmId, "DONE")
+
+        val consumerId = createProject(farmWorldId)
+        val rgId = insertGatheringItem(consumerId, oakPlanks.id, oakPlanks.name, required = 10)
+        markResourceManual(rgId)
+
+        val result = runBlocking {
+            GenerateGatheringPlanStep.process(GatheringPlanInput(consumerId, farmWorldId))
+        }
+
+        assertIs<Result.Success<*>>(result)
+        val node = (result as Result.Success).value.nodes[oakPlanks.id]
+        assertNotNull(node)
+        assertEquals(PlanNodeStatus.RESOLVED, node.status, "manual pick must opt out of farm supply")
+        assertEquals(null, node.supply)
+    }
+
+    @Test
+    fun `a project's own productions never supply its own plan`() {
+        val farmWorldId = createWorld(version)
+        // The planned project is itself a DONE farm producing oak_planks — its build
+        // materials must not be satisfied by its own output.
+        val selfId = createProject(farmWorldId, name = "Self Farm")
+        insertProduction(selfId, oakPlanks.id, oakPlanks.name)
+        setProjectState(selfId, "DONE")
+        insertGatheringItem(selfId, oakPlanks.id, oakPlanks.name, required = 10)
+
+        val result = runBlocking {
+            GenerateGatheringPlanStep.process(GatheringPlanInput(selfId, farmWorldId))
+        }
+
+        assertIs<Result.Success<*>>(result)
+        val node = (result as Result.Success).value.nodes[oakPlanks.id]
+        assertNotNull(node)
+        assertEquals(PlanNodeStatus.RESOLVED, node.status, "own productions must be excluded")
+        assertEquals(null, node.supply)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
     // MCO-247: ignored targets drop out of the derived plan, and a shared
     // intermediate's quantity recomputes without them (reversible via un-ignore).
     // ─────────────────────────────────────────────────────────────────────────
@@ -319,15 +463,56 @@ class GenerateGatheringPlanStepTest : WithUser() {
         (result as Result.Success).value
     }
 
-    private fun createProject(worldId: Int): Int = runBlocking {
+    private fun createProject(worldId: Int, name: String = "GatheringPlanStep Project"): Int = runBlocking {
         val result = DatabaseSteps.update<Unit>(
             sql = SafeSQL.insert(
                 "INSERT INTO projects (name, world_id, description, type, stage, location_x, location_y, location_z, location_dimension) " +
-                    "VALUES ('GatheringPlanStep Project', ?, '', 'BUILDING', 'PLANNING', 0, 0, 0, 'OVERWORLD') RETURNING id"
+                    "VALUES (?, ?, '', 'BUILDING', 'PLANNING', 0, 0, 0, 'OVERWORLD') RETURNING id"
             ),
-            parameterSetter = { stmt, _ -> stmt.setInt(1, worldId) }
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, name)
+                stmt.setInt(2, worldId)
+            }
         ).process(Unit)
         (result as Result.Success).value
+    }
+
+    private fun setProjectState(projectId: Int, state: String) {
+        runBlocking {
+            DatabaseSteps.update<Unit>(
+                sql = SafeSQL.update("UPDATE projects SET state = ? WHERE id = ?"),
+                parameterSetter = { stmt, _ ->
+                    stmt.setString(1, state)
+                    stmt.setInt(2, projectId)
+                }
+            ).process(Unit)
+        }
+    }
+
+    private fun insertProduction(projectId: Int, itemId: String, name: String, ratePerHour: Int = 100) {
+        runBlocking {
+            DatabaseSteps.update<Unit>(
+                sql = SafeSQL.insert(
+                    "INSERT INTO project_productions (project_id, item_id, name, rate_per_hour) " +
+                        "VALUES (?, ?, ?, ?) RETURNING id"
+                ),
+                parameterSetter = { stmt, _ ->
+                    stmt.setInt(1, projectId)
+                    stmt.setString(2, itemId)
+                    stmt.setString(3, name)
+                    stmt.setInt(4, ratePerHour)
+                }
+            ).process(Unit)
+        }
+    }
+
+    private fun markResourceManual(resourceGatheringId: Int) {
+        runBlocking {
+            DatabaseSteps.update<Unit>(
+                sql = SafeSQL.update("UPDATE resource_gathering SET source_type = 'manual' WHERE id = ?"),
+                parameterSetter = { stmt, _ -> stmt.setInt(1, resourceGatheringId) }
+            ).process(Unit)
+        }
     }
 
     private fun insertGatheringItem(

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/ResourceSourceStepsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/ResourceSourceStepsTest.kt
@@ -1,6 +1,7 @@
 package app.mcorg.pipeline.resources
 
 import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.resources.ResourceSourceType
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
@@ -50,7 +51,7 @@ class ResourceSourceStepsTest : WithUser() {
         val stored = runBlocking { GetResourceGatheringItemStep.process(rgId) }
         assertIs<Result.Success<*>>(stored)
         val item = (stored as Result.Success).value
-        assertEquals("manual", item.sourceType)
+        assertEquals(ResourceSourceType.MANUAL, item.sourceType)
         assertNull(item.solvedByProject)
     }
 
@@ -66,7 +67,7 @@ class ResourceSourceStepsTest : WithUser() {
         val stored = runBlocking { GetResourceGatheringItemStep.process(rgId) }
         assertIs<Result.Success<*>>(stored)
         val item = (stored as Result.Success).value
-        assertEquals("project", item.sourceType)
+        assertEquals(ResourceSourceType.PROJECT, item.sourceType)
         assertEquals(otherProjectId, item.solvedByProject?.first)
         assertEquals("ResourceSource Sibling", item.solvedByProject?.second)
     }


### PR DESCRIPTION
## Summary

Phase 1 of the farm-supply epic ([MCO-287](https://linear.app/evegul/issue/MCO-287)): operational (state `DONE`) projects' `project_productions` rows now enter every other project's gathering plan as `SupplySource.Farm` terminals — the first piece of the world supply model.

- New `GetWorldFarmSuppliesStep`: produced items of all DONE projects in the world, excluding the project being planned (a farm's build materials must not be satisfied by the farm itself)
- `GenerateGatheringPlanStep` folds farm supply into the `supplied` map. Farm supply applies to targets **and** engine-derived intermediates
- **Precedence — explicit beats ambient:** a row's explicit `manual` source pick opts that item out of farm supply; an explicit project link overlays the farm entry (`SupplySource.LinkedProject` wins)
- Multiple farms producing the same item resolve first-by-project-name (deterministic; promotion paths noted on [MCO-299](https://linear.app/evegul/issue/MCO-299))
- `mc-engine` untouched — `SupplySource.Farm` existed with tests, unwired

Linear: [MCO-296](https://linear.app/evegul/issue/MCO-296)

## Test plan

- [x] 6 new cases in `GenerateGatheringPlanStepTest` (database tier): farm supplies target · farm supplies intermediate · non-DONE project does not supply · project link wins over farm · manual pick opts out · own productions excluded
- [x] `mvn clean compile` clean; full unit + database tiers green (107 DB-tier tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)