### PR TITLE
MCO-297: production editor — Produces meta chip + panel

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -15,6 +15,7 @@ import app.mcorg.pipeline.resources.buildCandidateCounts
 import app.mcorg.pipeline.resources.buildNodeIngredients
 import app.mcorg.pipeline.resources.drillTreeFor
 import app.mcorg.pipeline.resources.getGraphForWorld
+import app.mcorg.pipeline.project.resources.GetResourceProductionStep
 import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
 import app.mcorg.pipeline.resources.commonsteps.GetProgressForProjectStep
 import app.mcorg.pipeline.task.SearchTasksInput
@@ -58,6 +59,8 @@ suspend fun ApplicationCall.handleGetProject() {
         ?: "list"
 
     val resources = GetAllResourceGatheringItemsStep.process(projectId).getOrNull() ?: emptyList()
+
+    val productions = GetResourceProductionStep.process(projectId).getOrNull() ?: emptyList()
 
     val tasks = when (val result = SearchTasksStep(projectId).process(SearchTasksInput(completionStatus = "ALL"))) {
         is Result.Success -> result.value
@@ -103,6 +106,7 @@ suspend fun ApplicationCall.handleGetProject() {
         projectDetailPage(
             user, project, worldName, resources, tasks, lens,
             isWorldAdmin = isAdmin, plan = plan, progressMap = progressMap,
+            productions = productions,
             drillTarget = drillTarget, drillCandidateCounts = drillCandidateCounts,
             drillNodeIngredients = drillNodeIngredients, drillHighlightItemId = drillItemId,
             drillOverrides = drillOverrides, drillGraph = drillGraph,

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/resources/ProjectProductionPipelines.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/resources/ProjectProductionPipelines.kt
@@ -1,0 +1,161 @@
+package app.mcorg.pipeline.project.resources
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.project.ProjectProduction
+import app.mcorg.domain.model.user.Role
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.ValidationSteps
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.failure.ValidationFailure
+import app.mcorg.pipeline.world.ValidateWorldMemberRole
+import app.mcorg.presentation.handler.handlePipeline
+import app.mcorg.presentation.templated.dsl.pages.productionsFieldFragment
+import app.mcorg.presentation.templated.dsl.pages.productionsPanelFragment
+import app.mcorg.presentation.utils.getProjectId
+import app.mcorg.presentation.utils.getProjectProductionItemId
+import app.mcorg.presentation.utils.getUser
+import app.mcorg.presentation.utils.getWorldId
+import app.mcorg.presentation.utils.respondHtml
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveParameters
+
+/** Validated input for [UpsertProjectProductionStep]. */
+data class ProjectProductionInput(
+    val itemId: String,
+    val name: String,
+    val ratePerHour: Int,
+)
+
+/**
+ * MCO-297 — the production editor endpoints. POST is an upsert on (project_id, item_id)
+ * (unique constraint from V2_50_0): adding an item that is already produced updates its
+ * rate instead of duplicating the row, so inline rate edits and the add form share one
+ * endpoint. Rate is optional and display-only under unbounded-supply V1; 0 means "unknown".
+ */
+internal data class ValidateProjectProductionInputStep(val validItems: List<Item>) :
+    Step<Parameters, AppFailure.ValidationError, ProjectProductionInput> {
+    override suspend fun process(input: Parameters): Result<AppFailure.ValidationError, ProjectProductionInput> {
+        val itemId = ValidationSteps.required("itemId") { it }.process(input)
+            .flatMap { id ->
+                ValidationSteps.validateAllowedValues(
+                    "itemId",
+                    validItems.map { item -> item.id },
+                    { it },
+                    ignoreCase = false
+                ).process(id)
+            }
+
+        val rateRaw = input["ratePerHour"]
+        val rate: Result<ValidationFailure, Int> = if (rateRaw.isNullOrBlank()) {
+            Result.success(0)
+        } else {
+            val parsed = rateRaw.toIntOrNull()
+            if (parsed != null && parsed >= 0) Result.success(parsed)
+            else Result.failure(ValidationFailure.InvalidFormat("ratePerHour", "must be a non-negative integer"))
+        }
+
+        val errors = mutableListOf<ValidationFailure>()
+        if (itemId is Result.Failure) errors.add(itemId.error)
+        if (rate is Result.Failure) errors.add(rate.error)
+
+        return if (errors.isEmpty()) {
+            val id = (itemId as Result.Success).value
+            val name = validItems.first { it.id == id }.name
+            Result.success(ProjectProductionInput(id, name, (rate as Result.Success).value))
+        } else {
+            Result.failure(AppFailure.ValidationError(errors))
+        }
+    }
+}
+
+internal data class UpsertProjectProductionStep(val projectId: Int) :
+    Step<ProjectProductionInput, AppFailure.DatabaseError, Int> {
+    override suspend fun process(input: ProjectProductionInput): Result<AppFailure.DatabaseError, Int> {
+        return DatabaseSteps.update<ProjectProductionInput>(
+            sql = SafeSQL.insert("""
+                INSERT INTO project_productions (project_id, item_id, name, rate_per_hour)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT (project_id, item_id)
+                DO UPDATE SET rate_per_hour = EXCLUDED.rate_per_hour, name = EXCLUDED.name, updated_at = NOW()
+                RETURNING id
+            """),
+            parameterSetter = { stmt, production ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, production.itemId)
+                stmt.setString(3, production.name)
+                stmt.setInt(4, production.ratePerHour)
+            }
+        ).process(input)
+    }
+}
+
+internal data class DeleteProjectProductionStep(val projectId: Int) :
+    Step<Int, AppFailure.DatabaseError, Int> {
+    override suspend fun process(input: Int): Result<AppFailure.DatabaseError, Int> {
+        return DatabaseSteps.update<Int>(
+            sql = SafeSQL.delete("DELETE FROM project_productions WHERE id = ? AND project_id = ?"),
+            parameterSetter = { stmt, productionId ->
+                stmt.setInt(1, productionId)
+                stmt.setInt(2, projectId)
+            }
+        ).process(input)
+    }
+}
+
+private suspend fun ApplicationCall.isWorldAdmin(worldId: Int): Boolean =
+    ValidateWorldMemberRole<Unit>(getUser(), Role.ADMIN, worldId).process(Unit) is Result.Success
+
+suspend fun ApplicationCall.handleGetProductionsPanel() {
+    val worldId = getWorldId()
+    val projectId = getProjectId()
+    val isAdmin = isWorldAdmin(worldId)
+    handlePipeline(
+        onSuccess = { productions: List<ProjectProduction> ->
+            respondHtml(productionsPanelFragment(worldId, projectId, productions, isAdmin))
+        }
+    ) {
+        GetResourceProductionStep.run(projectId)
+    }
+}
+
+suspend fun ApplicationCall.handleUpsertProjectProduction() {
+    val parameters = receiveParameters()
+    val worldId = getWorldId()
+    val projectId = getProjectId()
+    val isAdmin = isWorldAdmin(worldId)
+    val validItems = GetItemsInWorldVersionStep.process(worldId).getOrNull() ?: emptyList()
+    handlePipeline(
+        onSuccess = { productions: List<ProjectProduction> ->
+            respondHtml(
+                productionsPanelFragment(worldId, projectId, productions, isAdmin) +
+                    productionsFieldFragment(worldId, projectId, productions, isAdmin)
+            )
+        }
+    ) {
+        val input = ValidateProjectProductionInputStep(validItems).run(parameters)
+        UpsertProjectProductionStep(projectId).run(input)
+        GetResourceProductionStep.run(projectId)
+    }
+}
+
+suspend fun ApplicationCall.handleDeleteProjectProduction() {
+    val worldId = getWorldId()
+    val projectId = getProjectId()
+    val productionId = getProjectProductionItemId()
+    val isAdmin = isWorldAdmin(worldId)
+    handlePipeline(
+        onSuccess = { productions: List<ProjectProduction> ->
+            respondHtml(
+                productionsPanelFragment(worldId, projectId, productions, isAdmin) +
+                    productionsFieldFragment(worldId, projectId, productions, isAdmin)
+            )
+        }
+    ) {
+        DeleteProjectProductionStep(projectId).run(productionId)
+        GetResourceProductionStep.run(projectId)
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/ErrorHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/ErrorHandler.kt
@@ -181,6 +181,7 @@ private suspend fun ApplicationCall.handleErrorMessage(alertPopup: ErrorHandler.
 private fun AppFailure.toHttpStatusCode(): HttpStatusCode {
     return when (this) {
         is AppFailure.ValidationError -> this.errors.toHttpStatusCode()
+        is AppFailure.DatabaseError.NotFound -> HttpStatusCode.NotFound
         is AppFailure.DatabaseError -> HttpStatusCode.InternalServerError
         is AppFailure.ApiError -> HttpStatusCode.InternalServerError
         is AppFailure.FileError -> HttpStatusCode.InternalServerError

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -9,6 +9,9 @@ import app.mcorg.pipeline.project.handleDeleteProject
 import app.mcorg.pipeline.project.handleGetProject
 import app.mcorg.pipeline.project.handleGetDetailContent
 import app.mcorg.pipeline.project.resources.handleAddResourcesFromSchematic
+import app.mcorg.pipeline.project.resources.handleDeleteProjectProduction
+import app.mcorg.pipeline.project.resources.handleGetProductionsPanel
+import app.mcorg.pipeline.project.resources.handleUpsertProjectProduction
 import app.mcorg.pipeline.resources.handleClearOverride
 import app.mcorg.pipeline.resources.handleGetDrillChain
 import app.mcorg.pipeline.resources.handleGetNodePicker
@@ -61,6 +64,7 @@ import app.mcorg.pipeline.world.settings.members.handleUpdateWorldMemberRole
 import app.mcorg.presentation.plugins.ActionTaskParamPlugin
 import app.mcorg.presentation.plugins.InviteParamPlugin
 import app.mcorg.presentation.plugins.ProjectParamPlugin
+import app.mcorg.presentation.plugins.ProjectProductionItemParamPlugin
 import app.mcorg.presentation.plugins.ResourceGatheringIdParamPlugin
 import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
 import app.mcorg.presentation.plugins.WorldAdminPlugin
@@ -160,6 +164,20 @@ class WorldHandler {
                             patch("/state") { call.handleUpdateProjectStateInline() }
                             get("/location") { call.handleGetProjectLocationField() }
                             patch("/location") { call.handleUpdateProjectLocation() }
+                        }
+                        route("/productions") {
+                            get("/panel") {
+                                call.handleGetProductionsPanel()
+                            }
+                            post {
+                                call.handleUpsertProjectProduction()
+                            }
+                            route("/{productionId}") {
+                                install(ProjectProductionItemParamPlugin)
+                                delete {
+                                    call.handleDeleteProjectProduction()
+                                }
+                            }
                         }
                         get("/field-log-row") {
                             call.handleGetFieldLogRow()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/plugins/ParamPlugins.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/plugins/ParamPlugins.kt
@@ -171,7 +171,7 @@ val WorldMemberParamPlugin = createRouteScopedPlugin("MemberParamPlugin") {
 val ProjectProductionItemParamPlugin = createRouteScopedPlugin("ProjectProductionItemParamPlugin") {
     onCall { call ->
         val projectId = call.getProjectId()
-        val itemId = call.parameters["resourceId"]?.toIntOrNull()
+        val itemId = call.parameters["productionId"]?.toIntOrNull()
         if (itemId == null) {
             call.respondBadRequest("Invalid or missing project production item ID")
         } else {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProductionPanel.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProductionPanel.kt
@@ -1,0 +1,165 @@
+package app.mcorg.presentation.templated.dsl.pages
+
+import app.mcorg.domain.model.project.Project
+import app.mcorg.domain.model.project.ProjectProduction
+import kotlinx.html.*
+import kotlinx.html.stream.createHTML
+
+private fun productionsFieldId(projectId: Int) = "project-productions-field-$projectId"
+
+private fun productionsBase(worldId: Int, projectId: Int) = "/worlds/$worldId/projects/$projectId/productions"
+
+/**
+ * "Produces" meta-row field (MCO-297): a chip summarising the project's produced items,
+ * opening the productions editor in the shared #resource-panel dialog. Production is
+ * project identity — a DONE project with productions supplies the whole world (MCO-296) —
+ * so it sits beside state and location. Admins with no productions get a quiet
+ * "+ Produces" affordance; members with no productions see nothing.
+ */
+fun FlowContent.projectProductionsField(project: Project, productions: List<ProjectProduction>, isAdmin: Boolean) {
+    div("project-meta-field project-meta-field--productions") {
+        id = productionsFieldId(project.id)
+        productionsFieldInner(project.worldId, project.id, productions, isAdmin)
+    }
+}
+
+/** OOB re-render of the meta chip — sidecar on POST/DELETE panel responses. */
+fun productionsFieldFragment(worldId: Int, projectId: Int, productions: List<ProjectProduction>, isAdmin: Boolean): String =
+    createHTML().div("project-meta-field project-meta-field--productions") {
+        id = productionsFieldId(projectId)
+        attributes["hx-swap-oob"] = "true"
+        productionsFieldInner(worldId, projectId, productions, isAdmin)
+    }
+
+private fun DIV.productionsFieldInner(worldId: Int, projectId: Int, productions: List<ProjectProduction>, isAdmin: Boolean) {
+    val panelUrl = "${productionsBase(worldId, projectId)}/panel"
+    when {
+        productions.isNotEmpty() -> {
+            button(classes = "production-chip") {
+                type = ButtonType.button
+                attributes["data-production-panel-url"] = panelUrl
+                attributes["aria-label"] = "View produced items"
+                span("production-chip__label") { +"⚙ Produces:" }
+                val first = productions.first()
+                span("production-chip__item") {
+                    +first.name
+                    if (first.ratePerHour > 0) +" ${first.ratePerHour}/hr"
+                }
+                if (productions.size > 1) {
+                    span("production-chip__more") { +"+${productions.size - 1} more" }
+                }
+            }
+        }
+        isAdmin -> {
+            button(classes = "btn btn--ghost btn--sm") {
+                type = ButtonType.button
+                attributes["data-production-panel-url"] = panelUrl
+                +"+ Produces"
+            }
+        }
+    }
+}
+
+/**
+ * Productions editor panel — swaps into #resource-panel-content (opened by
+ * resource-panel.js via the chip's data-production-panel-url). Rate inputs upsert on
+ * change; the add search reuses /items/search with a panel-scoped results container
+ * (same capture-phase selection pattern as the variant search).
+ */
+fun FlowContent.productionsPanel(worldId: Int, projectId: Int, productions: List<ProjectProduction>, isAdmin: Boolean) {
+    val base = productionsBase(worldId, projectId)
+    div("resource-panel__header") {
+        button(classes = "resource-panel__close-btn") {
+            type = ButtonType.button
+            attributes["data-resource-panel-close"] = "true"
+            attributes["aria-label"] = "Back"
+            +"←"
+        }
+        button(classes = "resource-panel__close-btn resource-panel__close-btn--x") {
+            type = ButtonType.button
+            attributes["data-resource-panel-close"] = "true"
+            attributes["aria-label"] = "Close"
+            +"×"
+        }
+    }
+    div("resource-panel__title") {
+        h2("resource-panel__item-name") { +"Produces" }
+    }
+    p("production-panel__hint") {
+        +"Items this project outputs. Once the project is Done, they supply every other project's gathering plan."
+    }
+    div("resource-panel__divider") {}
+
+    if (productions.isEmpty()) {
+        p("resource-panel__source-empty") { +"No produced items declared" }
+    } else {
+        div("production-list") {
+            productions.forEach { production ->
+                div("production-row") {
+                    span("production-row__name") { +production.name }
+                    if (isAdmin) {
+                        div("production-row__controls") {
+                            input(type = InputType.number, classes = "form-control production-row__rate") {
+                                value = production.ratePerHour.toString()
+                                min = "0"
+                                attributes["aria-label"] = "${production.name} rate per hour"
+                                attributes["hx-post"] = base
+                                attributes["hx-vals"] = """js:{itemId:"${production.itemId}",ratePerHour:event.target.value}"""
+                                attributes["hx-target"] = "#resource-panel-content"
+                                attributes["hx-swap"] = "innerHTML"
+                                attributes["hx-trigger"] = "change"
+                            }
+                            span("production-row__unit") { +"/hr" }
+                            button(classes = "btn btn--ghost btn--sm production-row__delete") {
+                                type = ButtonType.button
+                                attributes["aria-label"] = "Remove ${production.name}"
+                                attributes["hx-delete"] = "$base/${production.id}"
+                                attributes["hx-target"] = "#resource-panel-content"
+                                attributes["hx-swap"] = "innerHTML"
+                                +"×"
+                            }
+                        }
+                    } else {
+                        span("production-row__unit") {
+                            +(if (production.ratePerHour > 0) "${production.ratePerHour}/hr" else "rate unknown")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (isAdmin) {
+        span("section-label production-panel__add-label") { +"Add produced item" }
+        div("production-panel__add") {
+            input(type = InputType.number, classes = "form-control production-row__rate") {
+                id = "production-panel-rate"
+                placeholder = "rate/hr"
+                min = "0"
+                attributes["aria-label"] = "Rate per hour for the item to add"
+            }
+            div("item-search-field") {
+                input(type = InputType.text, classes = "form-control") {
+                    id = "production-panel-item-input"
+                    placeholder = "Search items by name..."
+                    autoComplete = "off"
+                    attributes["hx-get"] = "/items/search"
+                    attributes["hx-trigger"] = "input changed delay:300ms"
+                    attributes["hx-target"] = "#production-panel-item-results"
+                    attributes["hx-swap"] = "innerHTML"
+                    attributes["hx-vals"] = "js:{q: this.value}"
+                }
+                div("item-search-results") {
+                    id = "production-panel-item-results"
+                    attributes["data-production-add-url"] = base
+                }
+            }
+        }
+    }
+}
+
+/** Full fragment for GET /productions/panel and the POST/DELETE re-renders. */
+fun productionsPanelFragment(worldId: Int, projectId: Int, productions: List<ProjectProduction>, isAdmin: Boolean): String =
+    createHTML().div {
+        productionsPanel(worldId, projectId, productions, isAdmin)
+    }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -1,6 +1,7 @@
 package app.mcorg.presentation.templated.dsl.pages
 
 import app.mcorg.domain.model.project.Project
+import app.mcorg.domain.model.project.ProjectProduction
 import app.mcorg.domain.model.resources.ResourceGatheringItem
 import app.mcorg.domain.model.task.ActionTask
 import app.mcorg.domain.model.user.TokenProfile
@@ -55,6 +56,7 @@ fun projectDetailPage(
     isWorldAdmin: Boolean = false,
     plan: GatheringPlan? = null,
     progressMap: Map<String, Int> = emptyMap(),
+    productions: List<ProjectProduction> = emptyList(),
     drillTarget: TargetTree? = null,
     drillCandidateCounts: Map<String, Int> = emptyMap(),
     drillNodeIngredients: Map<String, String> = emptyMap(),
@@ -112,6 +114,7 @@ fun projectDetailPage(
                     div("project-detail__meta") {
                         projectStateField(project, isWorldAdmin)
                         projectLocationField(project, isWorldAdmin)
+                        projectProductionsField(project, productions, isWorldAdmin)
                     }
                     gatheringOverallProgress(project.id, project.worldId, resources, plan, progressMap)
                 }

--- a/webapp/mc-web/src/main/resources/db/migration/V2_50_0__unique_project_production_item.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_50_0__unique_project_production_item.sql
@@ -1,0 +1,11 @@
+-- MCO-297: POST /worlds/{w}/projects/{p}/productions is an upsert on (project_id, item_id),
+-- which needs a unique constraint. Deduplicate first — idea imports could have written the
+-- same item twice; keep the lowest id per pair.
+DELETE FROM project_productions a
+USING project_productions b
+WHERE a.project_id = b.project_id
+  AND a.item_id = b.item_id
+  AND a.id > b.id;
+
+ALTER TABLE project_productions
+ADD CONSTRAINT uq_project_productions_project_item UNIQUE (project_id, item_id);

--- a/webapp/mc-web/src/main/resources/static/scripts/resource-panel.js
+++ b/webapp/mc-web/src/main/resources/static/scripts/resource-panel.js
@@ -235,6 +235,60 @@
     }
 
     // -------------------------------------------------------------------------
+    // Produces panel (MCO-297)
+    //
+    // The meta-row chip (and its empty-state "+ Produces" variant) opens the shared
+    // <dialog> with the productions editor. The add-item search reuses /items/search
+    // like the variant search above, with its own results container.
+    // -------------------------------------------------------------------------
+
+    function initProductionPanel() {
+        if (!document.body.dataset.productionChipInitialized) {
+            document.body.dataset.productionChipInitialized = 'true';
+            document.body.addEventListener('click', function (e) {
+                var trigger = e.target.closest('[data-production-panel-url]');
+                if (!trigger) return;
+                var dialog = getDialog();
+                var content = getContent();
+                if (!dialog || !content) return;
+                htmx.ajax('GET', trigger.dataset.productionPanelUrl, {
+                    target: '#resource-panel-content',
+                    swap: 'innerHTML'
+                }).then(function () {
+                    if (!dialog.open) dialog.showModal();
+                    currentResourceId = null;
+                });
+            });
+        }
+
+        var dialog = getDialog();
+        if (!dialog) return;
+        if (dialog.dataset.productionSearchInitialized) return;
+        dialog.dataset.productionSearchInitialized = 'true';
+
+        dialog.addEventListener('click', function (e) {
+            var results = e.target.closest('#production-panel-item-results');
+            if (!results) return;
+            var option = e.target.closest('.item-search-option');
+            if (!option) return;
+
+            e.stopPropagation();
+            e.preventDefault();
+
+            var itemId = option.dataset.itemId;
+            var addUrl = results.dataset.productionAddUrl;
+            if (!itemId || !addUrl) return;
+            var rateInput = document.getElementById('production-panel-rate');
+
+            htmx.ajax('POST', addUrl, {
+                target: '#resource-panel-content',
+                swap: 'innerHTML',
+                values: { itemId: itemId, ratePerHour: (rateInput && rateInput.value) || '0' }
+            });
+        }, true); // capture phase — see variant search above
+    }
+
+    // -------------------------------------------------------------------------
     // Init
     // -------------------------------------------------------------------------
 
@@ -244,6 +298,7 @@
         initViewToggleCleanup();
         initPanelQtyEdit();
         initVariantSearch();
+        initProductionPanel();
     }
 
     document.addEventListener('DOMContentLoaded', init);

--- a/webapp/mc-web/src/main/resources/static/styles/components/resource-panel.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/resource-panel.css
@@ -235,3 +235,57 @@ dialog#resource-panel::backdrop {
         border-top-right-radius: 12px;
     }
 }
+
+/* Produces panel (MCO-297) */
+.production-panel__hint {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    margin: 0;
+}
+
+.production-list {
+    display: flex;
+    flex-direction: column;
+}
+
+.production-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    padding: var(--space-2) 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.production-row__name {
+    font-family: var(--font-body);
+    font-size: var(--text-base);
+    color: var(--text-primary);
+}
+
+.production-row__controls {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+.production-row__rate {
+    width: 6.5rem;
+}
+
+.production-row__unit {
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+}
+
+.production-panel__add-label {
+    margin-top: var(--space-2);
+}
+
+.production-panel__add {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
@@ -552,3 +552,29 @@
     align-items: center;
     gap: var(--space-2);
 }
+
+/* "Produces" meta chip (MCO-297) */
+.production-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    background: none;
+    border: none;
+    padding: 0;
+    font-family: var(--font-ui);
+    font-size: var(--text-ui);
+    color: var(--text-muted);
+    cursor: pointer;
+}
+
+.production-chip__item {
+    color: var(--text-primary);
+}
+
+.production-chip:hover .production-chip__item {
+    color: var(--accent);
+}
+
+.production-chip__more {
+    color: var(--text-muted);
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ProjectProductionIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ProjectProductionIT.kt
@@ -1,0 +1,305 @@
+package app.mcorg.presentation.handler.project
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.minecraft.ServerData
+import app.mcorg.domain.model.resources.ResourceQuantity
+import app.mcorg.domain.model.resources.ResourceSource
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.minecraft.StoreMinecraftDataStep
+import app.mcorg.pipeline.project.resources.handleDeleteProjectProduction
+import app.mcorg.pipeline.project.resources.handleGetProductionsPanel
+import app.mcorg.pipeline.project.resources.handleUpsertProjectProduction
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.ProjectParamPlugin
+import app.mcorg.presentation.plugins.ProjectProductionItemParamPlugin
+import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
+import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+/**
+ * Endpoint tests for the production editor (MCO-297):
+ * - GET /productions/panel renders the editor
+ * - POST upserts (add, then same item again updates the rate — no duplicate row)
+ * - Validation: unknown item 422, missing item 400, blank rate defaults to 0
+ * - DELETE removes; deleting another project's production id is 404 (param plugin)
+ * - Unauthenticated requests redirect
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class ProjectProductionIT : WithUser() {
+
+    private val version = MinecraftVersion.Release(1, 99, 0)
+    private val ironIngot = Item("minecraft:iron_ingot", "Iron Ingot")
+    private val poppy = Item("minecraft:poppy", "Poppy")
+
+    private var worldId: Int = 0
+    private var projectId: Int = 0
+    private var siblingProjectId: Int = 0
+
+    @BeforeAll
+    fun setup() {
+        val serverData = ServerData(
+            version = version,
+            items = listOf(ironIngot, poppy),
+            sources = listOf(
+                ResourceSource(
+                    type = ResourceSource.SourceType.LootTypes.BLOCK,
+                    filename = "blocks/iron_ore.json",
+                    producedItems = listOf(ironIngot to ResourceQuantity.ItemQuantity(1))
+                )
+            )
+        )
+        val stored = runBlocking { StoreMinecraftDataStep.process(serverData) }
+        assertIs<Result.Success<*>>(stored)
+
+        worldId = createWorld("ProjectProduction IT World")
+        projectId = createProject(worldId, "Iron Farm")
+        siblingProjectId = createProject(worldId, "Sibling Project")
+    }
+
+    // -------------------------------------------------------------------------
+    // GET /productions/panel
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `GET panel returns editor HTML for world admin`() = testApplication {
+        setupRoutes()
+
+        val response = client.get(
+            "/worlds/$worldId/projects/$projectId/productions/panel"
+        ) { addAuthCookie(this) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertContains(body, "Produces")
+        assertContains(body, "Add produced item")
+    }
+
+    @Test
+    fun `GET panel unauthenticated returns redirect`() = testApplication {
+        setupRoutes()
+        val unauth = createClient { followRedirects = false }
+        val response = unauth.get("/worlds/$worldId/projects/$projectId/productions/panel")
+        assertEquals(HttpStatusCode.Found, response.status)
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /productions (upsert)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `POST adds a production and re-posting the same item updates the rate without duplicating`() = testApplication {
+        setupRoutes()
+
+        val first = client.post("/worlds/$worldId/projects/$projectId/productions") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("itemId=minecraft:iron_ingot&ratePerHour=400")
+        }
+        assertEquals(HttpStatusCode.OK, first.status)
+        assertContains(first.bodyAsText(), "Iron Ingot")
+        assertEquals(listOf("minecraft:iron_ingot" to 400), readProductions(projectId))
+
+        val second = client.post("/worlds/$worldId/projects/$projectId/productions") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("itemId=minecraft:iron_ingot&ratePerHour=800")
+        }
+        assertEquals(HttpStatusCode.OK, second.status)
+        assertEquals(listOf("minecraft:iron_ingot" to 800), readProductions(projectId), "upsert must not duplicate")
+
+        cleanupProductions(projectId)
+    }
+
+    @Test
+    fun `POST with blank rate defaults to 0`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/$projectId/productions") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("itemId=minecraft:poppy&ratePerHour=")
+        }
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(listOf("minecraft:poppy" to 0), readProductions(projectId))
+
+        cleanupProductions(projectId)
+    }
+
+    @Test
+    fun `POST with unknown item returns 422`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/$projectId/productions") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("itemId=minecraft:not_a_real_item&ratePerHour=10")
+        }
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertEquals(emptyList(), readProductions(projectId))
+    }
+
+    @Test
+    fun `POST with missing item returns 400`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/$projectId/productions") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("ratePerHour=10")
+        }
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    // -------------------------------------------------------------------------
+    // DELETE /productions/{productionId}
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `DELETE removes the production`() = testApplication {
+        setupRoutes()
+        val productionId = insertProduction(projectId, ironIngot.id, ironIngot.name, 400)
+
+        val response = client.delete(
+            "/worlds/$worldId/projects/$projectId/productions/$productionId"
+        ) { addAuthCookie(this) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertContains(response.bodyAsText(), "No produced items declared")
+        assertEquals(emptyList(), readProductions(projectId))
+    }
+
+    @Test
+    fun `DELETE with another project's production id returns 404`() = testApplication {
+        setupRoutes()
+        val foreignProductionId = insertProduction(siblingProjectId, poppy.id, poppy.name, 10)
+
+        val response = client.delete(
+            "/worlds/$worldId/projects/$projectId/productions/$foreignProductionId"
+        ) { addAuthCookie(this) }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+        assertEquals(listOf(poppy.id to 10), readProductions(siblingProjectId), "foreign row must survive")
+
+        cleanupProductions(siblingProjectId)
+    }
+
+    // -------------------------------------------------------------------------
+    // Routing — mirrors WorldHandler's /productions block
+    // -------------------------------------------------------------------------
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
+                install(UpdateActiveWorldPlugin)
+                route("/projects/{projectId}") {
+                    install(ProjectParamPlugin)
+                    route("/productions") {
+                        get("/panel") { call.handleGetProductionsPanel() }
+                        post { call.handleUpsertProjectProduction() }
+                        route("/{productionId}") {
+                            install(ProjectProductionItemParamPlugin)
+                            delete { call.handleDeleteProjectProduction() }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // DB fixture + read helpers
+    // -------------------------------------------------------------------------
+
+    private fun createWorld(name: String): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(name = name, description = "test", version = version)
+        )
+        (result as Result.Success).value
+    }
+
+    private fun createProject(worldId: Int, name: String): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, location_x, location_y, location_z, location_dimension) " +
+                    "VALUES (?, ?, '', 'FARMING', 'PLANNING', 0, 0, 0, 'OVERWORLD') RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, name)
+                stmt.setInt(2, worldId)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun insertProduction(projectId: Int, itemId: String, name: String, rate: Int): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO project_productions (project_id, item_id, name, rate_per_hour) VALUES (?, ?, ?, ?) RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+                stmt.setString(3, name)
+                stmt.setInt(4, rate)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun readProductions(projectId: Int): List<Pair<String, Int>> = runBlocking {
+        val result = DatabaseSteps.query<Int, List<Pair<String, Int>>>(
+            sql = SafeSQL.select(
+                "SELECT item_id, rate_per_hour FROM project_productions WHERE project_id = ? ORDER BY item_id"
+            ),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) },
+            resultMapper = { rs ->
+                val rows = mutableListOf<Pair<String, Int>>()
+                while (rs.next()) rows.add(rs.getString("item_id") to rs.getInt("rate_per_hour"))
+                rows
+            }
+        ).process(projectId)
+        (result as Result.Success).value
+    }
+
+    private fun cleanupProductions(projectId: Int) = runBlocking {
+        DatabaseSteps.update<Int>(
+            sql = SafeSQL.delete("DELETE FROM project_productions WHERE project_id = ?"),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) }
+        ).process(projectId)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of [MCO-287](https://linear.app/evegul/issue/MCO-287), **stacked on #367** — merge that first; this diff is the two phase-2 commits only.

- **Produces meta chip** beside state/location (quiet `+ Produces` for admins when empty; members with no productions see nothing) → opens the productions editor in the shared `#resource-panel` dialog
- **Panel**: rows with inline rate inputs + remove; add form reuses `/items/search` with the variant-search capture-phase selection pattern
- **One endpoint, upsert semantics**: POST upserts on `(project_id, item_id)` — add form and inline rate edits share it; `V2_50_0` dedupes and adds the unique constraint. Item ids validate against the world-version catalog; rate optional (0 = unknown, display-only under unbounded-supply V1). Writes are member-level, matching the resource-mutation family
- Mounts the orphaned `ProjectProductionItemParamPlugin` (param renamed to `productionId`) for DELETE scoping
- **Fixes `DatabaseError.NotFound` → 404** (was 500 for every param-plugin not-found path) — surfaced by the new IT's foreign-id DELETE test

Linear: [MCO-297](https://linear.app/evegul/issue/MCO-297)

## Test plan

- [x] `ProjectProductionIT` (8 tests): panel render, unauth redirect, add + upsert-no-duplicate, blank-rate default, unknown item 422, missing item 400, delete, foreign-id 404
- [x] Full unit + database tiers green (note [MCO-300](https://linear.app/evegul/issue/MCO-300): `*IT` classes don't run in CI — filed during this work)
- [x] **Verified in the running app**: added production via the panel, inline rate upsert, OOB chip refresh, farm-DONE → consumer project shows "Collect from farms · Iron Ingot · from Iron Farm · feeds 64 Hopper"

🤖 Generated with [Claude Code](https://claude.com/claude-code)