### PR TITLE
MCO-298: record an existing farm (quick-create in operational state)

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/RecordExistingFarmPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/RecordExistingFarmPipeline.kt
@@ -1,0 +1,297 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.config.CacheManager
+import app.mcorg.domain.model.minecraft.Dimension
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftLocation
+import app.mcorg.domain.model.project.ProjectType
+import app.mcorg.domain.model.user.Role
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.event.ProjectCreated
+import app.mcorg.event.actorDisplayName
+import app.mcorg.event.eventBus
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.failure.ValidationFailure
+import app.mcorg.pipeline.project.resources.GetItemsInWorldVersionStep
+import app.mcorg.pipeline.world.ValidateWorldMemberRole
+import app.mcorg.presentation.handler.handlePipeline
+import app.mcorg.presentation.utils.getUser
+import app.mcorg.presentation.utils.getWorldId
+import app.mcorg.presentation.utils.respondHtml
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.respond
+import java.time.Instant
+
+/** One produced item staged in the record-a-farm form. */
+data class FarmProductionInput(
+    val itemId: String,
+    val name: String,
+    val ratePerHour: Int,
+)
+
+data class RecordExistingFarmInput(
+    val name: String,
+    val description: String,
+    val type: ProjectType,
+    val location: MinecraftLocation?,
+    val productions: List<FarmProductionInput>,
+)
+
+/**
+ * MCO-298 — "record an existing farm": a farm that predates Seam enters the world
+ * already producing, so it is created directly in the operational state
+ * (`stage COMPLETED` + `state DONE`) with its productions attached.
+ *
+ * This deliberately bypasses [app.mcorg.domain.model.project.ProjectState.allowedTransitions]
+ * (there is no `PENDING -> DONE` edge): the state machine describes a project Seam
+ * planned and watched get built. A pre-existing farm was never planned here — there is
+ * no transition to make, only a fact to record. Under the MCO-287 anchor decision
+ * `DONE` *is* the producing condition, so recording it DONE is what makes it supply
+ * other projects' plans ([app.mcorg.pipeline.resources.GetWorldFarmSuppliesStep]).
+ */
+suspend fun ApplicationCall.handleRecordExistingFarm() {
+    val parameters = receiveParameters()
+    val user = getUser()
+    val worldId = getWorldId()
+    val bus = eventBus
+    val isHtmx = request.headers["HX-Request"] == "true"
+    val validItems = GetItemsInWorldVersionStep.process(worldId).getOrNull() ?: emptyList()
+
+    handlePipeline(
+        onSuccess = { _: Int ->
+            // The Field Log groups by state, and a recorded farm lands in a different
+            // group than the one the user is looking at — reload rather than splice a
+            // card into the wrong section.
+            if (isHtmx) {
+                response.headers.append("HX-Redirect", "/worlds/$worldId/projects")
+                respondHtml("")
+            } else {
+                response.headers.append("Location", "/worlds/$worldId/projects")
+                respond(HttpStatusCode.SeeOther, "")
+            }
+        }
+    ) {
+        val input = ValidateRecordExistingFarmInputStep(validItems).run(parameters)
+        ValidateWorldMemberRole<RecordExistingFarmInput>(user, Role.ADMIN, worldId).run(input)
+        val projectId = CreateExistingFarmStep(worldId).run(input)
+        CacheManager.onProjectCreated(worldId, projectId)
+        bus.publish(
+            ProjectCreated(
+                worldId,
+                user.id,
+                Instant.now(),
+                projectId,
+                input.name,
+                input.type,
+                actorName = user.actorDisplayName()
+            )
+        )
+        projectId
+    }
+}
+
+/**
+ * Validates the record-a-farm form.
+ *
+ * Field names are farm-prefixed because the create-project modal lives on the same page
+ * and the validation errors are swapped out-of-band by `validation-error-<parameter>` id —
+ * a shared `name` would land in the wrong (hidden) dialog.
+ *
+ * Produced items arrive as `productions[<itemId>]=<rate>` hidden inputs staged by
+ * farm-modal.js. At least one is required: a farm recorded with no output is a Done
+ * project that supplies nothing and is easy to never notice again.
+ */
+data class ValidateRecordExistingFarmInputStep(val validItems: List<Item>) :
+    Step<Parameters, AppFailure.ValidationError, RecordExistingFarmInput> {
+
+    private val productionParameter = Regex("""^productions\[(.+)]$""")
+
+    override suspend fun process(input: Parameters): Result<AppFailure.ValidationError, RecordExistingFarmInput> {
+        val errors = mutableListOf<ValidationFailure>()
+
+        val name = input["farmName"]?.trim().orEmpty()
+        if (name.isBlank()) {
+            errors.add(ValidationFailure.MissingParameter("farmName"))
+        } else if (name.length < 3 || name.length > 100) {
+            errors.add(ValidationFailure.CustomValidation("farmName", "Name must be between 3 and 100 characters"))
+        }
+
+        val description = input["farmDescription"]?.trim().orEmpty()
+        if (description.length > 500) {
+            errors.add(
+                ValidationFailure.CustomValidation("farmDescription", "Description must be at most 500 characters")
+            )
+        }
+
+        val typeRaw = input["farmType"]?.takeIf { it.isNotBlank() }
+        val type = if (typeRaw == null) {
+            ProjectType.FARMING
+        } else {
+            runCatching { ProjectType.valueOf(typeRaw.uppercase()) }.getOrElse {
+                errors.add(ValidationFailure.InvalidValue("farmType", ProjectType.entries.map { entry -> entry.name }))
+                ProjectType.FARMING
+            }
+        }
+
+        val location = parseLocation(input, errors)
+        val productions = parseProductions(input, errors)
+
+        return if (errors.isEmpty()) {
+            Result.success(
+                RecordExistingFarmInput(
+                    name = name,
+                    description = description,
+                    type = type,
+                    location = location,
+                    productions = productions,
+                )
+            )
+        } else {
+            Result.failure(AppFailure.ValidationError(errors))
+        }
+    }
+
+    /**
+     * Location is optional as a whole, but partial coordinates are a mistake, not a
+     * shorthand — X and Z go together (Y defaults to 0 and the dimension to the
+     * Overworld, matching the inline location editor).
+     */
+    private fun parseLocation(input: Parameters, errors: MutableList<ValidationFailure>): MinecraftLocation? {
+        val x = input["farmX"]?.takeIf { it.isNotBlank() }
+        val y = input["farmY"]?.takeIf { it.isNotBlank() }
+        val z = input["farmZ"]?.takeIf { it.isNotBlank() }
+        if (x == null && y == null && z == null) return null
+
+        if (x == null || z == null) {
+            errors.add(ValidationFailure.CustomValidation("farmLocation", "Give both X and Z, or leave the location empty"))
+            return null
+        }
+
+        val parsedX = x.toIntOrNull()
+        val parsedY = y?.toIntOrNull() ?: 0
+        val parsedZ = z.toIntOrNull()
+        if (parsedX == null || parsedZ == null || (y != null && y.toIntOrNull() == null)) {
+            errors.add(ValidationFailure.CustomValidation("farmLocation", "Coordinates must be whole numbers"))
+            return null
+        }
+
+        val dimensionRaw = input["farmDimension"]?.takeIf { it.isNotBlank() }
+        val dimension = if (dimensionRaw == null) {
+            Dimension.OVERWORLD
+        } else {
+            runCatching { Dimension.valueOf(dimensionRaw.uppercase()) }.getOrElse {
+                errors.add(ValidationFailure.InvalidValue("farmLocation", Dimension.entries.map { entry -> entry.name }))
+                return null
+            }
+        }
+
+        return MinecraftLocation(dimension = dimension, x = parsedX, y = parsedY, z = parsedZ)
+    }
+
+    private fun parseProductions(
+        input: Parameters,
+        errors: MutableList<ValidationFailure>,
+    ): List<FarmProductionInput> {
+        val itemsById = validItems.associateBy { it.id }
+        val staged = input.entries()
+            .mapNotNull { entry -> productionParameter.find(entry.key)?.groupValues?.get(1)?.to(entry.value.firstOrNull()) }
+            // The same item staged twice would collide on the (project_id, item_id)
+            // unique index (V2_50_0); the last rate entered wins, as in the panel's upsert.
+            .associate { (itemId, rate) -> itemId to rate }
+
+        if (staged.isEmpty()) {
+            errors.add(ValidationFailure.CustomValidation("productions", "Add at least one produced item"))
+            return emptyList()
+        }
+
+        return staged.mapNotNull { (itemId, rateRaw) ->
+            val item = itemsById[itemId]
+            if (item == null) {
+                errors.add(ValidationFailure.CustomValidation("productions", "Unknown item: $itemId"))
+                return@mapNotNull null
+            }
+            val rate = if (rateRaw.isNullOrBlank()) 0 else rateRaw.toIntOrNull()
+            if (rate == null || rate < 0) {
+                errors.add(
+                    ValidationFailure.CustomValidation("productions", "Rate for ${item.name} must be a non-negative whole number")
+                )
+                return@mapNotNull null
+            }
+            FarmProductionInput(itemId = item.id, name = item.name, ratePerHour = rate)
+        }
+    }
+}
+
+/**
+ * Inserts the farm project and its productions in one transaction — a farm without its
+ * produced items would be an ordinary Done project, silently supplying nothing.
+ */
+data class CreateExistingFarmStep(val worldId: Int) :
+    Step<RecordExistingFarmInput, AppFailure.DatabaseError, Int> {
+
+    override suspend fun process(input: RecordExistingFarmInput): Result<AppFailure.DatabaseError, Int> {
+        return DatabaseSteps.transaction<RecordExistingFarmInput, Int> { connection ->
+            object : Step<RecordExistingFarmInput, AppFailure.DatabaseError, Int> {
+                override suspend fun process(input: RecordExistingFarmInput): Result<AppFailure.DatabaseError, Int> {
+                    val projectIdResult = DatabaseSteps.update<RecordExistingFarmInput>(
+                        sql = SafeSQL.insert("""
+                            INSERT INTO projects (world_id, name, description, type, stage, state, location_x, location_y, location_z, location_dimension)
+                            VALUES (?, ?, ?, ?, 'COMPLETED', 'DONE', ?, ?, ?, ?)
+                            RETURNING id
+                        """.trimIndent()),
+                        parameterSetter = { statement, farm ->
+                            statement.setInt(1, worldId)
+                            statement.setString(2, farm.name)
+                            statement.setString(3, farm.description)
+                            statement.setString(4, farm.type.name)
+                            val location = farm.location
+                            if (location == null) {
+                                statement.setNull(5, java.sql.Types.INTEGER)
+                                statement.setNull(6, java.sql.Types.INTEGER)
+                                statement.setNull(7, java.sql.Types.INTEGER)
+                                statement.setNull(8, java.sql.Types.VARCHAR)
+                            } else {
+                                statement.setInt(5, location.x)
+                                statement.setInt(6, location.y)
+                                statement.setInt(7, location.z)
+                                statement.setString(8, location.dimension.name)
+                            }
+                        },
+                        transactionConnection = connection
+                    ).process(input)
+
+                    if (projectIdResult is Result.Failure) {
+                        return Result.Failure(projectIdResult.error)
+                    }
+                    val projectId = projectIdResult.getOrNull()!!
+
+                    val productions = DatabaseSteps.batchUpdate<FarmProductionInput>(
+                        SafeSQL.insert("""
+                            INSERT INTO project_productions (project_id, item_id, name, rate_per_hour)
+                            VALUES (?, ?, ?, ?)
+                        """.trimIndent()),
+                        parameterSetter = { statement, production ->
+                            statement.setInt(1, projectId)
+                            statement.setString(2, production.itemId)
+                            statement.setString(3, production.name)
+                            statement.setInt(4, production.ratePerHour)
+                        },
+                        transactionConnection = connection
+                    ).process(input.productions)
+
+                    if (productions is Result.Failure) {
+                        return Result.Failure(productions.error)
+                    }
+
+                    return Result.success(projectId)
+                }
+            }
+        }.process(input)
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -8,6 +8,7 @@ import app.mcorg.pipeline.project.handleCreateProjectFromSchematic
 import app.mcorg.pipeline.project.handleDeleteProject
 import app.mcorg.pipeline.project.handleGetProject
 import app.mcorg.pipeline.project.handleGetDetailContent
+import app.mcorg.pipeline.project.handleRecordExistingFarm
 import app.mcorg.pipeline.project.resources.handleAddResourcesFromSchematic
 import app.mcorg.pipeline.project.resources.handleDeleteProjectProduction
 import app.mcorg.pipeline.project.resources.handleGetProductionsPanel
@@ -139,6 +140,9 @@ class WorldHandler {
                     }
                     post("/from-schematic") {
                         call.handleCreateProjectFromSchematic()
+                    }
+                    post("/farm") {
+                        call.handleRecordExistingFarm()
                     }
                     route("/{projectId}") {
                         install(ProjectParamPlugin)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/NewProjectMenu.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/NewProjectMenu.kt
@@ -50,6 +50,18 @@ fun FlowContent.newProjectMenu(worldId: Int) {
                     span("np-menu__door-sub") { +"name it, fill it later" }
                 }
             }
+            // MCO-298: farms that predate Seam enter the world already producing — a
+            // separate door because it creates the project Done, not pending.
+            button(classes = "np-menu__door") {
+                type = ButtonType.button
+                attributes["onclick"] =
+                    "document.getElementById('new-project-menu')?.removeAttribute('open'); document.getElementById('record-farm-modal')?.showModal()"
+                span("np-menu__door-glyph") { +"⚙" }
+                span("np-menu__door-text") {
+                    span("np-menu__door-title") { +"Record an existing farm" }
+                    span("np-menu__door-sub") { +"already built, already producing" }
+                }
+            }
         }
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectListPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectListPage.kt
@@ -1,5 +1,6 @@
 package app.mcorg.presentation.templated.dsl.pages
 
+import app.mcorg.domain.model.minecraft.Dimension
 import app.mcorg.domain.model.project.ProjectListItem
 import app.mcorg.domain.model.project.ProjectPlanListItem
 import app.mcorg.domain.model.project.ProjectResourceEdge
@@ -66,8 +67,10 @@ fun projectListPage(
         "/static/styles/components/progress.css",
         "/static/styles/components/project-card.css",
         "/static/styles/pages/project-list.css",
+        "/static/styles/components/form.css",
+        "/static/styles/components/item-search.css",
     ),
-    scripts = listOf("/static/scripts/np-menu.js")
+    scripts = listOf("/static/scripts/np-menu.js", "/static/scripts/farm-modal.js")
 ) {
     appHeader(
         worldName = world.name,
@@ -102,8 +105,10 @@ fun projectListPageWithPlanView(
         "/static/styles/components/toggle.css",
         "/static/styles/components/project-card.css",
         "/static/styles/pages/project-list.css",
+        "/static/styles/components/form.css",
+        "/static/styles/components/item-search.css",
     ),
-    scripts = listOf("/static/scripts/np-menu.js")
+    scripts = listOf("/static/scripts/np-menu.js", "/static/scripts/farm-modal.js")
 ) {
     appHeader(
         worldName = world.name,
@@ -150,6 +155,7 @@ fun kotlinx.html.FlowContent.projectsContent(
     }
     createProjectModal(world.id, view)
     schematicProjectModal(world.id)
+    recordFarmModal(world.id)
 }
 
 fun kotlinx.html.FlowContent.projectsContentPlan(
@@ -164,6 +170,7 @@ fun kotlinx.html.FlowContent.projectsContentPlan(
     }
     createProjectModal(world.id, "plan")
     schematicProjectModal(world.id)
+    recordFarmModal(world.id)
 }
 
 fun kotlinx.html.FlowContent.projectsViewContent(
@@ -254,6 +261,18 @@ fun kotlinx.html.FlowContent.projectsEmptyState(worldId: Int) {
                         span("np-menu__door-sub") { +"name it, fill it later" }
                     }
                 }
+                // A world usually starts with farms that already exist — the empty state
+                // is the most likely place to record them (MCO-298).
+                button(classes = "np-menu__door") {
+                    type = ButtonType.button
+                    attributes["onclick"] =
+                        "document.getElementById('record-farm-modal')?.showModal()"
+                    span("np-menu__door-glyph") { +"⚙" }
+                    span("np-menu__door-text") {
+                        span("np-menu__door-title") { +"Record an existing farm" }
+                        span("np-menu__door-sub") { +"already built, already producing" }
+                    }
+                }
             }
         }
         div("empty-state-card") {
@@ -340,6 +359,182 @@ private fun kotlinx.html.FlowContent.schematicProjectModal(worldId: Int) {
                     }
                 }
             }
+    }
+}
+
+/**
+ * MCO-298 — "record an existing farm". Its own door and its own modal because it does
+ * something the create-project form cannot: the project is created operational
+ * (`COMPLETED`/`DONE`) with its produced items, so it supplies every other project's
+ * gathering plan the moment it exists.
+ *
+ * Produced items are staged client-side (farm-modal.js) as `productions[<itemId>]`
+ * hidden inputs — the project has no id to post them against yet, so the productions
+ * panel from MCO-297 cannot be reused here; it takes over once the project exists.
+ *
+ * Field names are farm-prefixed: validation errors come back as out-of-band swaps keyed
+ * by `validation-error-<parameter>`, and the create-project modal on this same page
+ * already owns `validation-error-name`.
+ */
+private fun kotlinx.html.FlowContent.recordFarmModal(worldId: Int) {
+    dialog {
+        id = "record-farm-modal"
+        classes = setOf("modal-backdrop")
+        div("modal") {
+            div("modal__heading") { +"Record an existing farm" }
+            div("modal__body") {
+                p("modal__description") {
+                    +"A farm already standing in your world. It is recorded as done and producing, so its output counts as supply in every project's gathering plan."
+                }
+                form {
+                    id = "record-farm-form"
+                    hxPost("/worlds/$worldId/projects/farm")
+                    hxTarget("#projects-view")
+                    hxSwap("afterbegin")
+                    hxTargetError(".form-error")
+                    // htmx events bubble: the item search inside this form fires
+                    // afterRequest too, and without the target check every keystroke's
+                    // search response would close the modal.
+                    attributes["hx-on::after-request"] =
+                        "if(event.target === this && event.detail.successful) { window.resetFarmModal(this) }"
+
+                    label {
+                        htmlFor = "record-farm-name"
+                        +"Farm name"
+                        span("required-indicator") { +"*" }
+                    }
+                    input(classes = "form-control") {
+                        id = "record-farm-name"
+                        type = InputType.text
+                        name = "farmName"
+                        placeholder = "Iron farm"
+                        maxLength = "100"
+                        minLength = "3"
+                        required = true
+                    }
+                    p("form-error") { id = "validation-error-farmName" }
+
+                    label {
+                        htmlFor = "record-farm-description"
+                        +"Notes"
+                    }
+                    textArea(classes = "form-control") {
+                        id = "record-farm-description"
+                        name = "farmDescription"
+                        maxLength = "500"
+                        placeholder = "Anything worth remembering — design, quirks, who built it"
+                    }
+                    p("form-error") { id = "validation-error-farmDescription" }
+
+                    label {
+                        htmlFor = "record-farm-type"
+                        +"Type"
+                    }
+                    select(classes = "form-control") {
+                        id = "record-farm-type"
+                        name = "farmType"
+                        ProjectType.entries.forEach { type ->
+                            option {
+                                value = type.name
+                                selected = type == ProjectType.FARMING
+                                +type.name.lowercase().replaceFirstChar { it.uppercase() }
+                            }
+                        }
+                    }
+
+                    label { +"Location" }
+                    div("farm-location-row") {
+                        input(classes = "form-control") {
+                            id = "record-farm-x"
+                            type = InputType.number
+                            name = "farmX"
+                            placeholder = "X"
+                            attributes["aria-label"] = "X coordinate"
+                        }
+                        input(classes = "form-control") {
+                            id = "record-farm-y"
+                            type = InputType.number
+                            name = "farmY"
+                            placeholder = "Y"
+                            attributes["aria-label"] = "Y coordinate"
+                        }
+                        input(classes = "form-control") {
+                            id = "record-farm-z"
+                            type = InputType.number
+                            name = "farmZ"
+                            placeholder = "Z"
+                            attributes["aria-label"] = "Z coordinate"
+                        }
+                        select(classes = "form-control") {
+                            id = "record-farm-dimension"
+                            name = "farmDimension"
+                            attributes["aria-label"] = "Dimension"
+                            Dimension.entries.forEach { dimension ->
+                                option {
+                                    value = dimension.name
+                                    +dimension.name.lowercase().replaceFirstChar { it.uppercase() }
+                                }
+                            }
+                        }
+                    }
+                    p("form-help-text") { +"Optional — leave empty if you would rather not pin it down." }
+                    p("form-error") { id = "validation-error-farmLocation" }
+
+                    label {
+                        +"Produces"
+                        span("required-indicator") { +"*" }
+                    }
+                    div("item-search-combo") {
+                        div("item-search-field") {
+                            input(type = InputType.text, classes = "form-control") {
+                                id = "record-farm-item-input"
+                                placeholder = "Search items by name..."
+                                autoComplete = "off"
+                                attributes["hx-get"] = "/items/search"
+                                attributes["hx-trigger"] = "input changed delay:300ms"
+                                attributes["hx-target"] = "#record-farm-item-results"
+                                attributes["hx-swap"] = "innerHTML"
+                                attributes["hx-vals"] = "js:{q: this.value}"
+                            }
+                            div("item-search-results") { id = "record-farm-item-results" }
+                        }
+                        input(type = InputType.hidden) { id = "record-farm-selected-item-id" }
+                        span("item-selected-label") { id = "record-farm-selected-item-label" }
+                    }
+                    div("item-add-row") {
+                        div {
+                            label { htmlFor = "record-farm-rate"; +"Rate per hour" }
+                            input(type = InputType.number, classes = "form-control") {
+                                id = "record-farm-rate"
+                                min = "0"
+                                placeholder = "unknown"
+                            }
+                        }
+                        button(classes = "btn btn--secondary btn--sm") {
+                            type = ButtonType.button
+                            attributes["onclick"] = "window.addFarmProduction()"
+                            +"Add item"
+                        }
+                    }
+                    div("farm-production-list") { id = "farm-production-list" }
+                    p("form-error") { id = "validation-error-productions" }
+
+                    div("modal__actions") {
+                        button {
+                            classes = setOf("btn", "btn--primary")
+                            type = ButtonType.submit
+                            +"Record farm"
+                        }
+                        button {
+                            classes = setOf("btn", "btn--ghost")
+                            type = ButtonType.button
+                            attributes["onclick"] = "window.resetFarmModal(document.getElementById('record-farm-form'))"
+                            +"Cancel"
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/webapp/mc-web/src/main/resources/static/scripts/farm-modal.js
+++ b/webapp/mc-web/src/main/resources/static/scripts/farm-modal.js
@@ -1,0 +1,111 @@
+/**
+ * farm-modal.js — "record an existing farm" modal (MCO-298)
+ *
+ * The project does not exist yet, so produced items cannot be posted to the
+ * productions endpoint the way the project-detail panel does. They are staged here as
+ * `productions[<itemId>]` hidden inputs and submitted with the form; the server
+ * resolves each id against the world's item catalog.
+ */
+(function () {
+    'use strict';
+
+    function el(id) {
+        return document.getElementById(id);
+    }
+
+    /**
+     * Called by the /items/search result rows (they render onclick="selectSearchedItem(this)").
+     * This page has exactly one item search — the farm modal's.
+     */
+    window.selectSearchedItem = function (option) {
+        var idField = el('record-farm-selected-item-id');
+        var label = el('record-farm-selected-item-label');
+        var input = el('record-farm-item-input');
+        var results = el('record-farm-item-results');
+        if (!idField || !label || !input) return;
+
+        idField.value = option.dataset.itemId;
+        label.textContent = option.dataset.itemName;
+        input.value = option.dataset.itemName;
+        if (results) results.innerHTML = '';
+    };
+
+    window.addFarmProduction = function () {
+        var idField = el('record-farm-selected-item-id');
+        var label = el('record-farm-selected-item-label');
+        var rateField = el('record-farm-rate');
+        var list = el('farm-production-list');
+        if (!idField || !list) return;
+
+        var itemId = idField.value.trim();
+        if (!itemId) return;
+        var itemName = (label && label.textContent.trim()) || itemId;
+        var rate = rateField && rateField.value.trim() !== '' ? parseInt(rateField.value, 10) : 0;
+        if (isNaN(rate) || rate < 0) rate = 0;
+
+        // Re-adding an item replaces its row: the server upserts on (project_id, item_id),
+        // so two rows for one item would silently collapse to the last rate anyway.
+        var rowId = 'farm-production-' + itemId;
+        var existing = el(rowId);
+        if (existing) existing.remove();
+
+        var row = document.createElement('div');
+        row.id = rowId;
+        row.className = 'farm-production-row';
+
+        var name = document.createElement('span');
+        name.className = 'farm-production-row__name';
+        name.textContent = itemName;
+        row.appendChild(name);
+
+        var rateLabel = document.createElement('span');
+        rateLabel.className = 'farm-production-row__rate';
+        rateLabel.textContent = rate > 0 ? rate + '/hr' : 'rate unknown';
+        row.appendChild(rateLabel);
+
+        var hidden = document.createElement('input');
+        hidden.type = 'hidden';
+        hidden.name = 'productions[' + itemId + ']';
+        hidden.value = String(rate);
+        row.appendChild(hidden);
+
+        var remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'btn btn--ghost btn--sm farm-production-row__remove';
+        remove.setAttribute('aria-label', 'Remove ' + itemName);
+        remove.textContent = '×';
+        remove.addEventListener('click', function () {
+            row.remove();
+        });
+        row.appendChild(remove);
+
+        list.appendChild(row);
+
+        idField.value = '';
+        if (label) label.textContent = '';
+        var input = el('record-farm-item-input');
+        if (input) input.value = '';
+        if (rateField) rateField.value = '';
+    };
+
+    /**
+     * form.reset() does not remove the staged rows (they are not form defaults), so the
+     * next farm would inherit the previous one's items.
+     */
+    window.resetFarmModal = function (form) {
+        if (form) form.reset();
+        var list = el('farm-production-list');
+        if (list) list.innerHTML = '';
+        var idField = el('record-farm-selected-item-id');
+        if (idField) idField.value = '';
+        var label = el('record-farm-selected-item-label');
+        if (label) label.textContent = '';
+        var results = el('record-farm-item-results');
+        if (results) results.innerHTML = '';
+        document.querySelectorAll('#record-farm-form .validation-error-message').forEach(function (error) {
+            error.textContent = '';
+        });
+        var dialog = el('record-farm-modal');
+        if (dialog && dialog.open) dialog.close();
+    };
+})();

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-list.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-list.css
@@ -626,3 +626,56 @@
         width: min(288px, calc(100vw - 32px));
     }
 }
+
+/* ==========================================================================
+   RECORD AN EXISTING FARM MODAL (MCO-298)
+   ========================================================================== */
+
+.farm-location-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr 1.4fr;
+    gap: var(--space-2);
+}
+
+.farm-production-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.farm-production-list:empty {
+    display: none;
+}
+
+.farm-production-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+}
+
+.farm-production-row__name {
+    flex: 1;
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+}
+
+.farm-production-row__rate {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+.farm-production-row__remove {
+    padding: 0 var(--space-2);
+}
+
+@media (max-width: 768px) {
+    .farm-location-row {
+        grid-template-columns: 1fr 1fr;
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/RecordExistingFarmIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/RecordExistingFarmIT.kt
@@ -1,0 +1,337 @@
+package app.mcorg.presentation.handler.project
+
+import app.mcorg.config.CacheManager
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.minecraft.ServerData
+import app.mcorg.domain.model.project.ProjectStage
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.domain.model.resources.ResourceQuantity
+import app.mcorg.domain.model.resources.ResourceSource
+import app.mcorg.domain.model.user.Role
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.minecraft.StoreMinecraftDataStep
+import app.mcorg.pipeline.project.handleRecordExistingFarm
+import app.mcorg.pipeline.resources.GetWorldFarmSuppliesStep
+import app.mcorg.pipeline.resources.WorldFarmSuppliesInput
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
+import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Endpoint tests for "record an existing farm" (MCO-298):
+ * - the project is created operational (COMPLETED/DONE) with its productions attached,
+ *   and immediately counts as farm supply for other projects (MCO-296)
+ * - location is optional, but partial coordinates are rejected
+ * - validation failures (no name, no produced items, unknown item) create nothing
+ * - non-admin world members are refused
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class RecordExistingFarmIT : WithUser() {
+
+    private val version = MinecraftVersion.Release(1, 98, 0)
+    private val ironIngot = Item("minecraft:iron_ingot", "Iron Ingot")
+    private val bamboo = Item("minecraft:bamboo", "Bamboo")
+
+    private var worldId: Int = 0
+
+    @BeforeAll
+    fun setup() {
+        val serverData = ServerData(
+            version = version,
+            items = listOf(ironIngot, bamboo),
+            sources = listOf(
+                ResourceSource(
+                    type = ResourceSource.SourceType.LootTypes.BLOCK,
+                    filename = "blocks/iron_ore.json",
+                    producedItems = listOf(ironIngot to ResourceQuantity.ItemQuantity(1))
+                )
+            )
+        )
+        val stored = runBlocking { StoreMinecraftDataStep.process(serverData) }
+        assertIs<Result.Success<*>>(stored)
+
+        worldId = createWorld("RecordExistingFarm IT World")
+    }
+
+    // ---- success --------------------------------------------------------------
+
+    @Test
+    fun `recording a farm creates a done project with its productions and supplies other projects`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/farm") {
+            addAuthCookie(this)
+            header("HX-Request", "true")
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "farmName=Iron Farm&farmDescription=Behind the base&farmType=FARMING" +
+                    "&farmX=120&farmY=64&farmZ=-40&farmDimension=OVERWORLD" +
+                    "&productions[minecraft:iron_ingot]=400&productions[minecraft:bamboo]="
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("/worlds/$worldId/projects", response.headers["HX-Redirect"])
+
+        val farm = readProject(worldId, "Iron Farm")!!
+        assertEquals(ProjectStage.COMPLETED.name, farm.stage)
+        assertEquals(ProjectState.DONE.name, farm.state)
+        assertEquals("Behind the base", farm.description)
+        assertEquals(listOf(120, 64, -40), listOf(farm.x, farm.y, farm.z))
+        assertEquals("OVERWORLD", farm.dimension)
+        assertEquals(
+            listOf("minecraft:bamboo" to 0, "minecraft:iron_ingot" to 400),
+            readProductions(farm.id),
+            "a blank rate is recorded as unknown (0)"
+        )
+
+        // The whole point of recording it Done: it is world supply straight away.
+        val supplies = runBlocking {
+            GetWorldFarmSuppliesStep.process(WorldFarmSuppliesInput(worldId, excludeProjectId = -1))
+        }
+        assertIs<Result.Success<*>>(supplies)
+        val suppliedItems = (supplies as Result.Success).value.map { it.itemId to it.projectName }
+        assertTrue(suppliedItems.contains("minecraft:iron_ingot" to "Iron Farm"), "got $suppliedItems")
+
+        deleteProject(farm.id)
+    }
+
+    /** Also covers the non-HTMX submit path, which redirects with a Location header. */
+    @Test
+    fun `location is optional`() = testApplication {
+        setupRoutes()
+        val noRedirects = createClient { followRedirects = false }
+
+        val response = noRedirects.post("/worlds/$worldId/projects/farm") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("farmName=Bamboo Farm&productions[minecraft:bamboo]=1200")
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status)
+        assertEquals("/worlds/$worldId/projects", response.headers["Location"])
+        val farm = readProject(worldId, "Bamboo Farm")!!
+        assertNull(farm.dimension, "no location means no dimension")
+        assertEquals(listOf("minecraft:bamboo" to 1200), readProductions(farm.id))
+
+        deleteProject(farm.id)
+    }
+
+    // ---- validation -----------------------------------------------------------
+
+    @Test
+    fun `a farm without produced items is rejected`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/farm") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("farmName=Empty Farm")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertNull(readProject(worldId, "Empty Farm"), "nothing is created when validation fails")
+    }
+
+    @Test
+    fun `an unknown item is rejected`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/farm") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("farmName=Mystery Farm&productions[minecraft:not_a_real_item]=10")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertNull(readProject(worldId, "Mystery Farm"))
+    }
+
+    @Test
+    fun `a blank name is rejected`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/farm") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("farmName=&productions[minecraft:bamboo]=10")
+        }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+    }
+
+    @Test
+    fun `half a location is rejected`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/farm") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("farmName=Lopsided Farm&farmX=10&productions[minecraft:bamboo]=10")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertNull(readProject(worldId, "Lopsided Farm"))
+    }
+
+    // ---- auth -----------------------------------------------------------------
+
+    @Test
+    fun `a world member without admin role cannot record a farm`() = testApplication {
+        setupRoutes()
+        val member = createExtraUser("member-cannot-record-farm")
+        addWorldMember(member.id, worldId, Role.MEMBER, "member-${member.id}")
+
+        val response = client.post("/worlds/$worldId/projects/farm") {
+            addAuthCookie(this, member)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("farmName=Member Farm&productions[minecraft:bamboo]=10")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertNull(readProject(worldId, "Member Farm"))
+    }
+
+    @Test
+    fun `unauthenticated requests redirect`() = testApplication {
+        setupRoutes()
+        val unauth = createClient { followRedirects = false }
+
+        val response = unauth.post("/worlds/$worldId/projects/farm") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("farmName=Anon Farm&productions[minecraft:bamboo]=10")
+        }
+
+        assertEquals(HttpStatusCode.Found, response.status)
+    }
+
+    // ---- routing — mirrors WorldHandler's /projects block -----------------------
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
+                install(UpdateActiveWorldPlugin)
+                route("/projects") {
+                    post("/farm") { call.handleRecordExistingFarm() }
+                }
+            }
+        }
+    }
+
+    // ---- fixtures + read helpers ------------------------------------------------
+
+    private data class ProjectRow(
+        val id: Int,
+        val stage: String,
+        val state: String,
+        val description: String,
+        val x: Int?,
+        val y: Int?,
+        val z: Int?,
+        val dimension: String?,
+    )
+
+    private fun createWorld(name: String): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(name = name, description = "test", version = version)
+        )
+        (result as Result.Success).value
+    }
+
+    private fun readProject(worldId: Int, name: String): ProjectRow? = runBlocking {
+        val result = DatabaseSteps.query<Unit, ProjectRow?>(
+            sql = SafeSQL.select(
+                "SELECT id, stage, state, description, location_x, location_y, location_z, location_dimension " +
+                    "FROM projects WHERE world_id = ? AND name = ?"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, worldId)
+                stmt.setString(2, name)
+            },
+            resultMapper = { rs ->
+                if (!rs.next()) null else ProjectRow(
+                    id = rs.getInt("id"),
+                    stage = rs.getString("stage"),
+                    state = rs.getString("state"),
+                    description = rs.getString("description") ?: "",
+                    x = rs.getInt("location_x").takeIf { !rs.wasNull() },
+                    y = rs.getInt("location_y").takeIf { !rs.wasNull() },
+                    z = rs.getInt("location_z").takeIf { !rs.wasNull() },
+                    dimension = rs.getString("location_dimension"),
+                )
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun readProductions(projectId: Int): List<Pair<String, Int>> = runBlocking {
+        val result = DatabaseSteps.query<Int, List<Pair<String, Int>>>(
+            sql = SafeSQL.select(
+                "SELECT item_id, rate_per_hour FROM project_productions WHERE project_id = ? ORDER BY item_id"
+            ),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) },
+            resultMapper = { rs ->
+                val rows = mutableListOf<Pair<String, Int>>()
+                while (rs.next()) rows.add(rs.getString("item_id") to rs.getInt("rate_per_hour"))
+                rows
+            }
+        ).process(projectId)
+        (result as Result.Success).value
+    }
+
+    private fun deleteProject(projectId: Int) = runBlocking {
+        DatabaseSteps.update<Int>(
+            sql = SafeSQL.delete("DELETE FROM projects WHERE id = ?"),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) }
+        ).process(projectId)
+    }
+
+    private fun addWorldMember(userId: Int, worldId: Int, role: Role, displayName: String) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert("INSERT INTO world_members (user_id, world_id, display_name, world_role) VALUES (?, ?, ?, ?)"),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, userId)
+                stmt.setInt(2, worldId)
+                stmt.setString(3, displayName)
+                stmt.setInt(4, role.level)
+            }
+        ).process(Unit)
+        CacheManager.onMemberAdded(userId, worldId)
+        CacheManager.worldMemberRole.asMap().keys
+            .filter { it.startsWith("$userId:$worldId:") }
+            .forEach { CacheManager.worldMemberRole.invalidate(it) }
+    }
+}


### PR DESCRIPTION
Phase 3 of [MCO-287](https://linear.app/evegul/issue/MCO-287). Farms that predate Seam had no way into the supply model: `CreateProjectStep` hardcodes `IDEA`/`PENDING`, and `ProjectState.allowedTransitions()` has no `PENDING -> DONE` edge, so recording one meant faking two transitions by hand and then adding each produced item one at a time.

## What this adds

- **A fourth door** in the "+ New project" menu, and in the empty state — "Record an existing farm · already built, already producing".
- **`POST /worlds/{worldId}/projects/farm`** (`RecordExistingFarmPipeline`): creates the project directly operational — `stage COMPLETED`, `state DONE` — with its productions, in one transaction. Under the MCO-287 anchor decision `DONE` *is* the producing condition, so the farm supplies every other project's plan (`GetWorldFarmSuppliesStep`, MCO-296) the moment it exists. The comment on the handler spells out why bypassing the state machine is correct here rather than an oversight.
- **Client-side staged productions.** The project has no id yet, so the MCO-297 panel can't be reused: items are staged as `productions[<itemId>]` hidden inputs (`farm-modal.js`) and resolved server-side against the world's item catalog. Rate is optional (0 = unknown), consistent with the panel.
- Location is optional as a whole; partial coordinates are rejected rather than half-saved.
- Form fields are farm-prefixed (`farmName`, …) because validation errors swap out-of-band by `validation-error-<parameter>` and the create-project modal on the same page already owns `validation-error-name`.

## Fixed en route

- **htmx events bubble**: the item search inside the modal's form fired the form's `hx-on::after-request`, so every search response reset and closed the modal. Guarded on `event.target === this`. Found by driving the flow, not by tests.
- The project-list pages used `.form-control` / `.form-error` without loading `form.css`; they now load it (also tidies the existing create-project and schematic modals).

## Tests

`RecordExistingFarmIT` — 8 cases: operational project + productions + farm supply end-to-end, optional location, HTMX and non-HTMX submit paths, no-items / unknown-item / blank-name / half-location rejections (nothing created), non-admin 403, unauthenticated redirect. Full suite green: 377 tests, unit + database tiers.

## Verified in the app

Recorded "Iron Farm" (2 produced items, one with a rate, one unknown) → lands Done with the "⚙ Produces" chip and its location → a second project needing iron ingots shows **Collect from farms — Iron Ingot · Supplied · from Iron Farm**. Checked at 1440 and 375; no errors in the app log.

## Known, deferred

A recorded farm lands in the Field Log's collapsed "done" group, which reads as shelved rather than operational. That surfacing work is [MCO-299](https://linear.app/evegul/issue/MCO-299).

🤖 Generated with [Claude Code](https://claude.com/claude-code)