### PR TITLE
MCO-299: planner surfacing for farm supply

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/project/ProjectListItem.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/project/ProjectListItem.kt
@@ -10,5 +10,15 @@ data class ProjectListItem(
     val resourcesRequired: Int,
     val resourcesGathered: Int,
     val itemCount: Int,
-    val nextTaskName: String?
-)
+    val nextTaskName: String?,
+    val producesCount: Int = 0,
+) {
+    /**
+     * A finished project that declares produced items is not finished work — it is
+     * running infrastructure supplying every other plan in the world (MCO-287). DONE
+     * means "inert" for a build and "producing" for a farm; this is the difference,
+     * and it is why the Field Log must not shelve these with the completed builds.
+     */
+    val isProducing: Boolean
+        get() = state == ProjectState.DONE && producesCount > 0
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
@@ -5,6 +5,7 @@ import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.project.commonsteps.GetProjectByIdStep
 import app.mcorg.pipeline.resources.GatheringPlanInput
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
+import app.mcorg.pipeline.resources.pendingFarmSuppliesFor
 import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
 import app.mcorg.pipeline.resources.commonsteps.GetProgressForProjectStep
 import app.mcorg.pipeline.task.SearchTasksInput
@@ -62,5 +63,7 @@ suspend fun ApplicationCall.handleGetDetailContent() {
     // Load persisted progress for all items in the project (covers derived activities too)
     val progressMap = GetProgressForProjectStep.process(projectId).getOrNull() ?: emptyMap()
 
-    respondHtml(gatheringPlannerFragment(project, resources, tasks, plan, lens, progressMap))
+    val pendingFarms = pendingFarmSuppliesFor(worldId, projectId, plan)
+
+    respondHtml(gatheringPlannerFragment(project, resources, tasks, plan, lens, progressMap, pendingFarms))
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -10,6 +10,7 @@ import app.mcorg.pipeline.project.commonsteps.GetViewPreferenceStep
 import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.pipeline.resources.GatheringPlanInput
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
+import app.mcorg.pipeline.resources.pendingFarmSuppliesFor
 import app.mcorg.pipeline.resources.GetPlanOverridesStep
 import app.mcorg.pipeline.resources.buildCandidateCounts
 import app.mcorg.pipeline.resources.buildNodeIngredients
@@ -90,6 +91,9 @@ suspend fun ApplicationCall.handleGetProject() {
     // Load persisted progress for all items in the project (covers derived activities too)
     val progressMap = GetProgressForProjectStep.process(projectId).getOrNull() ?: emptyMap()
 
+    // Farms promised but not running yet — the plan's partial-dependency notice (MCO-299)
+    val pendingFarms = pendingFarmSuppliesFor(worldId, projectId, plan)
+
     // ?drill=<item> deep-links into a target's chain so reload/share lands on the drill,
     // not the plan. Resolves only when the plan derives and the item is an actual target;
     // otherwise falls through to the normal lens render.
@@ -107,6 +111,7 @@ suspend fun ApplicationCall.handleGetProject() {
             user, project, worldName, resources, tasks, lens,
             isWorldAdmin = isAdmin, plan = plan, progressMap = progressMap,
             productions = productions,
+            pendingFarms = pendingFarms,
             drillTarget = drillTarget, drillCandidateCounts = drillCandidateCounts,
             drillNodeIngredients = drillNodeIngredients, drillHighlightItemId = drillItemId,
             drillOverrides = drillOverrides, drillGraph = drillGraph,

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetProjectListItemStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetProjectListItemStep.kt
@@ -24,6 +24,10 @@ object GetProjectListItemStep : Step<Int, AppFailure.DatabaseError, ProjectListI
                   COALESCE(SUM(rgp.collected), 0)                          AS resources_gathered,
                   COUNT(DISTINCT rg.id)                                    AS item_count,
                   (
+                    SELECT COUNT(*) FROM project_productions pp
+                    WHERE pp.project_id = p.id
+                  ) AS produces_count,
+                  (
                     SELECT t2.name FROM action_task t2
                     WHERE t2.project_id = p.id AND t2.completed = false
                     ORDER BY t2.id ASC
@@ -55,7 +59,8 @@ object GetProjectListItemStep : Step<Int, AppFailure.DatabaseError, ProjectListI
                         resourcesRequired = resultSet.getInt("resources_required"),
                         resourcesGathered = resultSet.getInt("resources_gathered"),
                         itemCount = resultSet.getInt("item_count"),
-                        nextTaskName = resultSet.getString("next_task_name")
+                        nextTaskName = resultSet.getString("next_task_name"),
+                        producesCount = resultSet.getInt("produces_count")
                     )
                 } else null
             }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetProjectListStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetProjectListStep.kt
@@ -24,6 +24,10 @@ data class GetProjectListStep(val worldId: Int) : Step<Unit, AppFailure.Database
                   COALESCE(SUM(rgp.collected), 0)                          AS resources_gathered,
                   COUNT(DISTINCT rg.id)                                    AS item_count,
                   (
+                    SELECT COUNT(*) FROM project_productions pp
+                    WHERE pp.project_id = p.id
+                  ) AS produces_count,
+                  (
                     SELECT t2.name FROM action_task t2
                     WHERE t2.project_id = p.id AND t2.completed = false
                     ORDER BY t2.id ASC
@@ -68,7 +72,8 @@ data class GetProjectListStep(val worldId: Int) : Step<Unit, AppFailure.Database
                                 resourcesRequired = resultSet.getInt("resources_required"),
                                 resourcesGathered = resultSet.getInt("resources_gathered"),
                                 itemCount = resultSet.getInt("item_count"),
-                                nextTaskName = resultSet.getString("next_task_name")
+                                nextTaskName = resultSet.getString("next_task_name"),
+                                producesCount = resultSet.getInt("produces_count")
                             )
                         )
                     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GetWorldPlannedFarmsStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GetWorldPlannedFarmsStep.kt
@@ -1,0 +1,64 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.SafeSQL
+
+/** Input for [GetWorldPlannedFarmsStep] — mirrors [WorldFarmSuppliesInput]. */
+data class WorldPlannedFarmsInput(
+    val worldId: Int,
+    val excludeProjectId: Int,
+)
+
+/** One produced item of a farm project that is not operational yet. */
+data class PlannedFarmRow(
+    val itemId: String,
+    val projectId: Int,
+    val projectName: String,
+)
+
+/**
+ * The mirror image of [GetWorldFarmSuppliesStep] (MCO-296): produced items of farm projects
+ * that are **not yet** operational — still PENDING, ACTIVE or PAUSED.
+ *
+ * These deliberately do not supply anything: until the farm is DONE, its output does not
+ * exist, and the planner must keep telling you to gather those items by hand. What they do
+ * carry is a promise worth surfacing (MCO-299) — "32 Iron Ingot will come from Iron Farm
+ * once it's running" — so the manual gathering reads as a stopgap rather than the plan.
+ *
+ * CANCELLED and ARCHIVED farms are decommissioned and promise nothing.
+ */
+val GetWorldPlannedFarmsStep = DatabaseSteps.query<WorldPlannedFarmsInput, List<PlannedFarmRow>>(
+    sql = SafeSQL.select("""
+                SELECT
+                    pp.item_id,
+                    p.id AS project_id,
+                    p.name AS project_name
+                FROM project_productions pp
+                JOIN projects p ON p.id = pp.project_id
+                WHERE p.world_id = ?
+                  AND p.state IN (?, ?, ?)
+                  AND p.id <> ?
+                ORDER BY p.name, pp.item_id
+            """),
+    parameterSetter = { statement, input ->
+        statement.setInt(1, input.worldId)
+        statement.setString(2, ProjectState.PENDING.name)
+        statement.setString(3, ProjectState.ACTIVE.name)
+        statement.setString(4, ProjectState.PAUSED.name)
+        statement.setInt(5, input.excludeProjectId)
+    },
+    resultMapper = { resultSet ->
+        val rows = mutableListOf<PlannedFarmRow>()
+        while (resultSet.next()) {
+            rows.add(
+                PlannedFarmRow(
+                    itemId = resultSet.getString("item_id"),
+                    projectId = resultSet.getInt("project_id"),
+                    projectName = resultSet.getString("project_name"),
+                )
+            )
+        }
+        rows
+    }
+)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PendingFarmSupply.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PendingFarmSupply.kt
@@ -1,0 +1,84 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.engine.plan.PlanNodeStatus
+
+/** One item a not-yet-operational farm has promised, with the amount this plan still needs. */
+data class PendingFarmItem(
+    val itemId: String,
+    val itemName: String,
+    val quantity: Long,
+)
+
+/**
+ * The partial-dependency notice's data (MCO-299): a farm project that is not operational
+ * yet, and the items in *this* plan it will supply once it is.
+ */
+data class PendingFarmSupply(
+    val projectId: Int,
+    val projectName: String,
+    val items: List<PendingFarmItem>,
+)
+
+/**
+ * Loads the world's not-yet-operational farms and matches them against [plan].
+ *
+ * Soft-fails to an empty list: the notice is a courtesy on top of the plan, and a failed
+ * lookup must not take the plan down with it. Called by every render path that shows the
+ * grouped plan, so the notice survives HTMX re-renders.
+ */
+suspend fun pendingFarmSuppliesFor(
+    worldId: Int,
+    projectId: Int,
+    plan: GatheringPlan?,
+): List<PendingFarmSupply> {
+    if (plan == null) return emptyList()
+    val plannedFarms = GetWorldPlannedFarmsStep
+        .process(WorldPlannedFarmsInput(worldId = worldId, excludeProjectId = projectId))
+        .getOrNull()
+        ?: return emptyList()
+    return buildPendingFarmSupplies(plan, plannedFarms)
+}
+
+/**
+ * Matches a plan's still-manual work against the world's not-yet-operational farms
+ * ([GetWorldPlannedFarmsStep]).
+ *
+ * Only activities the planner is still asking you to do by hand count: anything already
+ * [PlanNodeStatus.SUPPLIED] is solved (by an operational farm or a linked project) and has
+ * nothing pending about it. Everything else the farm produces is work you must do now but
+ * will not have to repeat — which is exactly what the notice says.
+ *
+ * Items are ordered biggest-first (the amount you would otherwise gather by hand is the
+ * reason the notice matters), farms by name for a stable read.
+ */
+fun buildPendingFarmSupplies(
+    plan: GatheringPlan,
+    plannedFarms: List<PlannedFarmRow>,
+): List<PendingFarmSupply> {
+    if (plannedFarms.isEmpty()) return emptyList()
+
+    val manualByItemId = plan.activityList
+        .filter { it.status != PlanNodeStatus.SUPPLIED }
+        .associateBy { it.item.id }
+    if (manualByItemId.isEmpty()) return emptyList()
+
+    return plannedFarms
+        .groupBy { it.projectId to it.projectName }
+        .mapNotNull { (project, rows) ->
+            val items = rows
+                .distinctBy { it.itemId }
+                .mapNotNull { row ->
+                    val activity = manualByItemId[row.itemId] ?: return@mapNotNull null
+                    PendingFarmItem(
+                        itemId = row.itemId,
+                        itemName = activity.item.name,
+                        quantity = activity.quantity,
+                    )
+                }
+                .sortedWith(compareByDescending<PendingFarmItem> { it.quantity }.thenBy { it.itemName })
+            if (items.isEmpty()) null
+            else PendingFarmSupply(projectId = project.first, projectName = project.second, items = items)
+        }
+        .sortedBy { it.projectName }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -354,7 +354,8 @@ private suspend fun ApplicationCall.respondListRerender(worldId: Int, projectId:
     val tasks = SearchTasksStep(projectId).process(SearchTasksInput(completionStatus = "ALL")).getOrNull() ?: emptyList()
     val plan = deriveOrNull(projectId, worldId)
     val progressMap = GetProgressForProjectStep.process(projectId).getOrNull() ?: emptyMap()
-    respondHtml(gatheringPlannerFragment(project, resources, tasks, plan, "list", progressMap))
+    val pendingFarms = pendingFarmSuppliesFor(worldId, projectId, plan)
+    respondHtml(gatheringPlannerFragment(project, resources, tasks, plan, "list", progressMap, pendingFarms))
 }
 
 /**

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/FieldLogModel.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/FieldLogModel.kt
@@ -13,6 +13,12 @@ data class FieldLogModel(
     val active: List<ProjectListItem>,
     val pending: List<ProjectListItem>,
     val paused: List<ProjectListItem>,
+    /**
+     * DONE projects that declare produced items (MCO-299). Kept apart from [done]
+     * because they are running infrastructure, not finished work — shelving them with
+     * the completed builds hides the farms the whole supply model depends on.
+     */
+    val producing: List<ProjectListItem>,
     val done: List<ProjectListItem>,
     val cancelled: List<ProjectListItem>,
     val archived: List<ProjectListItem>,
@@ -51,11 +57,16 @@ data class FieldLogModel(
                         .thenBy { it.name }
                 )
 
+            val (producing, inertDone) = (byState[ProjectState.DONE] ?: emptyList())
+                .sortedBy { it.name }
+                .partition { it.isProducing }
+
             return FieldLogModel(
                 active = active,
                 pending = (byState[ProjectState.PENDING] ?: emptyList()).sortedBy { it.name },
                 paused = (byState[ProjectState.PAUSED] ?: emptyList()).sortedBy { it.name },
-                done = (byState[ProjectState.DONE] ?: emptyList()).sortedBy { it.name },
+                producing = producing,
+                done = inertDone,
                 cancelled = (byState[ProjectState.CANCELLED] ?: emptyList()).sortedBy { it.name },
                 archived = (byState[ProjectState.ARCHIVED] ?: emptyList()).sortedBy { it.name },
                 feedsByProject = feeds,

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/FieldLogSections.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/FieldLogSections.kt
@@ -55,6 +55,19 @@ fun FlowContent.fieldLogSections(
         fieldLogChipSection("fl-paused-section", "Paused · ${model.paused.size}", worldId, model.paused, dimmed = true)
     }
 
+    // Producing farms sit above the shelf, not in it (MCO-299): they are DONE, but DONE for
+    // a farm means "running", and every other project's plan depends on them being visible.
+    if (model.producing.isNotEmpty()) {
+        fieldLogChipSection(
+            id = "fl-producing-section",
+            label = "Producing · ${model.producing.size}",
+            worldId = worldId,
+            projects = model.producing,
+            dimmed = false,
+            glyph = "⚙",
+        )
+    }
+
     if (model.done.isNotEmpty() || model.cancelled.isNotEmpty() || model.archived.isNotEmpty()) {
         fieldLogDoneShelf(worldId, model.done, model.cancelled, model.archived)
     }
@@ -155,6 +168,7 @@ private fun FlowContent.fieldLogChipSection(
     worldId: Int,
     projects: List<ProjectListItem>,
     dimmed: Boolean,
+    glyph: String? = null,
 ) {
     div("fl-section") {
         attributes["id"] = id
@@ -163,6 +177,7 @@ private fun FlowContent.fieldLogChipSection(
             projects.forEach { project ->
                 a(classes = if (dimmed) "fl-chip fl-chip--dimmed" else "fl-chip") {
                     href = "/worlds/$worldId/projects/${project.id}"
+                    if (glyph != null) span("fl-chip__glyph") { +glyph }
                     span("fl-chip__name") { +project.name }
                     projectStateBadge(project.id, project.state)
                 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -11,6 +11,7 @@ import app.mcorg.engine.plan.ActivityGroup
 import app.mcorg.engine.plan.GatheringPlan
 import app.mcorg.engine.plan.PlanNodeStatus
 import app.mcorg.engine.plan.PlanOverrides
+import app.mcorg.engine.plan.SupplySource
 import app.mcorg.presentation.hxDelete
 import app.mcorg.presentation.hxDeleteWithConfirm
 import app.mcorg.presentation.hxGet
@@ -42,6 +43,8 @@ import kotlinx.html.stream.createHTML
 import app.mcorg.engine.plan.TargetTree
 import app.mcorg.pipeline.resources.FeedsLabel
 import app.mcorg.pipeline.resources.buildFeedsLabels
+import app.mcorg.pipeline.resources.PendingFarmItem
+import app.mcorg.pipeline.resources.PendingFarmSupply
 import app.mcorg.pipeline.resources.buildNodeIngredients
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -57,6 +60,7 @@ fun projectDetailPage(
     plan: GatheringPlan? = null,
     progressMap: Map<String, Int> = emptyMap(),
     productions: List<ProjectProduction> = emptyList(),
+    pendingFarms: List<PendingFarmSupply> = emptyList(),
     drillTarget: TargetTree? = null,
     drillCandidateCounts: Map<String, Int> = emptyMap(),
     drillNodeIngredients: Map<String, String> = emptyMap(),
@@ -131,7 +135,7 @@ fun projectDetailPage(
                     // ?drill=<item> deep-links straight into a target's chain (reload/share-safe).
                     drillChainContent(project, drillTarget, drillCandidateCounts, drillNodeIngredients, overrides = drillOverrides, graph = drillGraph, highlightItemId = drillHighlightItemId)
                 } else {
-                    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap)
+                    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap, pendingFarms)
                 }
             }
         }
@@ -233,6 +237,7 @@ fun FlowContent.gatheringPlannerContent(
     plan: GatheringPlan?,
     lens: String = "list",
     progressMap: Map<String, Int> = emptyMap(),
+    pendingFarms: List<PendingFarmSupply> = emptyList(),
 ) {
     val activeLens = when (lens) {
         "next", "sessions" -> lens
@@ -261,7 +266,7 @@ fun FlowContent.gatheringPlannerContent(
     // Active lens body
     when (activeLens) {
         "next", "sessions" -> lensComingSoon(project.worldId, project.id, activeLens)
-        else -> listLensContent(project, resources, tasks, plan, progressMap)
+        else -> listLensContent(project, resources, tasks, plan, progressMap, pendingFarms)
     }
 }
 
@@ -290,6 +295,7 @@ private fun FlowContent.listLensContent(
     tasks: List<ActionTask>,
     plan: GatheringPlan?,
     progressMap: Map<String, Int> = emptyMap(),
+    pendingFarms: List<PendingFarmSupply> = emptyList(),
 ) {
     // Resolution toggle (client-side; default "targets" applied by plan-view.js).
     listResolutionToggle()
@@ -393,7 +399,7 @@ private fun FlowContent.listLensContent(
         id = "list-breakdown-view"
         attributes["data-resolution-view"] = "breakdown"
 
-        gatheringPlanSections(project, plan, progressMap)
+        gatheringPlanSections(project, plan, progressMap, pendingFarms)
     }
 
     // Tasks section (collapsed)
@@ -467,6 +473,7 @@ fun FlowContent.gatheringPlanSections(
     project: Project,
     plan: GatheringPlan?,
     progressMap: Map<String, Int> = emptyMap(),
+    pendingFarms: List<PendingFarmSupply> = emptyList(),
 ) {
     if (plan == null) {
         // Empty state — no resources yet or all collected
@@ -507,6 +514,48 @@ fun FlowContent.gatheringPlanSections(
                 }
             }
         }
+
+        pendingFarmNotice(project.worldId, pendingFarms)
+    }
+}
+
+/**
+ * The partial-dependency notice (MCO-299): items this plan still gathers by hand that a
+ * farm project in the world has promised but is not producing yet.
+ *
+ * Bottom of the plan, deliberately low visual weight — it changes nothing about what to do
+ * today, it only says the manual work is a stopgap. It appears solely for farms that are
+ * *not* operational; once one is Done, its items move into "Collect from farms" and the
+ * line for them disappears on its own.
+ */
+private fun FlowContent.pendingFarmNotice(worldId: Int, pendingFarms: List<PendingFarmSupply>) {
+    if (pendingFarms.isEmpty()) return
+
+    div("plan-pending-farms") {
+        id = "plan-pending-farms"
+        pendingFarms.forEach { farm ->
+            p("plan-pending-farms__line") {
+                +itemsPhrase(farm.items)
+                +" will come from "
+                a(classes = "plan-pending-farms__project") {
+                    href = "/worlds/$worldId/projects/${farm.projectId}"
+                    +farm.projectName
+                }
+                +" once it is running — gather "
+                +(if (farm.items.size == 1) "it" else "them")
+                +" manually meanwhile."
+            }
+        }
+    }
+}
+
+/** "32 Iron Ingot", "32 Iron Ingot and 12 Gold Ingot", "32 Iron Ingot, 12 Gold Ingot and 4 Diamond". */
+private fun itemsPhrase(items: List<PendingFarmItem>): String {
+    val parts = items.map { "${it.quantity} ${it.itemName}" }
+    return when (parts.size) {
+        1 -> parts.first()
+        2 -> "${parts[0]} and ${parts[1]}"
+        else -> parts.dropLast(1).joinToString(", ") + " and " + parts.last()
     }
 }
 
@@ -550,21 +599,43 @@ internal fun FlowContent.feedsLine(label: FeedsLabel?) {
     }
 }
 
-/** SUPPLIED row: badge + supply label, no counter. */
+/**
+ * SUPPLIED row: badge + supply label, no counter.
+ *
+ * Farm supply and linked-project supply share the group but are not the same promise
+ * (MCO-299): a farm keeps producing, a linked project hands over once. The badge says
+ * which, and a linked project's name is a link to it — the farm's name is not, because
+ * the supply is ambient (any operational producer of the item, resolved at plan time).
+ */
 private fun FlowContent.suppliedActivityRow(
     worldId: Int,
     projectId: Int,
     activity: Activity,
     feedsLabel: FeedsLabel? = null,
 ) {
-    val supplyLabel = activity.supply?.label ?: "Supplied"
+    val supply = activity.supply
     val encodedItemId = URLEncoder.encode(activity.item.id, StandardCharsets.UTF_8)
     div("resource-row") {
         id = "plan-activity-${activity.item.id.replace(":", "-")}"
         div("resource-row__desktop") {
             div("resource-row__name") { +activity.item.name }
-            span("badge badge--accent") { +"Supplied" }
-            span("resource-row__source") { +"from $supplyLabel" }
+            when (supply) {
+                is SupplySource.Farm -> {
+                    span("badge badge--accent") { +"Farm" }
+                    span("resource-row__source") { +"from ${supply.label}" }
+                }
+                is SupplySource.LinkedProject -> {
+                    span("badge badge--accent") { +"Project" }
+                    span("resource-row__source") {
+                        +"from "
+                        a(classes = "resource-row__source-link") {
+                            href = "/worlds/$worldId/projects/${supply.projectId}"
+                            +supply.label
+                        }
+                    }
+                }
+                null -> span("badge badge--accent") { +"Supplied" }
+            }
             drillButton(worldId, projectId, encodedItemId)
         }
         feedsLine(feedsLabel)
@@ -1018,9 +1089,10 @@ fun gatheringPlannerFragment(
     plan: GatheringPlan?,
     lens: String = "list",
     progressMap: Map<String, Int> = emptyMap(),
+    pendingFarms: List<PendingFarmSupply> = emptyList(),
 ): String = createHTML().div {
     id = "project-content"
-    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap)
+    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap, pendingFarms)
 }
 
 /** OOB fragment to update #project-progress after task create/complete. */

--- a/webapp/mc-web/src/main/resources/static/styles/components/resource-row.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/resource-row.css
@@ -105,6 +105,17 @@
     flex: 0 0 auto;
 }
 
+/* Linked-project supply names the project and links to it (MCO-299); farm supply is
+   ambient and has nothing to link to. */
+.resource-row__source-link {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.resource-row__source-link:hover {
+    text-decoration: underline;
+}
+
 /* Reverse-provenance line ("Feeds 24 Birch Door · 40 Chest") hung under a material row. */
 .resource-row__feeds {
     font-family: var(--font-ui);

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
@@ -578,3 +578,34 @@
 .production-chip__more {
     color: var(--text-muted);
 }
+
+/* ==========================================================================
+   PARTIAL-DEPENDENCY NOTICE (MCO-299)
+   Farms promised but not running yet. Sits under the plan at low visual weight —
+   it does not change today's work, it only frames it as temporary.
+   ========================================================================== */
+
+.plan-pending-farms {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    margin-top: var(--space-4);
+    padding-top: var(--space-3);
+    border-top: 1px dashed var(--border);
+}
+
+.plan-pending-farms__line {
+    margin: 0;
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+.plan-pending-farms__project {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.plan-pending-farms__project:hover {
+    text-decoration: underline;
+}

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-list.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-list.css
@@ -230,7 +230,18 @@
     opacity: 1;
 }
 
+/* Producing-farm marker (MCO-299) */
+.fl-chip__glyph {
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    color: var(--accent);
+}
+
 .fl-chip__name {
+    /* Takes the slack so the state badge stays right-aligned whether or not the chip
+       carries a leading glyph (a third child would otherwise centre the name). */
+    flex: 1;
+    text-align: left;
     font-family: var(--font-ui);
     font-size: var(--text-sm);
     font-weight: 600;

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/PendingFarmSupplyTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/PendingFarmSupplyTest.kt
@@ -1,0 +1,91 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.engine.plan.PlanNode
+import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.PlanTarget
+import app.mcorg.engine.plan.SupplySource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PendingFarmSupplyTest {
+
+    private val ironIngot = Item("minecraft:iron_ingot", "Iron Ingot")
+    private val goldIngot = Item("minecraft:gold_ingot", "Gold Ingot")
+    private val bamboo = Item("minecraft:bamboo", "Bamboo")
+
+    private fun plan(vararg nodes: PlanNode) = GatheringPlan(
+        nodes = nodes.associateBy { it.item.id },
+        targets = nodes.map { PlanTarget(it.item, it.quantity) },
+    )
+
+    private fun node(
+        item: Item,
+        quantity: Long,
+        status: PlanNodeStatus = PlanNodeStatus.RAW_GATHER,
+        supply: SupplySource? = null,
+    ) = PlanNode(item = item, quantity = quantity, crafts = 0, leftover = 0, status = status, supply = supply)
+
+    private fun row(itemId: String, projectId: Int = 7, projectName: String = "Iron Farm") =
+        PlannedFarmRow(itemId = itemId, projectId = projectId, projectName = projectName)
+
+    @Test
+    fun `an item still gathered by hand that a planned farm produces becomes a pending supply`() {
+        val result = buildPendingFarmSupplies(
+            plan(node(ironIngot, 32)),
+            listOf(row(ironIngot.id)),
+        )
+
+        assertEquals(1, result.size)
+        val farm = result.first()
+        assertEquals("Iron Farm", farm.projectName)
+        assertEquals(7, farm.projectId)
+        assertEquals(listOf(PendingFarmItem("minecraft:iron_ingot", "Iron Ingot", 32)), farm.items)
+    }
+
+    @Test
+    fun `an already supplied item is not pending`() {
+        // An operational farm (or a linked project) already solves it — there is nothing
+        // to promise, and the row lives in "Collect from farms" instead.
+        val result = buildPendingFarmSupplies(
+            plan(node(ironIngot, 32, PlanNodeStatus.SUPPLIED, SupplySource.Farm("Other Iron Farm"))),
+            listOf(row(ironIngot.id)),
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `a planned farm producing nothing this plan needs is not mentioned`() {
+        val result = buildPendingFarmSupplies(
+            plan(node(ironIngot, 32)),
+            listOf(row(bamboo.id, projectId = 9, projectName = "Bamboo Farm")),
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `items are grouped per farm, biggest amount first`() {
+        val result = buildPendingFarmSupplies(
+            plan(node(ironIngot, 32), node(goldIngot, 96), node(bamboo, 12)),
+            listOf(
+                row(ironIngot.id),
+                row(goldIngot.id),
+                row(bamboo.id, projectId = 9, projectName = "Bamboo Farm"),
+            ),
+        )
+
+        assertEquals(listOf("Bamboo Farm", "Iron Farm"), result.map { it.projectName }, "farms sort by name")
+        val iron = result.first { it.projectName == "Iron Farm" }
+        assertEquals(listOf("Gold Ingot", "Iron Ingot"), iron.items.map { it.itemName })
+        assertEquals(listOf(96L, 32L), iron.items.map { it.quantity })
+    }
+
+    @Test
+    fun `no planned farms means no notice`() {
+        assertTrue(buildPendingFarmSupplies(plan(node(ironIngot, 32)), emptyList()).isEmpty())
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSupplySurfacingIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSupplySurfacingIT.kt
@@ -1,0 +1,231 @@
+package app.mcorg.presentation.handler.project
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.minecraft.ServerData
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.domain.model.resources.ResourceQuantity
+import app.mcorg.domain.model.resources.ResourceSource
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.minecraft.StoreMinecraftDataStep
+import app.mcorg.pipeline.project.handleGetProject
+import app.mcorg.pipeline.project.handleGetProjectList
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.ProjectParamPlugin
+import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
+import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+
+/**
+ * How farm supply reads in the planner and the Field Log (MCO-299):
+ * - an operational farm's items sit in "Collect from farms" badged as a Farm
+ * - a farm that is not running yet produces the partial-dependency notice instead
+ * - a producing farm is not shelved with finished builds in the Field Log
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class FarmSupplySurfacingIT : WithUser() {
+
+    private val version = MinecraftVersion.Release(1, 97, 0)
+    private val ironIngot = Item("minecraft:iron_ingot", "Iron Ingot")
+
+    private var worldId: Int = 0
+    private var consumerId: Int = 0
+    private var farmId: Int = 0
+
+    @BeforeAll
+    fun setup() {
+        val stored = runBlocking {
+            StoreMinecraftDataStep.process(
+                ServerData(
+                    version = version,
+                    items = listOf(ironIngot),
+                    sources = listOf(
+                        ResourceSource(
+                            type = ResourceSource.SourceType.LootTypes.BLOCK,
+                            filename = "blocks/iron_ore.json",
+                            producedItems = listOf(ironIngot to ResourceQuantity.ItemQuantity(1))
+                        )
+                    )
+                )
+            )
+        }
+        assertIs<Result.Success<*>>(stored)
+
+        worldId = createWorld("FarmSupplySurfacing IT World")
+        consumerId = createProject(worldId, "Beacon Build", ProjectState.PENDING)
+        farmId = createProject(worldId, "Iron Farm", ProjectState.ACTIVE)
+        createResourceGathering(consumerId, ironIngot, required = 32)
+        insertProduction(farmId, ironIngot, rate = 400)
+    }
+
+    @Test
+    fun `a farm that is not running yet shows the partial-dependency notice, not a supplied row`() = testApplication {
+        setupRoutes()
+        setProjectState(farmId, ProjectState.ACTIVE)
+
+        val body = client.get("/worlds/$worldId/projects/$consumerId") { addAuthCookie(this) }.bodyAsText()
+
+        assertContains(body, "plan-pending-farms")
+        assertContains(body, "32 Iron Ingot will come from")
+        assertContains(body, "Iron Farm")
+        assertContains(body, "once it is running")
+        assertFalse(body.contains("Collect from farms"), "the item is still manual work")
+    }
+
+    @Test
+    fun `once the farm is done the item moves to collect-from-farms and the notice disappears`() = testApplication {
+        setupRoutes()
+        setProjectState(farmId, ProjectState.DONE)
+
+        val body = client.get("/worlds/$worldId/projects/$consumerId") { addAuthCookie(this) }.bodyAsText()
+
+        assertContains(body, "Collect from farms")
+        assertContains(body, "from Iron Farm")
+        assertFalse(body.contains("plan-pending-farms"), "nothing is pending once the farm runs")
+
+        setProjectState(farmId, ProjectState.ACTIVE)
+    }
+
+    @Test
+    fun `a producing farm is listed as producing, not shelved with finished builds`() = testApplication {
+        setupRoutes()
+        setProjectState(farmId, ProjectState.DONE)
+
+        val response = client.get("/worlds/$worldId/projects") { addAuthCookie(this) }
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+
+        assertContains(body, "fl-producing-section")
+        assertContains(body, "Producing · 1")
+        assertFalse(body.contains("1 done"), "a running farm is not shelf material")
+
+        setProjectState(farmId, ProjectState.ACTIVE)
+    }
+
+    @Test
+    fun `a finished build with no productions still goes to the shelf`() = testApplication {
+        setupRoutes()
+        val inertBuild = createProject(worldId, "Finished Statue", ProjectState.DONE)
+
+        val body = client.get("/worlds/$worldId/projects") { addAuthCookie(this) }.bodyAsText()
+
+        assertContains(body, "1 done")
+        assertFalse(body.contains("fl-producing-section"), "no farm is producing in this state")
+
+        deleteProject(inertBuild)
+    }
+
+    // ---- routing ----------------------------------------------------------------
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
+                install(UpdateActiveWorldPlugin)
+                route("/projects") {
+                    get { call.handleGetProjectList() }
+                    route("/{projectId}") {
+                        install(ProjectParamPlugin)
+                        get { call.handleGetProject() }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- fixtures ----------------------------------------------------------------
+
+    private fun createWorld(name: String): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(name = name, description = "test", version = version)
+        )
+        (result as Result.Success).value
+    }
+
+    private fun createProject(worldId: Int, name: String, state: ProjectState): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, state, location_x, location_y, location_z, location_dimension) " +
+                    "VALUES (?, ?, '', 'FARMING', 'PLANNING', ?, 0, 0, 0, 'OVERWORLD') RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, name)
+                stmt.setInt(2, worldId)
+                stmt.setString(3, state.name)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun createResourceGathering(projectId: Int, item: Item, required: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO resource_gathering (project_id, item_id, name, required) VALUES (?, ?, ?, ?)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, item.id)
+                stmt.setString(3, item.name)
+                stmt.setInt(4, required)
+            }
+        ).process(Unit)
+    }
+
+    private fun insertProduction(projectId: Int, item: Item, rate: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO project_productions (project_id, item_id, name, rate_per_hour) VALUES (?, ?, ?, ?)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, item.id)
+                stmt.setString(3, item.name)
+                stmt.setInt(4, rate)
+            }
+        ).process(Unit)
+    }
+
+    private fun setProjectState(projectId: Int, state: ProjectState) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.update("UPDATE projects SET state = ? WHERE id = ?"),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, state.name)
+                stmt.setInt(2, projectId)
+            }
+        ).process(Unit)
+    }
+
+    private fun deleteProject(projectId: Int) = runBlocking {
+        DatabaseSteps.update<Int>(
+            sql = SafeSQL.delete("DELETE FROM projects WHERE id = ?"),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) }
+        ).process(projectId)
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/FieldLogModelTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/FieldLogModelTest.kt
@@ -17,6 +17,7 @@ class FieldLogModelTest {
         state: ProjectState = ProjectState.ACTIVE,
         gathered: Int = 0,
         required: Int = 100,
+        producesCount: Int = 0,
     ) = ProjectListItem(
         id = id,
         name = name,
@@ -28,6 +29,7 @@ class FieldLogModelTest {
         resourcesGathered = gathered,
         itemCount = 1,
         nextTaskName = null,
+        producesCount = producesCount,
     )
 
     private fun edge(
@@ -165,5 +167,30 @@ class FieldLogModelTest {
         assertEquals(listOf(4), model.paused.map { it.id })
         assertEquals(listOf(5), model.pending.map { it.id })
         assertTrue(model.active.isEmpty())
+    }
+
+    // --- Producing farms (MCO-299) ---------------------------------------------
+
+    @Test
+    fun `a DONE project with productions is producing, not shelved`() {
+        val farm = project(1, "Iron Farm", state = ProjectState.DONE, producesCount = 2)
+        val build = project(2, "Beacon", state = ProjectState.DONE)
+
+        val model = FieldLogModel.of(listOf(farm, build), emptyList())
+
+        assertEquals(listOf("Iron Farm"), model.producing.map { it.name })
+        assertEquals(listOf("Beacon"), model.done.map { it.name })
+    }
+
+    @Test
+    fun `productions on a project that is not DONE do not make it producing`() {
+        // The farm is built but not finished — it produces nothing yet, and the plan's
+        // partial-dependency notice, not this section, is what mentions it.
+        val plannedFarm = project(1, "Gold Farm", state = ProjectState.ACTIVE, producesCount = 1)
+
+        val model = FieldLogModel.of(listOf(plannedFarm), emptyList())
+
+        assertTrue(model.producing.isEmpty())
+        assertEquals(listOf("Gold Farm"), model.active.map { it.name })
     }
 }


### PR DESCRIPTION
Phase 4 of [MCO-287](https://linear.app/evegul/issue/MCO-287) — the last child. Makes the supply model legible where the work happens.

## Farm vs linked project

"Collect from farms" badged everything `Supplied`, so two different promises read the same. A farm keeps producing; a linked project hands over once. The badge now says which, and a linked project's name links to it — a farm's does not, because farm supply is *ambient* (any operational producer of the item, resolved at plan time), not a relationship with one project.

## The partial-dependency notice

`GetWorldPlannedFarmsStep` is the mirror of MCO-296's supply query: farm projects that are `PENDING`/`ACTIVE`/`PAUSED` and produce items this plan is still gathering by hand. They deliberately supply nothing — until the farm is `DONE` its output does not exist — but the promise is worth surfacing, so the plan closes with:

> 32 Iron Ingot will come from **Iron Farm** once it is running — gather it manually meanwhile.

Low visual weight, bottom of the section, per the IA. It disappears on its own once the farm goes `DONE` and its items move up into "Collect from farms". It soft-fails to nothing — a courtesy line must not be able to take the plan down — and is wired into all three render paths so it survives HTMX re-renders.

## The Field Log wrinkle

Flagged during MCO-298 and agreed for this issue: a recorded farm landed in the collapsed done shelf, reading as shelved when it is the most operational thing in the world. `DONE` projects with productions now get their own **Producing** section above the shelf; inert finished builds stay shelved. `ProjectListItem` carries `producesCount` and owns the `isProducing` rule so the split is one testable place.

**One IA judgement call worth your eye:** I pulled producing farms into a separate section rather than marking them inside the shelf — a marker would still leave them collapsed behind "1 done · show", which is the actual complaint. Easy to change during the UI/UX pass if you'd rather they sat somewhere else (they are currently below Pending/Paused, above the shelf).

## Tests

- `PendingFarmSupplyTest` (5) — the pure matcher: pending item matched, already-supplied item excluded, irrelevant farm ignored, per-farm grouping and ordering, empty case.
- `FieldLogModelTest` +2 — producing/inert split; productions on a non-DONE project don't count.
- `FarmSupplySurfacingIT` (4) — drives both plan states and both Field Log placements through the real handlers.

Full suite green: 381 tests, unit + database tiers.

## Verified in the app

Farm `ACTIVE` → item sits under "Hunt" with the notice below. Farm `DONE` → "Collect from farms" with the `Farm` badge, notice gone. Field Log shows **Producing · 1** with the ⚙ chip instead of the collapsed shelf. Also fixed a chip layout nit the new glyph exposed (a third child centred the name).

Closes the MCO-287 epic once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)