### PR TITLE
MCO-288: world roadmap page — derived dependency table

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/world/Roadmap.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/world/Roadmap.kt
@@ -1,6 +1,7 @@
 package app.mcorg.domain.model.world
 
 import app.mcorg.domain.model.project.ProjectStage
+import app.mcorg.domain.model.project.ProjectState
 import app.mcorg.domain.model.project.ProjectType
 
 /**
@@ -70,6 +71,12 @@ data class RoadmapNode(
     val projectName: String,
     val projectType: ProjectType,
     val stage: ProjectStage,
+    /**
+     * Lifecycle state — the axis the rest of the app blocks and groups on. [stage] tracks
+     * progress *within* a project; DONE vs not-DONE is what decides whether this node
+     * still blocks the ones downstream of it.
+     */
+    val state: ProjectState,
     val tasksTotal: Int,
     val tasksCompleted: Int,
     val isBlocked: Boolean,
@@ -122,7 +129,13 @@ data class RoadmapEdge(
     val fromNodeName: String,
     val toNodeId: Int,
     val toNodeName: String,
-    val isBlocking: Boolean
+    val isBlocking: Boolean,
+    /**
+     * The resource this edge is about, when it is a resource edge. Null for a manual
+     * project→project sequencing edge. The roadmap's "Blocked by" cell names the project
+     * *and* the resource, so the reader knows what to go and get.
+     */
+    val itemName: String? = null,
 ) {
     /**
      * Checks if this edge represents a blocking dependency

--- a/webapp/mc-domain/src/test/kotlin/app/mcorg/domain/model/world/RoadmapTest.kt
+++ b/webapp/mc-domain/src/test/kotlin/app/mcorg/domain/model/world/RoadmapTest.kt
@@ -1,6 +1,7 @@
 package app.mcorg.domain.model.world
 
 import app.mcorg.domain.model.project.ProjectStage
+import app.mcorg.domain.model.project.ProjectState
 import app.mcorg.domain.model.project.ProjectType
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -260,6 +261,7 @@ class RoadmapTest {
         projectName = name,
         projectType = type,
         stage = stage,
+        state = ProjectState.fromStage(stage),
         tasksTotal = tasksTotal,
         tasksCompleted = tasksCompleted,
         isBlocked = isBlocked,

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetFarmSupplyEdgesStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetFarmSupplyEdgesStep.kt
@@ -1,0 +1,78 @@
+package app.mcorg.pipeline.project.commonsteps
+
+import app.mcorg.domain.model.project.ProjectResourceEdge
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+
+/**
+ * Producer→consumer edges implied by farm supply (MCO-288, on top of MCO-287).
+ *
+ * A project that needs an item another project *produces* depends on that project, even
+ * though nobody declared the link: `solved_by_project_id` was never set and there is no
+ * `project_dependencies` row. The plan page already says so — MCO-299's notice promises
+ * "32 Iron Ingot will come from Iron Farm once it is running" — so a roadmap that omitted
+ * these would contradict the page the user just came from.
+ *
+ * Blocking follows the same rule as every other edge ([ProjectResourceEdge.isBlocking]):
+ * an operational (DONE) farm supplies now and blocks nothing; a farm still being built
+ * blocks its consumers. That falls straight out of the producer's state — no special case.
+ *
+ * Matching is on declared requirements (`resource_gathering`), not on the derived plan:
+ * same granularity as `solved_by_project_id`, and one query instead of one plan derivation
+ * per project. Ignored requirements (MCO-247) are not demand and are excluded.
+ */
+data class GetFarmSupplyEdgesStep(val worldId: Int) : Step<Unit, AppFailure.DatabaseError, List<ProjectResourceEdge>> {
+    override suspend fun process(input: Unit): Result<AppFailure.DatabaseError, List<ProjectResourceEdge>> {
+        return DatabaseSteps.query<Unit, List<ProjectResourceEdge>>(
+            sql = SafeSQL.select("""
+                SELECT DISTINCT
+                  rg.project_id  AS consumer_id,
+                  pc.name        AS consumer_name,
+                  pc.state       AS consumer_state,
+                  pp.project_id  AS producer_id,
+                  prod.name      AS producer_name,
+                  rg.name        AS item_name,
+                  prod.state     AS producer_state
+                FROM resource_gathering rg
+                JOIN projects pc         ON pc.id = rg.project_id
+                JOIN project_productions pp ON pp.item_id = rg.item_id
+                JOIN projects prod       ON prod.id = pp.project_id
+                WHERE pc.world_id = ?
+                  AND prod.world_id = ?
+                  AND prod.id <> rg.project_id
+                  AND rg.ignored = FALSE
+                  AND prod.state NOT IN (?, ?)
+                  -- An explicitly solved requirement already produces an edge via
+                  -- GetProjectEdgesStep; deriving a second one would double-count it.
+                  AND rg.solved_by_project_id IS NULL
+            """.trimIndent()),
+            parameterSetter = { statement, _ ->
+                statement.setInt(1, worldId)
+                statement.setInt(2, worldId)
+                statement.setString(3, ProjectState.CANCELLED.name)
+                statement.setString(4, ProjectState.ARCHIVED.name)
+            },
+            resultMapper = { resultSet ->
+                buildList {
+                    while (resultSet.next()) {
+                        add(
+                            ProjectResourceEdge(
+                                consumerId = resultSet.getInt("consumer_id"),
+                                consumerName = resultSet.getString("consumer_name"),
+                                consumerState = ProjectState.valueOf(resultSet.getString("consumer_state")),
+                                producerId = resultSet.getInt("producer_id"),
+                                producerName = resultSet.getString("producer_name"),
+                                itemName = resultSet.getString("item_name"),
+                                producerState = ProjectState.valueOf(resultSet.getString("producer_state")),
+                            )
+                        )
+                    }
+                }
+            }
+        ).process(input)
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/roadmap/GetWorldRoadMapStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/roadmap/GetWorldRoadMapStep.kt
@@ -1,140 +1,146 @@
 package app.mcorg.pipeline.world.roadmap
 
+import app.mcorg.domain.model.project.ProjectResourceEdge
 import app.mcorg.domain.model.project.ProjectStage
+import app.mcorg.domain.model.project.ProjectState
 import app.mcorg.domain.model.project.ProjectType
 import app.mcorg.domain.model.world.Roadmap
 import app.mcorg.domain.model.world.RoadmapEdge
 import app.mcorg.domain.model.world.RoadmapLayer
 import app.mcorg.domain.model.world.RoadmapNode
-import app.mcorg.pipeline.Result
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.project.commonsteps.GetFarmSupplyEdgesStep
+import app.mcorg.pipeline.project.commonsteps.GetProjectEdgesStep
 import java.sql.ResultSet
 
+/**
+ * Builds the world's project dependency roadmap (MCO-288).
+ *
+ * **The roadmap is derived, never hand-curated.** Its edges come from three places, all of
+ * them consequences of what the user actually declared about resources:
+ *
+ * 1. item-level links — a requirement solved by another project (`solved_by_project_id`)
+ * 2. farm supply — a requirement another project *produces* ([GetFarmSupplyEdgesStep], MCO-287)
+ * 3. manual project→project sequencing rows (`project_dependencies`), for the non-resource
+ *    ordering that no item can express ("dig the perimeter first")
+ *
+ * The first and third arrive together from [GetProjectEdgesStep], which the Field Log already
+ * uses — so the roadmap and the Field Log cannot disagree about what blocks what.
+ *
+ * Blocking is a function of the producer's [ProjectState]: not DONE means still blocking.
+ * This is the same rule as [ProjectResourceEdge.isBlocking] and the same one the planner
+ * uses to decide whether a farm supplies anything yet.
+ */
 data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadmap> {
+
     override suspend fun process(input: Unit): Result<AppFailure, Roadmap> {
-        // Step 1: Get all projects in the world with task counts
-        val projects = when (val projectsResult = getProjects()) {
-            is Result.Success -> projectsResult.value
-            is Result.Failure -> return projectsResult
+        val worldName = when (val r = getWorldName()) {
+            is Result.Success -> r.value ?: return Result.failure(AppFailure.DatabaseError.NotFound)
+            is Result.Failure -> return r
         }
 
-        // Step 2: Get all dependencies
-        val dependencies = when (val dependenciesResult = getDependencies()) {
-            is Result.Success -> dependenciesResult.value
-            is Result.Failure -> return dependenciesResult
+        val projects = when (val r = getProjects()) {
+            is Result.Success -> r.value
+            is Result.Failure -> return r
         }
 
-        // Step 3: Build the roadmap structure
-        val roadmap = buildRoadmap(projects, dependencies)
+        val declaredEdges = when (val r = GetProjectEdgesStep(worldId).process(Unit)) {
+            is Result.Success -> r.value
+            is Result.Failure -> return r
+        }
 
-        return Result.success(roadmap)
+        val farmEdges = when (val r = GetFarmSupplyEdgesStep(worldId).process(Unit)) {
+            is Result.Success -> r.value
+            is Result.Failure -> return r
+        }
+
+        // Same (consumer, producer, item) can arrive from more than one source; the roadmap
+        // shows the relationship once.
+        val edges = (declaredEdges + farmEdges)
+            .distinctBy { Triple(it.consumerId, it.producerId, it.itemName) }
+
+        return Result.success(buildRoadmap(worldName, projects, edges))
     }
 
-    private suspend fun getProjects(): Result<AppFailure.DatabaseError, List<ProjectRecord>> {
-        return DatabaseSteps.query<Unit, List<ProjectRecord>>(
+    private suspend fun getWorldName(): Result<AppFailure.DatabaseError, String?> =
+        DatabaseSteps.query<Unit, String?>(
+            sql = SafeSQL.select("SELECT name FROM world WHERE id = ?"),
+            parameterSetter = { statement, _ -> statement.setInt(1, worldId) },
+            resultMapper = { if (it.next()) it.getString("name") else null }
+        ).process(Unit)
+
+    private suspend fun getProjects(): Result<AppFailure.DatabaseError, List<ProjectRecord>> =
+        DatabaseSteps.query<Unit, List<ProjectRecord>>(
             SafeSQL.select("""
-                SELECT 
+                SELECT
                     p.id,
                     p.name,
                     p.type,
                     p.stage,
-                    p.world_id,
-                    COUNT(t.id) as tasks_total,
-                    COUNT(CASE WHEN t.completed = TRUE THEN 1 ELSE 0 END) as tasks_completed
+                    p.state,
+                    COUNT(t.id)                                AS tasks_total,
+                    COUNT(t.id) FILTER (WHERE t.completed)     AS tasks_completed
                 FROM projects p
                 LEFT JOIN action_task t ON t.project_id = p.id
                 WHERE p.world_id = ?
-                GROUP BY p.id, p.name, p.type, p.stage, p.world_id
+                GROUP BY p.id, p.name, p.type, p.stage, p.state
                 ORDER BY p.name
             """.trimIndent()),
-            parameterSetter = { statement, _ ->
-                statement.setInt(1, worldId)
-            },
+            parameterSetter = { statement, _ -> statement.setInt(1, worldId) },
             resultMapper = { it.toProjectRecords() }
         ).process(Unit)
-    }
 
-    private suspend fun getDependencies(): Result<AppFailure.DatabaseError, List<DependencyRecord>> {
-        return DatabaseSteps.query<Unit, List<DependencyRecord>>(
-            SafeSQL.select("""
-                SELECT 
-                    pd.project_id as from_id,
-                    p1.name as from_name,
-                    pd.depends_on_project_id as to_id,
-                    p2.name as to_name,
-                    p2.stage as to_stage
-                FROM project_dependencies pd
-                JOIN projects p1 ON pd.project_id = p1.id
-                JOIN projects p2 ON pd.depends_on_project_id = p2.id
-                WHERE p1.world_id = ?
-                ORDER BY pd.project_id, pd.depends_on_project_id
-            """.trimIndent()),
-            parameterSetter = { statement, _ ->
-                statement.setInt(1, worldId)
-            },
-            resultMapper = { it.toDependencyRecords() }
-        ).process(Unit)
-    }
+    private fun buildRoadmap(
+        worldName: String,
+        projects: List<ProjectRecord>,
+        edges: List<ProjectResourceEdge>,
+    ): Roadmap {
+        // Edges reference only projects in this world (every query is world-scoped), but a
+        // project may appear in neither map — that just means it is isolated.
+        val incoming = edges.groupBy { it.consumerId }
+        val outgoing = edges.groupBy { it.producerId }
 
-    private fun buildRoadmap(projects: List<ProjectRecord>, dependencies: List<DependencyRecord>): Roadmap {
-        // Build dependency maps
-        val dependencyMap = dependencies.groupBy { it.fromId }
-        val dependentMap = dependencies.groupBy { it.toId }
+        val layers = calculateLayers(projects, edges)
 
-        // Calculate layers using topological sort
-        val layers = calculateLayers(projects, dependencies)
-
-        // Get world name from first project (or use default)
-        val worldName = projects.firstOrNull()?.let { "World ${it.worldId}" } ?: "Empty World"
-
-        // Build nodes
         val nodes = projects.map { project ->
-            val projectDependencies = dependencyMap[project.id] ?: emptyList()
-            val projectDependents = dependentMap[project.id] ?: emptyList()
-
-            // A project is blocked if any of its dependencies are not completed
-            val blockingProjects = projectDependencies.filter { it.toStage != ProjectStage.COMPLETED }
-            val isBlocked = blockingProjects.isNotEmpty()
+            val dependencies = incoming[project.id].orEmpty()
+            val blocking = dependencies.filter { it.isBlocking }
 
             RoadmapNode(
                 projectId = project.id,
                 projectName = project.name,
                 projectType = project.type,
                 stage = project.stage,
+                state = project.state,
                 tasksTotal = project.tasksTotal,
                 tasksCompleted = project.tasksCompleted,
-                isBlocked = isBlocked,
-                blockingProjectIds = blockingProjects.map { it.toId },
-                dependentProjectIds = projectDependents.map { it.fromId },
-                layer = layers[project.id] ?: 0
+                isBlocked = blocking.isNotEmpty(),
+                blockingProjectIds = blocking.map { it.producerId }.distinct(),
+                dependentProjectIds = outgoing[project.id].orEmpty().map { it.consumerId }.distinct(),
+                layer = layers[project.id] ?: 0,
             )
         }
 
-        // Build edges
-        val edges = dependencies.map { dep ->
-            val isBlocking = dep.toStage != ProjectStage.COMPLETED
+        val roadmapEdges = edges.map { edge ->
             RoadmapEdge(
-                fromNodeId = dep.fromId,
-                fromNodeName = dep.fromName,
-                toNodeId = dep.toId,
-                toNodeName = dep.toName,
-                isBlocking = isBlocking
+                fromNodeId = edge.consumerId,
+                fromNodeName = edge.consumerName,
+                toNodeId = edge.producerId,
+                toNodeName = edge.producerName,
+                isBlocking = edge.isBlocking,
+                itemName = edge.itemName,
             )
         }
 
-        // Build layer groups
         val layerGroups = layers.entries
             .groupBy { it.value }
             .map { (depth, entries) ->
                 val projectIds = entries.map { it.key }
-                RoadmapLayer(
-                    depth = depth,
-                    projectIds = projectIds,
-                    projectCount = projectIds.size
-                )
+                RoadmapLayer(depth = depth, projectIds = projectIds, projectCount = projectIds.size)
             }
             .sortedBy { it.depth }
 
@@ -142,64 +148,51 @@ data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadma
             worldId = worldId,
             worldName = worldName,
             nodes = nodes,
-            edges = edges,
-            layers = layerGroups
+            edges = roadmapEdges,
+            layers = layerGroups,
         )
     }
 
     /**
-     * Calculates the layer depth for each project using topological sort.
-     * Layer 0 = projects with no dependencies
-     * Layer N = projects whose dependencies are all in layers 0..N-1
+     * Layer depth per project: 0 for projects that depend on nothing, otherwise
+     * max(dependency layer) + 1. BFS from the roots, promoting a project only once every
+     * one of its dependencies is placed.
+     *
+     * Anything left unplaced is in a dependency cycle. Cycles are not supposed to exist,
+     * but a roadmap that silently dropped projects would be worse than one that shows them
+     * at depth 0 — so they land at the top, visible.
      */
-    private fun calculateLayers(projects: List<ProjectRecord>, dependencies: List<DependencyRecord>): Map<Int, Int> {
+    private fun calculateLayers(
+        projects: List<ProjectRecord>,
+        edges: List<ProjectResourceEdge>,
+    ): Map<Int, Int> {
         val layers = mutableMapOf<Int, Int>()
-        val dependencyMap = dependencies.groupBy { it.fromId }
-        val processed = mutableSetOf<Int>()
+        val dependenciesOf = edges.groupBy { it.consumerId }
+        val dependentsOf = edges.groupBy { it.producerId }
+        val placed = mutableSetOf<Int>()
         val queue = ArrayDeque<Int>()
 
-        // Find root projects (no dependencies)
-        val projectsWithDeps = dependencyMap.keys
-        val rootProjects = projects.filter { it.id !in projectsWithDeps }
-
-        // Initialize root projects at layer 0
-        rootProjects.forEach { project ->
+        projects.filter { it.id !in dependenciesOf }.forEach { project ->
             layers[project.id] = 0
-            processed.add(project.id)
+            placed.add(project.id)
             queue.add(project.id)
         }
 
-        // Process queue using BFS
         while (queue.isNotEmpty()) {
             val currentId = queue.removeFirst()
-
-            // Find all projects that depend on this one
-            val dependents = dependencies.filter { it.toId == currentId }
-
-            dependents.forEach { dep ->
-                val dependentId = dep.fromId
-
-                // Check if all dependencies of the dependent project are processed
-                val allDeps = dependencyMap[dependentId] ?: emptyList()
-                val allDepsProcessed = allDeps.all { it.toId in processed }
-
-                if (allDepsProcessed && dependentId !in processed) {
-                    // Calculate the layer as max(dependency layers) + 1
-                    val maxDepLayer = allDeps.maxOfOrNull { layers[it.toId] ?: 0 } ?: 0
-                    layers[dependentId] = maxDepLayer + 1
-                    processed.add(dependentId)
+            dependentsOf[currentId].orEmpty().forEach { edge ->
+                val dependentId = edge.consumerId
+                if (dependentId in placed) return@forEach
+                val dependencies = dependenciesOf[dependentId].orEmpty()
+                if (dependencies.all { it.producerId in placed }) {
+                    layers[dependentId] = (dependencies.maxOfOrNull { layers[it.producerId] ?: 0 } ?: 0) + 1
+                    placed.add(dependentId)
                     queue.add(dependentId)
                 }
             }
         }
 
-        // Handle any unprocessed projects (shouldn't happen with valid data, but safety first)
-        projects.forEach { project ->
-            if (project.id !in layers) {
-                layers[project.id] = 0
-            }
-        }
-
+        projects.forEach { project -> layers.putIfAbsent(project.id, 0) }
         return layers
     }
 
@@ -211,23 +204,9 @@ data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadma
                     name = getString("name"),
                     type = ProjectType.valueOf(getString("type")),
                     stage = ProjectStage.valueOf(getString("stage")),
-                    worldId = getInt("world_id"),
+                    state = ProjectState.valueOf(getString("state")),
                     tasksTotal = getInt("tasks_total"),
-                    tasksCompleted = getInt("tasks_completed")
-                )
-            )
-        }
-    }
-
-    private fun ResultSet.toDependencyRecords() = buildList {
-        while (next()) {
-            add(
-                DependencyRecord(
-                    fromId = getInt("from_id"),
-                    fromName = getString("from_name"),
-                    toId = getInt("to_id"),
-                    toName = getString("to_name"),
-                    toStage = ProjectStage.valueOf(getString("to_stage"))
+                    tasksCompleted = getInt("tasks_completed"),
                 )
             )
         }
@@ -238,16 +217,8 @@ data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadma
         val name: String,
         val type: ProjectType,
         val stage: ProjectStage,
-        val worldId: Int,
+        val state: ProjectState,
         val tasksTotal: Int,
-        val tasksCompleted: Int
-    )
-
-    private data class DependencyRecord(
-        val fromId: Int,
-        val fromName: String,
-        val toId: Int,
-        val toName: String,
-        val toStage: ProjectStage
+        val tasksCompleted: Int,
     )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/roadmap/GetWorldRoadmapPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/roadmap/GetWorldRoadmapPipeline.kt
@@ -1,0 +1,32 @@
+package app.mcorg.pipeline.world.roadmap
+
+import app.mcorg.domain.model.user.Role
+import app.mcorg.domain.model.world.Roadmap
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.world.ValidateWorldMemberRole
+import app.mcorg.presentation.handler.handlePipeline
+import app.mcorg.presentation.templated.dsl.pages.roadmapPage
+import app.mcorg.presentation.utils.getUser
+import app.mcorg.presentation.utils.getWorldId
+import app.mcorg.presentation.utils.respondHtml
+import io.ktor.server.application.ApplicationCall
+
+/**
+ * `GET /worlds/{worldId}/roadmap` (MCO-288) — the world's derived project sequence.
+ *
+ * Read-only, so world membership (enforced by the route's plugins) is the whole
+ * authorization story; the admin check only decides what the header offers.
+ */
+suspend fun ApplicationCall.handleGetWorldRoadmap() {
+    val user = getUser()
+    val worldId = getWorldId()
+    val isAdmin = ValidateWorldMemberRole<Unit>(user, Role.ADMIN, worldId).process(Unit) is Result.Success
+
+    handlePipeline(
+        onSuccess = { roadmap: Roadmap ->
+            respondHtml(roadmapPage(user, roadmap, isWorldAdmin = isAdmin))
+        }
+    ) {
+        GetWorldRoadMapStep(worldId).run(Unit)
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -8,6 +8,7 @@ import app.mcorg.pipeline.project.handleCreateProjectFromSchematic
 import app.mcorg.pipeline.project.handleDeleteProject
 import app.mcorg.pipeline.project.handleGetProject
 import app.mcorg.pipeline.project.handleGetDetailContent
+import app.mcorg.pipeline.world.roadmap.handleGetWorldRoadmap
 import app.mcorg.pipeline.project.handleRecordExistingFarm
 import app.mcorg.pipeline.project.resources.handleAddResourcesFromSchematic
 import app.mcorg.pipeline.project.resources.handleDeleteProjectProduction
@@ -124,6 +125,9 @@ class WorldHandler {
                 get {
                     val worldId = call.parameters["worldId"]!!.toInt()
                     call.respondRedirect("/worlds/$worldId/projects", permanent = true)
+                }
+                get("/roadmap") {
+                    call.handleGetWorldRoadmap()
                 }
                 route("/projects") {
                     get {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectListPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectListPage.kt
@@ -641,6 +641,12 @@ fun planProjectCardFragment(worldId: Int, project: ProjectPlanListItem): String 
 fun kotlinx.html.FlowContent.projectsToolbar(worldId: Int, view: String = "execute") {
     div("projects-toolbar") {
         newProjectMenu(worldId)
+        // Understated link, not a nav item (MCO-288): the roadmap is progressive disclosure —
+        // it means nothing until projects depend on each other.
+        a(classes = "projects-toolbar__roadmap-link") {
+            href = "/worlds/$worldId/roadmap"
+            +"View roadmap →"
+        }
         planExecuteToggle(worldId, view)
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/RoadmapPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/RoadmapPage.kt
@@ -1,0 +1,217 @@
+package app.mcorg.presentation.templated.dsl.pages
+
+import app.mcorg.domain.model.user.TokenProfile
+import app.mcorg.domain.model.world.Roadmap
+import app.mcorg.domain.model.world.RoadmapEdge
+import app.mcorg.domain.model.world.RoadmapNode
+import app.mcorg.presentation.templated.dsl.appHeader
+import app.mcorg.presentation.templated.dsl.container
+import app.mcorg.presentation.templated.dsl.emptyState
+import app.mcorg.presentation.templated.dsl.pageShell
+import app.mcorg.presentation.templated.dsl.projectStateBadge
+import kotlinx.html.FlowContent
+import kotlinx.html.a
+import kotlinx.html.div
+import kotlinx.html.h1
+import kotlinx.html.id
+import kotlinx.html.main
+import kotlinx.html.span
+import kotlinx.html.table
+import kotlinx.html.tbody
+import kotlinx.html.td
+import kotlinx.html.th
+import kotlinx.html.thead
+import kotlinx.html.tr
+
+/**
+ * The world roadmap (MCO-288) — every project as a row, ordered by dependency depth, so the
+ * sequence the world implies is readable top to bottom.
+ *
+ * Table form on purpose: the layered graph the model already computes is the follow-up, and
+ * a table is the accessible, mobile-survivable, hundreds-of-rows form to lead with. Nothing
+ * here is editable — the roadmap is derived from resource relationships, never curated.
+ */
+fun roadmapPage(
+    user: TokenProfile,
+    roadmap: Roadmap,
+    isWorldAdmin: Boolean = false,
+): String = pageShell(
+    pageTitle = "Seam — ${roadmap.worldName} roadmap",
+    user = user,
+    stylesheets = listOf(
+        "/static/styles/components/btn.css",
+        "/static/styles/components/badge.css",
+        "/static/styles/pages/roadmap.css",
+    ),
+) {
+    appHeader(
+        worldName = roadmap.worldName,
+        worldId = roadmap.worldId,
+        user = user,
+        isWorldAdmin = isWorldAdmin,
+        breadcrumbBlock = {
+            link("Worlds", "/worlds")
+                .link(roadmap.worldName, "/worlds/${roadmap.worldId}/projects")
+                .current("Roadmap")
+        }
+    )
+    main {
+        container {
+            div("roadmap-title") {
+                h1("roadmap-title__name") { +"Roadmap" }
+                div("roadmap-title__meta") { +roadmapSummary(roadmap) }
+            }
+
+            if (roadmap.isEmpty()) {
+                roadmapEmptyState(roadmap.worldId)
+            } else {
+                roadmapTable(roadmap)
+            }
+        }
+    }
+}
+
+/** "12 projects · 3 blocked · 4 layers deep" — straight off the model's own statistics. */
+private fun roadmapSummary(roadmap: Roadmap): String {
+    val stats = roadmap.getStatistics()
+    val parts = buildList {
+        add("${stats.totalProjects} ${if (stats.totalProjects == 1) "project" else "projects"}")
+        if (stats.blockedProjects > 0) add("${stats.blockedProjects} blocked")
+        if (stats.totalDependencies > 0) {
+            add("${stats.maxDepth} ${if (stats.maxDepth == 1) "layer" else "layers"} deep")
+        }
+    }
+    return parts.joinToString(" · ")
+}
+
+/**
+ * Shown when the world has no projects at all. A full page with a way forward, not a hidden
+ * feature — someone who followed the roadmap link wants to know what would fill it.
+ */
+private fun FlowContent.roadmapEmptyState(worldId: Int) {
+    emptyState(
+        heading = "Nothing to sequence yet",
+        body = "The roadmap draws itself from your projects' resources: when one project's " +
+            "requirement is produced or solved by another, an edge appears here and the order " +
+            "follows. Define some resources to see it fill in.",
+    ) {
+        a(classes = "btn btn--primary") {
+            href = "/worlds/$worldId/projects"
+            +"Back to projects"
+        }
+    }
+}
+
+private fun FlowContent.roadmapTable(roadmap: Roadmap) {
+    val blockingByConsumer = roadmap.edges.filter { it.isBlocking }.groupBy { it.fromNodeId }
+    val consumersByProducer = roadmap.edges.groupBy { it.toNodeId }
+
+    // Depth first — that is the sequence. Blocked projects sink within their layer, and
+    // names break the remaining ties so the order is stable between renders.
+    val rows = roadmap.nodes.sortedWith(
+        compareBy<RoadmapNode> { it.layer }
+            .thenBy { it.isBlocked }
+            .thenBy { it.projectName }
+    )
+
+    div("roadmap-table-wrap") {
+        table(classes = "data-table roadmap-table") {
+            id = "roadmap-table"
+            thead {
+                tr {
+                    th { +"Layer" }
+                    th { +"Project" }
+                    th { +"State" }
+                    th { +"Tasks" }
+                    th { +"Blocked by" }
+                    th { +"Blocks" }
+                }
+            }
+            tbody {
+                rows.forEach { node ->
+                    tr {
+                        td {
+                            attributes["data-label"] = "Layer"
+                            span("roadmap-layer") { +node.layer.toString() }
+                        }
+                        td {
+                            attributes["data-label"] = "Project"
+                            a(classes = "roadmap-project-link") {
+                                href = "/worlds/${roadmap.worldId}/projects/${node.projectId}"
+                                +node.projectName
+                            }
+                        }
+                        td {
+                            attributes["data-label"] = "State"
+                            projectStateBadge(node.projectId, node.state)
+                        }
+                        td {
+                            attributes["data-label"] = "Tasks"
+                            if (node.tasksTotal == 0) {
+                                span("roadmap-muted") { +"—" }
+                            } else {
+                                +"${node.tasksCompleted} / ${node.tasksTotal}"
+                            }
+                        }
+                        td("roadmap-cell--blocked") {
+                            attributes["data-label"] = "Blocked by"
+                            blockedByCell(roadmap.worldId, blockingByConsumer[node.projectId].orEmpty())
+                        }
+                        td {
+                            attributes["data-label"] = "Blocks"
+                            blocksCell(roadmap.worldId, consumersByProducer[node.projectId].orEmpty())
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Names the project *and* the resource, per the IA: "Iron Farm — Iron Ingot". Knowing which
+ * project blocks you is only half an answer; the other half is what you are waiting for.
+ * A manual sequencing edge has no resource, so it names the project alone.
+ */
+private fun FlowContent.blockedByCell(worldId: Int, edges: List<RoadmapEdge>) {
+    if (edges.isEmpty()) {
+        span("roadmap-muted") { +"—" }
+        return
+    }
+    div("roadmap-edge-list") {
+        edges
+            .sortedWith(compareBy({ it.toNodeName }, { it.itemName ?: "" }))
+            .forEach { edge ->
+                div("roadmap-edge") {
+                    a(classes = "roadmap-project-link") {
+                        href = "/worlds/$worldId/projects/${edge.toNodeId}"
+                        +edge.toNodeName
+                    }
+                    edge.itemName?.let { item ->
+                        span("roadmap-edge__item") { +" — $item" }
+                    }
+                }
+            }
+    }
+}
+
+/** The other direction: who is waiting on this project. Names only — the detail is on their row. */
+private fun FlowContent.blocksCell(worldId: Int, edges: List<RoadmapEdge>) {
+    val consumers = edges
+        .distinctBy { it.fromNodeId }
+        .sortedBy { it.fromNodeName }
+    if (consumers.isEmpty()) {
+        span("roadmap-muted") { +"—" }
+        return
+    }
+    div("roadmap-edge-list") {
+        consumers.forEach { edge ->
+            div("roadmap-edge") {
+                a(classes = "roadmap-project-link") {
+                    href = "/worlds/$worldId/projects/${edge.fromNodeId}"
+                    +edge.fromNodeName
+                }
+            }
+        }
+    }
+}

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-list.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-list.css
@@ -12,6 +12,20 @@
     margin-bottom: var(--space-5);
 }
 
+/* Roadmap entry point — understated by design (progressive disclosure). */
+.projects-toolbar__roadmap-link {
+    margin-right: auto;
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    text-decoration: none;
+}
+
+.projects-toolbar__roadmap-link:hover {
+    color: var(--accent);
+    text-decoration: underline;
+}
+
 /* --- Card list --- */
 
 .project-card-list {

--- a/webapp/mc-web/src/main/resources/static/styles/pages/roadmap.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/roadmap.css
@@ -1,0 +1,108 @@
+/* ==========================================================================
+   WORLD ROADMAP (MCO-288)
+   Projects as rows, ordered by dependency depth. The layered graph is the
+   follow-up; this table is the form that survives hundreds of rows and mobile.
+   ========================================================================== */
+
+.roadmap-title {
+    margin-bottom: var(--space-5);
+}
+
+.roadmap-title__name {
+    font-family: var(--font-ui);
+    font-size: var(--text-xl);
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+}
+
+.roadmap-title__meta {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    margin-top: var(--space-1);
+}
+
+/* The table can outgrow the viewport sideways; it scrolls in its own box rather
+   than making the page scroll horizontally. */
+.roadmap-table-wrap {
+    overflow-x: auto;
+}
+
+.roadmap-table {
+    min-width: 720px;
+}
+
+.roadmap-layer {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 24px;
+    height: 24px;
+    padding: 0 var(--space-2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-raised);
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+.roadmap-project-link {
+    color: var(--text-primary);
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.roadmap-project-link:hover {
+    color: var(--accent);
+    text-decoration: underline;
+}
+
+.roadmap-edge-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.roadmap-edge {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+}
+
+/* The resource is the actionable half of "blocked by" — present, but subordinate
+   to the project name it hangs off. */
+.roadmap-edge__item {
+    color: var(--text-muted);
+    font-size: var(--text-xs);
+}
+
+.roadmap-cell--blocked .roadmap-project-link {
+    color: var(--red);
+}
+
+.roadmap-muted {
+    color: var(--text-muted);
+}
+
+@media (max-width: 768px) {
+    /* data-table collapses rows into stacked cards below this width. A min-width and a
+       scroll box would fight that — the cards would be 720px wide inside a 375px viewport
+       and every value would sit off-screen. Hand the layout back to the component. */
+    .roadmap-table-wrap {
+        overflow-x: visible;
+    }
+
+    .roadmap-table {
+        min-width: 0;
+    }
+
+    /* Stacked cards put the label left and the value right; an edge list of several
+       projects reads better stacked under its label than squeezed into the right half. */
+    .roadmap-edge-list {
+        align-items: flex-end;
+        text-align: right;
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/world/roadmap/GetWorldRoadMapStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/world/roadmap/GetWorldRoadMapStepTest.kt
@@ -353,5 +353,184 @@ class GetWorldRoadMapStepTest : WithUser() {
             }
         ).process(Unit)
     }
-}
 
+    // -------------------------------------------------------------------------
+    // Derived edges (MCO-288): the roadmap reads resource relationships, not just
+    // the manual project_dependencies table.
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `an item-level solved-by link is a roadmap edge naming the resource`(): Unit = runBlocking {
+        val worldId = createTestWorld("Solved-by World")
+        val consumer = createTestProject(worldId, "Beacon", ProjectType.BUILDING, ProjectStage.PLANNING)
+        val producer = createTestProject(worldId, "Iron Farm", ProjectType.FARMING, ProjectStage.BUILDING)
+        val requirementId = createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot", 32)
+        solveRequirementBy(requirementId, producer)
+
+        val roadmap = (GetWorldRoadMapStep(worldId).process(Unit) as Result.Success).value
+
+        val edge = roadmap.edges.single()
+        assertEquals(consumer, edge.fromNodeId)
+        assertEquals(producer, edge.toNodeId)
+        assertEquals("Iron Ingot", edge.itemName, "the blocked-by cell needs the resource, not just the project")
+        assertTrue(edge.isBlocking, "the producer is not DONE")
+        assertEquals(1, roadmap.nodes.single { it.projectId == consumer }.layer)
+        assertTrue(roadmap.nodes.single { it.projectId == consumer }.isBlocked)
+
+        deleteTestWorld(worldId)
+    }
+
+    @Test
+    fun `a project that produces what another needs is an edge even with nothing declared`(): Unit = runBlocking {
+        // Nobody set solved_by_project_id and there is no project_dependencies row: the farm
+        // simply produces an item the other project requires (MCO-287).
+        val worldId = createTestWorld("Farm Supply World")
+        val consumer = createTestProject(worldId, "Beacon", ProjectType.BUILDING, ProjectStage.PLANNING)
+        val farm = createTestProject(worldId, "Iron Farm", ProjectType.FARMING, ProjectStage.BUILDING)
+        createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot", 32)
+        createProduction(farm, "minecraft:iron_ingot", "Iron Ingot")
+
+        val roadmap = (GetWorldRoadMapStep(worldId).process(Unit) as Result.Success).value
+
+        val edge = roadmap.edges.single()
+        assertEquals(farm, edge.toNodeId)
+        assertEquals("Iron Ingot", edge.itemName)
+        assertTrue(edge.isBlocking, "a farm that is not running yet still blocks")
+
+        deleteTestWorld(worldId)
+    }
+
+    @Test
+    fun `an operational farm supplies without blocking`(): Unit = runBlocking {
+        val worldId = createTestWorld("Operational Farm World")
+        val consumer = createTestProject(worldId, "Beacon", ProjectType.BUILDING, ProjectStage.PLANNING)
+        val farm = createTestProject(worldId, "Iron Farm", ProjectType.FARMING, ProjectStage.COMPLETED)
+        createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot", 32)
+        createProduction(farm, "minecraft:iron_ingot", "Iron Ingot")
+
+        val roadmap = (GetWorldRoadMapStep(worldId).process(Unit) as Result.Success).value
+
+        assertFalse(roadmap.edges.single().isBlocking, "DONE means producing (MCO-287)")
+        assertFalse(roadmap.nodes.single { it.projectId == consumer }.isBlocked)
+
+        deleteTestWorld(worldId)
+    }
+
+    @Test
+    fun `a requirement solved by the same farm produces one edge, not two`(): Unit = runBlocking {
+        val worldId = createTestWorld("Dedupe World")
+        val consumer = createTestProject(worldId, "Beacon", ProjectType.BUILDING, ProjectStage.PLANNING)
+        val farm = createTestProject(worldId, "Iron Farm", ProjectType.FARMING, ProjectStage.BUILDING)
+        val requirementId = createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot", 32)
+        solveRequirementBy(requirementId, farm)
+        createProduction(farm, "minecraft:iron_ingot", "Iron Ingot")
+
+        val roadmap = (GetWorldRoadMapStep(worldId).process(Unit) as Result.Success).value
+
+        assertEquals(1, roadmap.edges.size, "declared and derived describe the same relationship")
+
+        deleteTestWorld(worldId)
+    }
+
+    @Test
+    fun `an ignored requirement is not demand`(): Unit = runBlocking {
+        val worldId = createTestWorld("Ignored Requirement World")
+        val consumer = createTestProject(worldId, "Beacon", ProjectType.BUILDING, ProjectStage.PLANNING)
+        val farm = createTestProject(worldId, "Iron Farm", ProjectType.FARMING, ProjectStage.BUILDING)
+        val requirementId = createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot", 32)
+        ignoreRequirement(requirementId)
+        createProduction(farm, "minecraft:iron_ingot", "Iron Ingot")
+
+        val roadmap = (GetWorldRoadMapStep(worldId).process(Unit) as Result.Success).value
+
+        assertTrue(roadmap.edges.isEmpty(), "an ignored row (MCO-247) asks for nothing")
+
+        deleteTestWorld(worldId)
+    }
+
+    @Test
+    fun `the roadmap carries the world's real name`(): Unit = runBlocking {
+        val worldId = createTestWorld("Nether Hub Server")
+
+        val roadmap = (GetWorldRoadMapStep(worldId).process(Unit) as Result.Success).value
+
+        assertEquals("Nether Hub Server", roadmap.worldName)
+
+        deleteTestWorld(worldId)
+    }
+
+    @Test
+    fun `task counts distinguish completed from total`(): Unit = runBlocking {
+        val worldId = createTestWorld("Task Count World")
+        val projectId = createTestProject(worldId, "Beacon", ProjectType.BUILDING, ProjectStage.BUILDING)
+        createTask(projectId, "Dig out area", completed = true)
+        createTask(projectId, "Place hoppers", completed = false)
+        createTask(projectId, "Wire redstone", completed = false)
+
+        val roadmap = (GetWorldRoadMapStep(worldId).process(Unit) as Result.Success).value
+
+        val node = roadmap.nodes.single()
+        assertEquals(3, node.tasksTotal)
+        assertEquals(1, node.tasksCompleted)
+
+        deleteTestWorld(worldId)
+    }
+
+    private fun createRequirement(projectId: Int, itemId: String, name: String, required: Int): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                "INSERT INTO resource_gathering (project_id, item_id, name, required) VALUES (?, ?, ?, ?) RETURNING id"
+            ),
+            parameterSetter = { statement, _ ->
+                statement.setInt(1, projectId)
+                statement.setString(2, itemId)
+                statement.setString(3, name)
+                statement.setInt(4, required)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun solveRequirementBy(requirementId: Int, producerId: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.update("UPDATE resource_gathering SET solved_by_project_id = ? WHERE id = ?"),
+            parameterSetter = { statement, _ ->
+                statement.setInt(1, producerId)
+                statement.setInt(2, requirementId)
+            }
+        ).process(Unit)
+    }
+
+    private fun ignoreRequirement(requirementId: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.update("UPDATE resource_gathering SET ignored = TRUE WHERE id = ?"),
+            parameterSetter = { statement, _ -> statement.setInt(1, requirementId) }
+        ).process(Unit)
+    }
+
+    private fun createProduction(projectId: Int, itemId: String, name: String) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                "INSERT INTO project_productions (project_id, item_id, name, rate_per_hour) VALUES (?, ?, ?, 0)"
+            ),
+            parameterSetter = { statement, _ ->
+                statement.setInt(1, projectId)
+                statement.setString(2, itemId)
+                statement.setString(3, name)
+            }
+        ).process(Unit)
+    }
+
+    private fun createTask(projectId: Int, name: String, completed: Boolean) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                "INSERT INTO action_task (project_id, name, completed) VALUES (?, ?, ?)"
+            ),
+            parameterSetter = { statement, _ ->
+                statement.setInt(1, projectId)
+                statement.setString(2, name)
+                statement.setBoolean(3, completed)
+            }
+        ).process(Unit)
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/WorldRoadmapIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/WorldRoadmapIT.kt
@@ -1,0 +1,198 @@
+package app.mcorg.presentation.handler.world
+
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.project.ProjectStage
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.project.commonsteps.UpdateProjectStageStep
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.pipeline.world.roadmap.handleGetWorldRoadmap
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
+import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * `GET /worlds/{worldId}/roadmap` (MCO-288): the derived dependency table, its empty state,
+ * and the membership gate.
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class WorldRoadmapIT : WithUser() {
+
+    @Test
+    fun `the roadmap names the blocking project and the resource it owes`() = testApplication {
+        setupRoutes()
+        val worldId = createWorld("Roadmap IT World")
+        val consumer = createProject(worldId, "Beacon Build")
+        val farm = createProject(worldId, "Iron Farm")
+        createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot")
+        createProduction(farm, "minecraft:iron_ingot", "Iron Ingot")
+
+        val response = client.get("/worlds/$worldId/roadmap") { addAuthCookie(this) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertContains(body, "roadmap-table")
+        assertContains(body, "Beacon Build")
+        assertContains(body, "Iron Farm")
+        // The IA asks the blocked-by cell to name both halves.
+        assertContains(body, "Iron Ingot")
+        assertContains(body, "/worlds/$worldId/projects/$farm")
+
+        deleteWorld(worldId)
+    }
+
+    @Test
+    fun `an operational farm still appears, no longer blocking`() = testApplication {
+        setupRoutes()
+        val worldId = createWorld("Operational Roadmap World")
+        val consumer = createProject(worldId, "Beacon Build")
+        val farm = createProject(worldId, "Iron Farm")
+        createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot")
+        createProduction(farm, "minecraft:iron_ingot", "Iron Ingot")
+        runBlocking { UpdateProjectStageStep(farm).process(ProjectStage.COMPLETED) }
+
+        val body = client.get("/worlds/$worldId/roadmap") { addAuthCookie(this) }.bodyAsText()
+
+        // The relationship is still on the roadmap — it just stopped being a blocker, which
+        // the summary line reports (it only counts blocked projects when there are any).
+        assertContains(body, "Iron Farm")
+        assertContains(body, "2 projects")
+        assertFalse(body.contains("1 blocked"), "an operational farm blocks nobody")
+
+        deleteWorld(worldId)
+    }
+
+    @Test
+    fun `a world with no projects gets the empty state, not a bare table`() = testApplication {
+        setupRoutes()
+        val worldId = createWorld("Empty Roadmap World")
+
+        val response = client.get("/worlds/$worldId/roadmap") { addAuthCookie(this) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertContains(body, "Nothing to sequence yet")
+        assertContains(body, "/worlds/$worldId/projects")
+        assertFalse(body.contains("roadmap-table"), "no table until there is something to sequence")
+
+        deleteWorld(worldId)
+    }
+
+    @Test
+    fun `a non-member cannot read the roadmap`() = testApplication {
+        setupRoutes()
+        val worldId = createWorld("Private Roadmap World")
+        val outsider = createExtraUser("roadmap-outsider")
+
+        val response = client.get("/worlds/$worldId/roadmap") { addAuthCookie(this, outsider) }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+
+        deleteWorld(worldId)
+    }
+
+    @Test
+    fun `unauthenticated requests redirect`() = testApplication {
+        setupRoutes()
+        val worldId = createWorld("Anon Roadmap World")
+        val unauth = createClient { followRedirects = false }
+
+        val response = unauth.get("/worlds/$worldId/roadmap")
+
+        assertEquals(HttpStatusCode.Found, response.status)
+
+        deleteWorld(worldId)
+    }
+
+    // ---- routing — mirrors WorldHandler ------------------------------------------
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
+                install(UpdateActiveWorldPlugin)
+                get("/roadmap") { call.handleGetWorldRoadmap() }
+            }
+        }
+    }
+
+    // ---- fixtures ------------------------------------------------------------------
+
+    private fun createWorld(name: String): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(name = name, description = "test", version = MinecraftVersion.fromString("1.20.1"))
+        )
+        (result as Result.Success).value
+    }
+
+    private fun deleteWorld(worldId: Int) = runBlocking {
+        DatabaseSteps.update<Int>(
+            SafeSQL.delete("DELETE FROM world WHERE id = ?"),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) }
+        ).process(worldId)
+    }
+
+    private fun createProject(worldId: Int, name: String): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, location_x, location_y, location_z, location_dimension) " +
+                    "VALUES (?, ?, '', 'BUILDING', 'PLANNING', 0, 0, 0, 'OVERWORLD') RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, name)
+                stmt.setInt(2, worldId)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun createRequirement(projectId: Int, itemId: String, name: String) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                "INSERT INTO resource_gathering (project_id, item_id, name, required) VALUES (?, ?, ?, 32)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+                stmt.setString(3, name)
+            }
+        ).process(Unit)
+    }
+
+    private fun createProduction(projectId: Int, itemId: String, name: String) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                "INSERT INTO project_productions (project_id, item_id, name, rate_per_hour) VALUES (?, ?, ?, 0)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+                stmt.setString(3, name)
+            }
+        ).process(Unit)
+    }
+}


### PR DESCRIPTION
The `Roadmap` model and `GetWorldRoadMapStep` have been in the tree fully implemented, tested, and referenced only by tests. Shipping them needed more than a route.

## The step read the wrong half of the system

`GetWorldRoadMapStep` derived everything from `project_dependencies` — the manual project→project table that nothing writes (`ProjectDependencyItemPlugin` is mounted nowhere). Meanwhile `GetProjectEdgesStep`, live behind the Field Log, already unions the **derived** item-level edges (`resource_gathering.solved_by_project_id`) with the manual ones. Under the MCO-287 anchor decision — item-level edges are the atomic truth, the roadmap is derived — the roadmap has to read that union. As it stood, the page would have rendered an empty table for every real world.

Three more staleness bugs fixed in passing:

| | |
|---|---|
| `worldName` | was the placeholder `"World {id}"`, never the world's name |
| `tasksCompleted` | `COUNT(CASE WHEN completed THEN 1 ELSE 0 END)` counts both branches (`0` isn't NULL), so it always equalled `tasksTotal` |
| blocked detection | used `stage != COMPLETED`; everything else, including `ProjectResourceEdge.isBlocking`, moved to `state != DONE` long ago |

## Farm supply is a roadmap edge

New `GetFarmSupplyEdgesStep`: a project needing an item another project *produces* depends on it, even though nobody declared the link. MCO-299's notice already promises exactly this on the plan page — a roadmap without these edges would contradict the page the user just came from. Blocking falls out of the producer's state, no special case: an operational farm supplies now and blocks nobody; one still being built blocks its consumers. Matching is on declared requirements, same granularity as `solved_by_project_id`, so it stays one query rather than one plan derivation per project.

## The page

The IA's table form: rows ordered by dependency depth, **Blocked by** naming both the project and the resource it owes, an understated "View roadmap →" in the Field Log toolbar rather than a nav item, and a full-page empty state with a way back. Nothing on it is editable — the roadmap is derived, never curated.

## Deferred

The manual dependency editor is **MCO-302**, split out so this table could ship and get looked at first. That is also what finally gives `project_dependencies` a writer.

## Tests

- `GetWorldRoadMapStepTest` +7 — item-level edges carrying the resource name, farm supply blocking and not-blocking, no double edge when both sources describe the same relationship, ignored requirements aren't demand, real world name, task counts.
- `WorldRoadmapIT` (5) — the route, the blocked-by cell naming both halves, the empty state, non-member 403, unauthenticated redirect.

Full suite green: 393 tests.

## Verified in the app

Both farm states (operational → no blocker, "2 projects · 2 layers deep"; building → "1 blocked" and **Iron Farm — Iron Ingot** in the blocked-by cell), desktop and 375. Fixed a mobile bug found doing it: my `min-width` fought `data-table`'s stacked-card mode and pushed every value off-screen.

**Pre-existing, not from this PR:** the mobile app header renders the world name overlapping itself — visible on the project list too. Worth a line in the UI/UX pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
