### PR TITLE
MCO-306: route idea import through the review screen

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetSelectWorldForIdeaImportFragment.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetSelectWorldForIdeaImportFragment.kt
@@ -34,11 +34,11 @@ suspend fun ApplicationCall.handleGetSelectWorldForIdeaImportFragment() {
                 id = "import-idea-selector"
                 name = "worldId"
 
-                hxPost(Link.Ideas.single(ideaId) + "/import")
-                hxTarget("#import-idea-selector")
-                hxSwap("outerHTML")
-                hxTrigger("change")
-                hxInclude("#import-idea-selector")
+                // Picking a world used to import immediately. It now opens the review
+                // screen (MCO-306) — a plain navigation, so the page is reloadable and the
+                // import only happens when the user says so there.
+                attributes["onchange"] =
+                    "if (this.value) window.location.assign('${Link.Ideas.single(ideaId)}/import/review?worldId=' + encodeURIComponent(this.value))"
 
                 option {
                     value = ""

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -18,6 +18,14 @@ import app.mcorg.pipeline.failure.ValidationFailure
 import app.mcorg.pipeline.project.resources.GetItemsInWorldVersionStep
 import app.mcorg.presentation.handler.defaultHandleError
 import app.mcorg.presentation.handler.handlePipeline
+import io.ktor.server.response.respond
+import io.ktor.http.Parameters
+import io.ktor.http.HttpStatusCode
+import app.mcorg.presentation.utils.getWorldName
+import app.mcorg.presentation.utils.respondHtml
+import app.mcorg.presentation.templated.dsl.pages.importReviewPage
+import app.mcorg.pipeline.world.ValidateWorldMemberRole
+import app.mcorg.domain.model.user.Role
 import app.mcorg.presentation.templated.dsl.Link
 import app.mcorg.presentation.utils.clientRedirect
 import app.mcorg.presentation.utils.getIdeaId
@@ -36,30 +44,156 @@ data class IdeaForImport(
     val production: Map<Item, Int>
 )
 
+/**
+ * Step one of an idea import (MCO-306): show what the idea would create, before creating it.
+ *
+ * This matters more here than for a schematic. A schematic can be edited in Litematica and
+ * re-uploaded; an idea is someone else's list, and this screen is the only place to say
+ * "not that part" before it becomes a hundred resource rows.
+ *
+ * A GET, unlike the schematic flow's review — the material list comes from the database, so
+ * the page is reloadable and shareable rather than tied to one upload.
+ */
+suspend fun ApplicationCall.handleReviewIdeaImport() {
+    val ideaId = this.getIdeaId()
+    val user = this.getUser()
+
+    val worldId = request.queryParameters["worldId"]?.toIntOrNull()
+        ?: return defaultHandleError(
+            AppFailure.customValidationError("worldId", "Pick a world to import into")
+        )
+
+    val taskId = request.queryParameters["forTask"]?.toIntOrNull()
+    val items = GetItemsInWorldVersionStep.process(worldId).getOrNull() ?: emptyList()
+
+    handlePipeline(
+        onSuccess = { idea: IdeaForImport ->
+            respondHtml(
+                importReviewPage(
+                    user = user,
+                    worldId = worldId,
+                    worldName = getWorldName(worldId),
+                    projectName = idea.name,
+                    requirements = idea.requirements,
+                    action = Link.Ideas.single(ideaId) + "/import",
+                    hiddenFields = buildMap {
+                        put("worldId", worldId.toString())
+                        taskId?.let { put("forTask", it.toString()) }
+                    },
+                )
+            )
+        }
+    ) {
+        ValidateWorldMemberRole<Pair<Int, Int>>(user, Role.ADMIN, worldId).run(worldId to ideaId)
+        ValidateVersionRangeStep.run(worldId to ideaId)
+        val ideaData = GetIdeaForImportStep.run(ideaId)
+        ValidateItemIdsStep(items).run(ideaData)
+    }
+}
+
+/**
+ * Step two: create the project from the **reviewed** requirements.
+ *
+ * Only the requirements are reviewed. An idea's productions describe what the farm puts out
+ * (MCO-287's supply model) — they are not work you are agreeing to do, so they are not the
+ * user's to exclude here and carry through untouched, along with the idea link, the starter
+ * tasks and any `forTask` dependency.
+ */
 suspend fun ApplicationCall.handleImportIdea() {
     val ideaId = this.getIdeaId()
     val user = this.getUser()
     val bus = this.eventBus
 
-    val worldId = (this.receiveParameters()["worldId"] ?: parameters["worldId"])?.toIntOrNull()
+    val submitted = this.receiveParameters()
+    val worldId = (submitted["worldId"] ?: parameters["worldId"])?.toIntOrNull()
         ?: return run {
             defaultHandleError(AppFailure.customValidationError("worldId", "Invalid or missing worldId parameter"))
         }
 
-    val taskId = parameters["forTask"]?.toIntOrNull()
+    val taskId = (submitted["forTask"] ?: parameters["forTask"])?.toIntOrNull()
 
     val items = GetItemsInWorldVersionStep.process(worldId).getOrNull() ?: emptyList()
 
     handlePipeline(
-        onSuccess = { clientRedirect(Link.Worlds.world(worldId).project(it).to) }
+        onSuccess = { projectId: Int ->
+            val target = Link.Worlds.world(worldId).project(projectId).to
+            // The review page submits as a plain form, so a browser needs a real redirect;
+            // an HX-Redirect header would be silently ignored and leave a blank page.
+            if (request.headers["HX-Request"] == "true") {
+                clientRedirect(target)
+            } else {
+                response.headers.append("Location", target)
+                respond(HttpStatusCode.SeeOther, "")
+            }
+        }
     ) {
+        ValidateWorldMemberRole<Pair<Int, Int>>(user, Role.ADMIN, worldId).run(worldId to ideaId)
         ValidateVersionRangeStep.run(worldId to ideaId)
         val ideaData = GetIdeaForImportStep.run(ideaId)
         val validatedIdea = ValidateItemIdsStep(items).run(ideaData)
-        val projectId = CreateProjectFromIdeaStep(worldId, taskId).run(validatedIdea)
+        val reviewedIdea = ApplyReviewedRequirementsStep(submitted, items).run(validatedIdea)
+        val projectId = CreateProjectFromIdeaStep(worldId, taskId).run(reviewedIdea)
         CacheManager.onProjectCreated(worldId, projectId)
-        bus.publish(IdeaImported(worldId, user.id, Instant.now(), ideaId, validatedIdea.name))
+        bus.publish(IdeaImported(worldId, user.id, Instant.now(), ideaId, reviewedIdea.name))
         projectId
+    }
+}
+
+/**
+ * Replaces an idea's requirements with the ones the review page sent back.
+ *
+ * Rows arrive as `qty[<itemId>]=<amount>`; excluded rows are simply absent. Ids are checked
+ * against the world's catalog rather than against the idea, so a submission cannot smuggle
+ * in an item the idea never listed.
+ *
+ * There is deliberately no "not reviewed, use the idea's list" fallback. A form with every
+ * row unchecked and a bare direct post are byte-identical, so a fallback would silently
+ * import everything at exactly the moment the user asked for nothing. Import goes through
+ * the review screen; a submission with no rows is refused like any other empty one.
+ */
+internal data class ApplyReviewedRequirementsStep(
+    val submitted: Parameters,
+    val availableItems: List<Item>,
+) : Step<IdeaForImport, AppFailure, IdeaForImport> {
+
+    private val quantityParameter = Regex("""^qty\[(.+)]$""")
+
+    override suspend fun process(input: IdeaForImport): Result<AppFailure, IdeaForImport> {
+        val submittedRows = submitted.entries()
+            .mapNotNull { entry ->
+                val itemId = quantityParameter.find(entry.key)?.groupValues?.get(1) ?: return@mapNotNull null
+                itemId to entry.value.firstOrNull()
+            }
+
+        val byId = availableItems.associateBy { it.id }
+        val errors = mutableListOf<ValidationFailure>()
+        val requirements = mutableMapOf<Item, Int>()
+
+        submittedRows.forEach { (itemId, rawAmount) ->
+            val item = byId[itemId]
+            if (item == null) {
+                errors.add(ValidationFailure.CustomValidation("materials", "Unknown item: $itemId"))
+                return@forEach
+            }
+            val amount = rawAmount?.toIntOrNull()
+            if (amount == null || amount <= 0) {
+                errors.add(
+                    ValidationFailure.CustomValidation("materials", "${item.name} needs a positive amount")
+                )
+                return@forEach
+            }
+            requirements[item] = amount
+        }
+
+        if (errors.isNotEmpty()) return Result.failure(AppFailure.ValidationError(errors))
+        if (requirements.isEmpty()) {
+            return Result.failure(
+                AppFailure.customValidationError("materials", "Keep at least one material to import")
+            )
+        }
+
+        val name = submitted["name"]?.trim()?.takeIf { it.isNotBlank() }?.take(100) ?: input.name
+        return Result.success(input.copy(name = name, requirements = requirements))
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/IdeaHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/IdeaHandler.kt
@@ -23,6 +23,7 @@ import app.mcorg.pipeline.idea.single.handleFavouriteIdea
 import app.mcorg.pipeline.idea.single.handleGetIdea
 import app.mcorg.pipeline.project.handleGetSelectWorldForIdeaImportFragment
 import app.mcorg.pipeline.project.handleImportIdea
+import app.mcorg.pipeline.project.handleReviewIdeaImport
 import app.mcorg.presentation.plugins.IdeaCommentParamPlugin
 import app.mcorg.presentation.plugins.IdeaCreatorPlugin
 import app.mcorg.presentation.plugins.IdeaParamPlugin
@@ -108,6 +109,9 @@ class IdeaHandler {
                 route("/import") {
                     get("/select") {
                         call.handleGetSelectWorldForIdeaImportFragment()
+                    }
+                    get("/review") {
+                        call.handleReviewIdeaImport()
                     }
                     post {
                         call.handleImportIdea()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -36,6 +36,10 @@ import kotlinx.html.tr
  * a hidden quantity beside it. An unchecked box is simply not submitted, so excluding is
  * exclusion with no server-side concept behind it. Nothing is persisted until Create.
  *
+ * Shared by both import doors (MCO-306): the schematic upload posts its parsed list here,
+ * and an idea import arrives with the idea's requirements. [action] and [hiddenFields] are
+ * the only difference — what the screen *does* is identical either way.
+ *
  * Substitution (MCO-304) and the unobtainable/expensive warning strip (MCO-305) land on
  * this same screen.
  */
@@ -45,6 +49,8 @@ fun importReviewPage(
     worldName: String,
     projectName: String,
     requirements: Map<Item, Int>,
+    action: String = "/worlds/$worldId/projects/from-schematic",
+    hiddenFields: Map<String, String> = emptyMap(),
 ): String = pageShell(
     pageTitle = "Seam — review import",
     user = user,
@@ -76,7 +82,14 @@ fun importReviewPage(
             form(classes = "import-review__form") {
                 id = "import-review-form"
                 method = kotlinx.html.FormMethod.post
-                action = "/worlds/$worldId/projects/from-schematic"
+                this.action = action
+
+                hiddenFields.forEach { (field, fieldValue) ->
+                    hiddenInput {
+                        name = field
+                        value = fieldValue
+                    }
+                }
 
                 div("import-review__name-field") {
                     label {

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
@@ -1,0 +1,303 @@
+package app.mcorg.presentation.handler.project
+
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.user.Role
+import app.mcorg.config.CacheManager
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.project.handleImportIdea
+import app.mcorg.pipeline.project.handleReviewIdeaImport
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.IdeaParamPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Idea import through the review screen (MCO-306): the second import door gets the same
+ * exclude-before-you-commit treatment as the schematic upload.
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class ImportIdeaReviewIT : WithUser() {
+
+    private val version = MinecraftVersion.fromString("1.21.4")
+
+    private var worldId: Int = 0
+    private var ideaId: Int = 0
+
+    @BeforeAll
+    fun setup() {
+        worldId = createWorld("Idea Import IT World")
+        seedItem("minecraft:iron_ingot", "Iron Ingot")
+        seedItem("minecraft:oak_planks", "Oak Planks")
+        seedItem("minecraft:redstone", "Redstone Dust")
+        ideaId = createIdea("Iron Farm Idea")
+        addRequirement(ideaId, "minecraft:iron_ingot", 64)
+        addRequirement(ideaId, "minecraft:oak_planks", 32)
+        addRequirement(ideaId, "minecraft:redstone", 8)
+    }
+
+    // ---- review ------------------------------------------------------------------
+
+    @Test
+    fun `review lists the idea's requirements and creates nothing`() = testApplication {
+        setupRoutes()
+        val before = countProjects()
+
+        val response = client.get("/ideas/$ideaId/import/review?worldId=$worldId") { addAuthCookie(this) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertContains(body, "Review this import")
+        assertContains(body, "Iron Farm Idea")
+        assertContains(body, "qty[minecraft:iron_ingot]")
+        assertContains(body, "qty[minecraft:oak_planks]")
+        // The form has to carry the world through — the action URL has no room for it.
+        assertContains(body, "name=\"worldId\"")
+        assertEquals(before, countProjects(), "review must not create anything")
+    }
+
+    @Test
+    fun `review without a world is refused`() = testApplication {
+        setupRoutes()
+
+        val response = client.get("/ideas/$ideaId/import/review") { addAuthCookie(this) }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+    }
+
+    @Test
+    fun `a non-member cannot review an import into someone else's world`() = testApplication {
+        setupRoutes()
+        val outsider = createExtraUser("idea-review-outsider")
+
+        val response = client.get("/ideas/$ideaId/import/review?worldId=$worldId") {
+            addAuthCookie(this, outsider)
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    // ---- create ------------------------------------------------------------------
+
+    @Test
+    fun `import creates the project from the reviewed rows only`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        val response = client.post("/ideas/$ideaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("worldId=$worldId&name=Reviewed Iron Farm&qty[minecraft:iron_ingot]=64&qty[minecraft:redstone]=8")
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val projectId = response.headers["Location"]!!.substringAfterLast("/").toInt()
+
+        assertEquals("Reviewed Iron Farm", getProjectName(projectId))
+        assertEquals(
+            listOf("minecraft:iron_ingot" to 64, "minecraft:redstone" to 8),
+            readRequirements(projectId),
+            "oak planks were excluded on the review screen",
+        )
+        assertEquals(ideaId, getProjectIdeaId(projectId), "the idea link survives the review step")
+    }
+
+    @Test
+    fun `a submission with no rows is refused rather than importing the whole idea`() = testApplication {
+        setupRoutes()
+        val before = countProjects()
+
+        // Unchecking every row submits no qty[...] fields at all, which is byte-identical to
+        // a bare direct post. Importing the idea's full list here would do the opposite of
+        // what the user just asked for.
+        val response = client.post("/ideas/$ideaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("worldId=$worldId")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertEquals(before, countProjects())
+    }
+
+    @Test
+    fun `an item outside the world's catalog is refused`() = testApplication {
+        setupRoutes()
+        val before = countProjects()
+
+        val response = client.post("/ideas/$ideaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("worldId=$worldId&qty[minecraft:not_a_real_item]=1")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertEquals(before, countProjects())
+    }
+
+    @Test
+    fun `a non-member cannot import into someone else's world`() = testApplication {
+        setupRoutes()
+        val outsider = createExtraUser("idea-import-outsider")
+        val before = countProjects()
+
+        val response = client.post("/ideas/$ideaId/import") {
+            addAuthCookie(this, outsider)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("worldId=$worldId&qty[minecraft:iron_ingot]=1")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertEquals(before, countProjects())
+    }
+
+    @Test
+    fun `unauthenticated review is redirected`() = testApplication {
+        setupRoutes()
+        val unauth = createClient { followRedirects = false }
+
+        val response = unauth.get("/ideas/$ideaId/import/review?worldId=$worldId")
+
+        assertEquals(HttpStatusCode.Found, response.status)
+    }
+
+    // ---- routing — mirrors IdeaHandler --------------------------------------------
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/ideas/{ideaId}") {
+                install(IdeaParamPlugin)
+                route("/import") {
+                    get("/review") { call.handleReviewIdeaImport() }
+                    post { call.handleImportIdea() }
+                }
+            }
+        }
+    }
+
+    // ---- fixtures ------------------------------------------------------------------
+
+    private fun createWorld(name: String): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(name = name, description = "test", version = version)
+        )
+        (result as Result.Success).value
+    }
+
+    private fun seedItem(itemId: String, itemName: String) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert("INSERT INTO minecraft_version (version) VALUES ('1.21.4') ON CONFLICT DO NOTHING"),
+            parameterSetter = { _, _ -> }
+        ).process(Unit)
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                "INSERT INTO minecraft_items (version, item_id, item_name) VALUES ('1.21.4', ?, ?) ON CONFLICT DO NOTHING"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, itemId)
+                stmt.setString(2, itemName)
+            }
+        ).process(Unit)
+    }
+
+    private fun createIdea(name: String): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                """
+                INSERT INTO ideas (name, description, category, author, difficulty, minecraft_version_range, category_data, created_by)
+                VALUES (?, 'test idea', 'FARM', '{"type":"single","name":"tester"}'::jsonb, 'EASY',
+                        '{"type":"app.mcorg.domain.model.minecraft.MinecraftVersionRange.Unbounded"}'::jsonb, '{}'::jsonb, ?)
+                RETURNING id
+                """.trimIndent()
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, name)
+                stmt.setInt(2, user.id)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun addRequirement(ideaId: Int, itemId: String, quantity: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                "INSERT INTO idea_item_requirements (idea_id, item_id, quantity) VALUES (?, ?, ?)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, ideaId)
+                stmt.setString(2, itemId)
+                stmt.setInt(3, quantity)
+            }
+        ).process(Unit)
+    }
+
+    private fun countProjects(): Int = runBlocking {
+        val result = DatabaseSteps.query<Int, Int>(
+            sql = SafeSQL.select("SELECT COUNT(*) FROM projects WHERE world_id = ?"),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) },
+            resultMapper = { rs -> if (rs.next()) rs.getInt(1) else 0 }
+        ).process(worldId)
+        (result as Result.Success).value
+    }
+
+    private fun getProjectName(projectId: Int): String = runBlocking {
+        val result = DatabaseSteps.query<Int, String>(
+            sql = SafeSQL.select("SELECT name FROM projects WHERE id = ?"),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) },
+            resultMapper = { rs -> rs.next(); rs.getString("name") }
+        ).process(projectId)
+        (result as Result.Success).value
+    }
+
+    private fun getProjectIdeaId(projectId: Int): Int = runBlocking {
+        val result = DatabaseSteps.query<Int, Int>(
+            sql = SafeSQL.select("SELECT project_idea_id FROM projects WHERE id = ?"),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) },
+            resultMapper = { rs -> rs.next(); rs.getInt("project_idea_id") }
+        ).process(projectId)
+        (result as Result.Success).value
+    }
+
+    private fun readRequirements(projectId: Int): List<Pair<String, Int>> = runBlocking {
+        val result = DatabaseSteps.query<Int, List<Pair<String, Int>>>(
+            sql = SafeSQL.select(
+                "SELECT item_id, required FROM resource_gathering WHERE project_id = ? ORDER BY item_id"
+            ),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) },
+            resultMapper = { rs ->
+                val rows = mutableListOf<Pair<String, Int>>()
+                while (rs.next()) rows.add(rs.getString("item_id") to rs.getInt("required"))
+                rows
+            }
+        ).process(projectId)
+        (result as Result.Success).value
+    }
+}


### PR DESCRIPTION
Phase 4 of [MCO-289](https://linear.app/evegul/issue/MCO-289) — the second import door. Picking a world on an idea used to import it on the spot; it now opens the review screen, and the import happens when you say so there.

This matters more for ideas than for schematics: a schematic can be edited in Litematica and re-uploaded, but an idea is someone else's list, and the review screen is the only place to change what you are committing to.

## Shape

`GET /ideas/{id}/import/review?worldId=N` renders the shared review page. A **GET**, unlike the schematic flow's review — the list comes from the database rather than an upload, so the page reloads and shares cleanly. The page itself grew an `action` and `hiddenFields`; nothing else about it differs between the two doors.

Only **requirements** are reviewed. An idea's productions describe what the farm puts out (MCO-287's supply model) — not work you are agreeing to do — so they carry through untouched, along with the `project_idea_id` link, the starter tasks, and any `forTask` dependency.

## The fallback that could not exist

I wrote a "no `qty[…]` fields means not reviewed, use the idea's own list" fallback so direct posts would keep working. The exclude-everything test caught why that is wrong: **a form with every row unchecked and a bare direct post are byte-identical**, so the fallback silently imported everything at exactly the moment the user asked for nothing.

Removed. A submission with no rows is refused like any other empty one. Nothing else in the app posts to this endpoint (`forTask` has no producer either), so there is no path that needed the bypass — only one that would have been surprised by it.

## Pre-existing authorization gap, fixed en route

`POST /ideas/{id}/import` never checked world membership. The world dropdown filters to worlds you administer, but the endpoint accepted any `worldId` — so a crafted post could import an idea into a stranger's world. Both endpoints now require world admin, and there are tests for it.

## Tests

`ImportIdeaReviewIT` (8) — the first coverage this flow has ever had: review lists the requirements and creates nothing, review without a world is refused, import builds from the reviewed rows only and keeps the idea link, a no-rows submission is refused rather than importing everything, an item outside the world's catalog is refused, non-member refused on **both** endpoints, unauthenticated redirected.

Full suite green: 407 tests.

## Verified in the app

Idea → pick world → review (40 rows) → uncheck Air → Create → project has the other 39.

That surfaced a real data problem, now written up on [MCO-305](https://linear.app/evegul/issue/MCO-305): the idea's largest row is **`Air (Block)` × 9,389,854** — 90% of the project's total — because idea requirements get no equivalent of the schematic path's non-material filter (`NON_MATERIAL_BLOCKS`). The review screen made it a one-click fix, but nobody should have to notice it in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
