### PR TITLE
MCO-304: import review — batch substitution by family

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
@@ -12,6 +12,7 @@ import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.failure.ValidationFailure
 import app.mcorg.pipeline.project.resources.GetItemsInWorldVersionStep
+import app.mcorg.pipeline.resources.findSubstitutionFamilies
 import app.mcorg.pipeline.world.ValidateWorldMemberRole
 import app.mcorg.presentation.handler.handlePipeline
 import app.mcorg.presentation.templated.dsl.Link
@@ -75,6 +76,7 @@ suspend fun ApplicationCall.handleReviewSchematic() {
                     worldName = getWorldName(worldId),
                     projectName = project.name,
                     requirements = project.requirements,
+                    families = findSubstitutionFamilies(items, project.requirements.map { it.key.id }),
                 )
             )
         }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -16,6 +16,7 @@ import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.failure.ValidationFailure
 import app.mcorg.pipeline.project.resources.GetItemsInWorldVersionStep
+import app.mcorg.pipeline.resources.findSubstitutionFamilies
 import app.mcorg.presentation.handler.defaultHandleError
 import app.mcorg.presentation.handler.handlePipeline
 import io.ktor.server.response.respond
@@ -75,6 +76,7 @@ suspend fun ApplicationCall.handleReviewIdeaImport() {
                     worldName = getWorldName(worldId),
                     projectName = idea.name,
                     requirements = idea.requirements,
+                    families = findSubstitutionFamilies(items, idea.requirements.map { it.key.id }),
                     action = Link.Ideas.single(ideaId) + "/import",
                     hiddenFields = buildMap {
                         put("worldId", worldId.toString())

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/SubstituteInImportReviewPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/SubstituteInImportReviewPipeline.kt
@@ -1,0 +1,133 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.project.resources.GetItemsInWorldVersionStep
+import app.mcorg.pipeline.resources.applySubstitution
+import app.mcorg.pipeline.resources.findSubstitutionFamilies
+import app.mcorg.pipeline.resources.substitutedId
+import app.mcorg.pipeline.resources.variantTokens
+import app.mcorg.presentation.handler.handlePipeline
+import app.mcorg.presentation.templated.dsl.pages.importReviewMaterials
+import app.mcorg.presentation.utils.getWorldId
+import app.mcorg.presentation.utils.respondHtml
+import io.ktor.http.Parameters
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveParameters
+
+/**
+ * MCO-304: batch substitution on the import review screen — all oak to spruce, all blue
+ * terracotta to red, before any of it is a project.
+ *
+ * Nothing is persisted. The review screen holds the whole material list in one form, so a
+ * swap is a round-trip: post the form, rewrite the list, hand back the same section of the
+ * page. That keeps substitution exactly as reversible as every other edit on this screen —
+ * swap back, or hit Cancel — and leaves no draft state to garbage-collect.
+ *
+ * Substitution is demand-side: it edits *what you want*, and the scorer never sees it as
+ * something to optimise. Pins and tag resolutions edit how to get it, and live elsewhere.
+ */
+suspend fun ApplicationCall.handleSubstituteInImportReview() {
+    val worldId = this.getWorldId()
+    val parameters = receiveParameters()
+    val items = GetItemsInWorldVersionStep.process(worldId).getOrNull() ?: emptyList()
+
+    handlePipeline(
+        onSuccess = { reviewed: ReviewedList ->
+            respondHtml(
+                importReviewMaterials(
+                    worldId = worldId,
+                    requirements = reviewed.requirements,
+                    excluded = reviewed.excluded,
+                    families = findSubstitutionFamilies(
+                        catalog = items,
+                        requirements = reviewed.requirements.map { it.key.id },
+                    ),
+                )
+            )
+        }
+    ) {
+        SubstituteReviewedListStep(items).run(parameters)
+    }
+}
+
+/**
+ * The review screen's list as it currently stands: every row, plus which of them the user
+ * has struck. [excluded] is the complement of the checked boxes rather than a stored concept —
+ * the screen has no server-side state and this keeps it that way.
+ */
+data class ReviewedList(
+    val requirements: Map<Item, Int>,
+    val excluded: Set<String>,
+)
+
+/**
+ * Reads the review form, applies one family swap, and hands back the rewritten list.
+ *
+ * The form sends each row twice: `row[<id>]` always, and `qty[<id>]` only while the row is
+ * checked. Reading the list from `row[...]` is what lets an excluded row survive a swap —
+ * from `qty[...]` alone, striking a row and then swapping would delete it for good.
+ *
+ * Ids are re-checked against the world catalog. The review page is a form like any other and
+ * what it sends is not trusted just because the server rendered it a moment ago.
+ */
+internal data class SubstituteReviewedListStep(val availableItems: List<Item>) :
+    Step<Parameters, AppFailure, ReviewedList> {
+
+    private val rowParameter = Regex("""^row\[(.+)]$""")
+    private val quantityParameter = Regex("""^qty\[(.+)]$""")
+
+    override suspend fun process(input: Parameters): Result<AppFailure, ReviewedList> {
+        val fromToken = input["from"]?.takeIf { it.isNotBlank() }
+            ?: return Result.failure(AppFailure.customValidationError("from", "Nothing to swap"))
+        val toToken = input["to[$fromToken]"]?.takeIf { it.isNotBlank() }
+            ?: return Result.failure(AppFailure.customValidationError("to", "Pick what to swap to"))
+
+        val byId = availableItems.associateBy { it.id }
+        val requirements = LinkedHashMap<Item, Int>()
+
+        input.entries().forEach { entry ->
+            val itemId = rowParameter.find(entry.key)?.groupValues?.get(1) ?: return@forEach
+            val item = byId[itemId]
+                ?: return Result.failure(
+                    AppFailure.customValidationError("materials", "Unknown item: $itemId")
+                )
+            val amount = entry.value.firstOrNull()?.toIntOrNull()
+            if (amount == null || amount <= 0) {
+                return Result.failure(
+                    AppFailure.customValidationError("materials", "${item.name} needs a positive amount")
+                )
+            }
+            requirements[item] = amount
+        }
+
+        if (requirements.isEmpty()) {
+            return Result.failure(
+                AppFailure.customValidationError("materials", "There is nothing here to swap")
+            )
+        }
+
+        val checked = input.entries()
+            .mapNotNullTo(mutableSetOf()) { quantityParameter.find(it.key)?.groupValues?.get(1) }
+
+        val tokens = variantTokens(availableItems)
+        val catalogIds = availableItems.mapTo(HashSet()) { it.id }
+        val swapped = applySubstitution(availableItems, requirements, fromToken, toToken, tokens)
+
+        // Exclusions follow their row through the swap: strike the oak stairs, swap oak to
+        // spruce, and it is the spruce stairs that stay struck.
+        //
+        // Where a kept row and a struck row land on the same id, the merged row is kept. The
+        // alternative — striking a row the user had checked, or dropping the struck row's
+        // quantity — either surprises them or loses a number they can never get back; a row
+        // that comes back checked is visible in the total and one click from struck again.
+        val keptTargets = requirements.keys
+            .filter { it.id in checked }
+            .mapTo(mutableSetOf()) { substitutedId(catalogIds, it.id, fromToken, toToken, tokens) }
+        val excluded = swapped.keys.mapNotNullTo(mutableSetOf()) { it.id.takeIf { id -> id !in keptTargets } }
+
+        return Result.success(ReviewedList(swapped, excluded))
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/ItemFamilies.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/ItemFamilies.kt
@@ -1,0 +1,203 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.minecraft.Item
+
+/**
+ * MCO-304: item *families*, for moving a whole material list from oak to spruce or from blue
+ * to red in one action, while the list is still a form.
+ *
+ * The unit of work is a **variant token** — the leading `_`-separated part of an id naming
+ * which member of a family it is: `oak` in `oak_planks`, `light_blue` in
+ * `light_blue_terracotta`. Swapping a family means replacing that token across every row that
+ * carries it.
+ *
+ * **Why not tags.** The issue asked to check `mc-data`'s tag extraction first, and the check
+ * comes back negative for the case it was asked about. A tag is only a graph node when some
+ * recipe or loot source references it as a choice ingredient (see [findVariantCandidates] and
+ * `mc-engine/CLAUDE.md`), and vanilla has no "any terracotta" ingredient anywhere — dyeing
+ * takes plain `minecraft:terracotta` plus a dye. So "all blue terracotta -> red", the issue's
+ * own headline example, is invisible to tags. Doors, per [findVariantCandidates], are missing
+ * for the same reason.
+ *
+ * **What is used instead** is the world's own item catalog, read the same way a tag would have
+ * been ([variantTokens]): ids that agree on everything except a leading token *are* a family,
+ * and vanilla naming says so consistently. Nothing is hardcoded and nothing is invented — no
+ * colour list, no wood list; the catalog for the world's version is the whole input, so a
+ * version that adds a wood species gets it for free.
+ *
+ * This is demand-side. Substitution edits *what you want*; the scorer must never "optimize" it
+ * and nothing here touches how the planner sources anything (MCO-289's standing principle).
+ */
+
+/** A family present in one material list: the rows sharing a variant token, and where they can go. */
+data class SubstitutionFamily(
+    /** The shared token, e.g. `oak` or `light_blue`. */
+    val token: String,
+    /** Human-facing name for the token, e.g. "Dark Oak". */
+    val label: String,
+    /** The ids carrying [token], in the order they were given. */
+    val itemIds: List<String>,
+    /**
+     * Tokens this family can move to *in full* — every row in [itemIds] has a catalog item
+     * under the target token. Partial targets are withheld on purpose: "swap all oak to
+     * crimson" must not quietly leave three oak rows behind because crimson has no sapling.
+     */
+    val targets: List<SubstitutionTarget>,
+)
+
+data class SubstitutionTarget(val token: String, val label: String)
+
+/** A family needs this many members before the catalog is willing to call it one. */
+private const val MIN_FAMILY_SIZE = 4
+
+/**
+ * The families worth offering a batch swap for, given a review screen's rows.
+ *
+ * A family needs at least two rows — one row is MCO-246's per-row variant swap, which already
+ * exists and does not need a batch control — and at least one target it can move to whole.
+ */
+fun findSubstitutionFamilies(
+    catalog: List<Item>,
+    requirements: Collection<String>,
+    tokens: Set<String> = variantTokens(catalog),
+): List<SubstitutionFamily> {
+    if (tokens.isEmpty()) return emptyList()
+
+    val catalogIds = catalog.mapTo(HashSet()) { it.id }
+    val byToken = LinkedHashMap<String, MutableList<Pair<String, String>>>()
+
+    for (itemId in requirements) {
+        val (token, remainder) = splitVariant(itemId, tokens) ?: continue
+        byToken.getOrPut(token) { mutableListOf() }.add(itemId to remainder)
+    }
+
+    return byToken.mapNotNull { (token, rows) ->
+        if (rows.size < 2) return@mapNotNull null
+        val targets = tokens
+            .asSequence()
+            .filter { it != token }
+            .filter { candidate -> rows.all { (_, remainder) -> joinVariant(candidate, remainder) in catalogIds } }
+            .map { SubstitutionTarget(it, labelOf(it)) }
+            .sortedBy { it.label }
+            .toList()
+        if (targets.isEmpty()) null
+        else SubstitutionFamily(token, labelOf(token), rows.map { it.first }, targets)
+    }.sortedBy { it.label }
+}
+
+/**
+ * Rewrites [requirements], moving every row carrying [fromToken] onto [toToken].
+ *
+ * Rows with no catalog item under the target token are left alone rather than dropped —
+ * [findSubstitutionFamilies] only offers targets where every row maps, so this should not
+ * happen from the UI, and silently losing a row is the one outcome nobody could recover from.
+ *
+ * Quantities merge where a swap lands on an id the list already holds (swapping oak to spruce
+ * in a list that already has spruce planks): two rows for one item is not a material list.
+ * A swapped row keeps the position of the row it replaced.
+ */
+fun applySubstitution(
+    catalog: List<Item>,
+    requirements: Map<Item, Int>,
+    fromToken: String,
+    toToken: String,
+    tokens: Set<String> = variantTokens(catalog),
+): Map<Item, Int> {
+    val byId = catalog.associateBy { it.id }
+    val result = LinkedHashMap<Item, Int>()
+
+    for ((item, amount) in requirements) {
+        // Falls back to the row itself when the id is not in the catalog at all — the caller
+        // validates ids, and a lookup miss must not cost the row.
+        val target = byId[substitutedId(byId.keys, item.id, fromToken, toToken, tokens)] ?: item
+        result[target] = (result[target] ?: 0) + amount
+    }
+
+    return result
+}
+
+/**
+ * Where a single id lands under a [fromToken] -> [toToken] swap, or the id itself when the
+ * swap does not touch it or [catalogIds] has no such target.
+ *
+ * Exposed so a caller can follow something *attached* to a row — the review screen tracks
+ * which rows are excluded, and an exclusion has to move with the row it was applied to.
+ */
+fun substitutedId(
+    catalogIds: Set<String>,
+    itemId: String,
+    fromToken: String,
+    toToken: String,
+    tokens: Set<String>,
+): String {
+    val remainder = splitVariant(itemId, tokens)?.takeIf { it.first == fromToken }?.second
+        ?: return itemId
+    return joinVariant(toToken, remainder).takeIf { it in catalogIds } ?: itemId
+}
+
+/**
+ * The variant vocabulary a version's item catalog spells out.
+ *
+ * Ids are keyed by what follows their leading token, and a key reached by [MIN_FAMILY_SIZE] or
+ * more distinct leading tokens is a family: `planks` is reached by oak, spruce, birch...;
+ * `terracotta` by fourteen colours. Those leading tokens are the vocabulary.
+ *
+ * Two-token variants (`dark_oak`, `light_blue`) need a second pass, because a single-token
+ * split puts `dark_oak_planks` under the key `oak_planks` where it has only `pale_oak` for
+ * company. So an id whose single-token key landed in a group too small to be a family gets to
+ * try again one token deeper — which files `dark_oak` under `planks` alongside `oak`, and
+ * `light_blue` under `terracotta` alongside `blue`.
+ *
+ * The retry is conditional for a reason: applied unconditionally it would also file
+ * `white_stained` under `glass_pane`, and then a list holding both `white_wool` and
+ * `white_stained_glass_pane` would see two different "white" families instead of one.
+ */
+fun variantTokens(catalog: List<Item>): Set<String> {
+    val split = catalog.mapNotNull { item ->
+        val name = item.id.substringAfter(':').takeIf { item.id.contains(':') } ?: return@mapNotNull null
+        name.split('_').takeIf { it.size >= 2 }
+    }
+
+    fun key(tokens: List<String>, prefixLength: Int) = tokens.drop(prefixLength).joinToString("_")
+
+    val groups = LinkedHashMap<String, MutableSet<String>>()
+    split.forEach { tokens ->
+        groups.getOrPut(key(tokens, 1)) { linkedSetOf() }.add(tokens.first())
+    }
+
+    // Snapshot before the second pass, which writes into the same map: "was this id already
+    // in a family?" has to be answered against the first pass alone, or the answer would
+    // depend on catalog order.
+    val singleTokenGroupSize = groups.mapValues { (_, prefixes) -> prefixes.size }
+    split.filter { it.size >= 3 }.forEach { tokens ->
+        if ((singleTokenGroupSize[key(tokens, 1)] ?: 0) >= MIN_FAMILY_SIZE) return@forEach
+        groups.getOrPut(key(tokens, 2)) { linkedSetOf() }.add(tokens.take(2).joinToString("_"))
+    }
+
+    return groups.values.filterTo(mutableListOf()) { it.size >= MIN_FAMILY_SIZE }.flatten().toSet()
+}
+
+/**
+ * Splits an id into (variant token, remainder), longest token first.
+ *
+ * Longest-first is what keeps `dark_oak_planks` out of the `oak` family — its tokens are
+ * `[dark, oak, planks]`, so `oak` is not a token-aligned prefix at all — and what picks
+ * `light_blue` over a bare `light` on `light_blue_terracotta`.
+ */
+private fun splitVariant(itemId: String, tokens: Set<String>): Pair<String, String>? {
+    if (!itemId.contains(':')) return null
+    val namespace = itemId.substringBefore(':')
+    val name = itemId.substringAfter(':')
+
+    return tokens
+        .filter { name.startsWith("${it}_") }
+        .maxByOrNull { it.length }
+        ?.let { token -> token to "$namespace:${name.removePrefix("${token}_")}" }
+}
+
+/** [splitVariant]'s inverse — the remainder carries the namespace, so it goes back in front. */
+private fun joinVariant(token: String, remainder: String): String =
+    "${remainder.substringBefore(':')}:${token}_${remainder.substringAfter(':')}"
+
+private fun labelOf(token: String): String =
+    token.split('_').joinToString(" ") { part -> part.replaceFirstChar { it.uppercase() } }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -6,6 +6,7 @@ import app.mcorg.pipeline.project.viewpreference.handleSetViewPreference
 import app.mcorg.pipeline.project.handleCreateProject
 import app.mcorg.pipeline.project.handleCreateProjectFromSchematic
 import app.mcorg.pipeline.project.handleReviewSchematic
+import app.mcorg.pipeline.project.handleSubstituteInImportReview
 import app.mcorg.pipeline.project.handleDeleteProject
 import app.mcorg.pipeline.project.handleGetProject
 import app.mcorg.pipeline.project.handleGetDetailContent
@@ -148,6 +149,14 @@ class WorldHandler {
                     }
                     post("/from-schematic") {
                         call.handleCreateProjectFromSchematic()
+                    }
+                    // Shared by both import doors (MCO-304) — the idea review screen posts
+                    // here too, since a swap only needs the world's item catalog.
+                    route("/import-review/substitute") {
+                        install(WorldAdminPlugin)
+                        post {
+                            call.handleSubstituteInImportReview()
+                        }
                     }
                     post("/farm") {
                         call.handleRecordExistingFarm()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -2,14 +2,21 @@ package app.mcorg.presentation.templated.dsl.pages
 
 import app.mcorg.domain.model.minecraft.Item
 import app.mcorg.domain.model.user.TokenProfile
+import app.mcorg.pipeline.resources.SubstitutionFamily
+import app.mcorg.presentation.hxInclude
+import app.mcorg.presentation.hxPost
+import app.mcorg.presentation.hxSwap
+import app.mcorg.presentation.hxTarget
 import app.mcorg.presentation.templated.dsl.appHeader
 import app.mcorg.presentation.templated.dsl.container
 import app.mcorg.presentation.templated.dsl.pageShell
 import kotlinx.html.ButtonType
+import kotlinx.html.DIV
 import kotlinx.html.FlowContent
 import kotlinx.html.InputType
 import kotlinx.html.a
 import kotlinx.html.button
+import kotlinx.html.classes
 import kotlinx.html.div
 import kotlinx.html.form
 import kotlinx.html.h1
@@ -18,8 +25,11 @@ import kotlinx.html.id
 import kotlinx.html.input
 import kotlinx.html.label
 import kotlinx.html.main
+import kotlinx.html.option
 import kotlinx.html.p
+import kotlinx.html.select
 import kotlinx.html.span
+import kotlinx.html.stream.createHTML
 import kotlinx.html.table
 import kotlinx.html.tbody
 import kotlinx.html.td
@@ -40,8 +50,10 @@ import kotlinx.html.tr
  * and an idea import arrives with the idea's requirements. [action] and [hiddenFields] are
  * the only difference — what the screen *does* is identical either way.
  *
- * Substitution (MCO-304) and the unobtainable/expensive warning strip (MCO-305) land on
- * this same screen.
+ * Batch substitution (MCO-304) rewrites the list in place: the swap controls post the
+ * current form back and swap [importReviewMaterials] for a rewritten copy, so a swap is
+ * just another edit to an unsaved form. The unobtainable/expensive warning strip (MCO-305)
+ * lands on this same screen.
  */
 fun importReviewPage(
     user: TokenProfile,
@@ -51,6 +63,7 @@ fun importReviewPage(
     requirements: Map<Item, Int>,
     action: String = "/worlds/$worldId/projects/from-schematic",
     hiddenFields: Map<String, String> = emptyMap(),
+    families: List<SubstitutionFamily> = emptyList(),
 ): String = pageShell(
     pageTitle = "Seam — review import",
     user = user,
@@ -106,7 +119,7 @@ fun importReviewPage(
                     }
                 }
 
-                materialsTable(requirements)
+                materialsSection(worldId, requirements, excluded = emptySet(), families = families)
 
                 div("import-review__actions") {
                     button(classes = "btn btn--primary") {
@@ -123,7 +136,100 @@ fun importReviewPage(
     }
 }
 
-private fun FlowContent.materialsTable(requirements: Map<Item, Int>) {
+/**
+ * The swappable part of the screen, rendered standalone so a substitution can replace it
+ * (MCO-304). Everything a swap can change lives in here — the controls, the row set and the
+ * quantities; the project name and the hidden carry-through fields sit outside and survive
+ * untouched.
+ */
+fun importReviewMaterials(
+    worldId: Int,
+    requirements: Map<Item, Int>,
+    excluded: Set<String>,
+    families: List<SubstitutionFamily>,
+): String = createHTML().div {
+    materialsSectionBody(worldId, requirements, excluded, families)
+}
+
+private fun FlowContent.materialsSection(
+    worldId: Int,
+    requirements: Map<Item, Int>,
+    excluded: Set<String>,
+    families: List<SubstitutionFamily>,
+) {
+    div {
+        materialsSectionBody(worldId, requirements, excluded, families)
+    }
+}
+
+private fun DIV.materialsSectionBody(
+    worldId: Int,
+    requirements: Map<Item, Int>,
+    excluded: Set<String>,
+    families: List<SubstitutionFamily>,
+) {
+    id = MATERIALS_ID
+    classes = setOf("import-review__materials")
+    substitutionControls(worldId, families)
+    materialsTable(requirements, excluded)
+}
+
+private const val MATERIALS_ID = "import-review-materials"
+
+/**
+ * One control per family found in the list: "all Oak -> [ Spruce ]".
+ *
+ * The swap posts the *whole* form and swaps this section for the rewritten one, which is why
+ * the rows carry a hidden `row[...]` mirror of their quantity — an unchecked checkbox submits
+ * nothing, and a swap must not silently resurrect or delete the rows you struck.
+ *
+ * The target select is named per family (`to[<token>]`) so several controls can coexist in
+ * one form; the button says which family it is via `hx-vals`.
+ */
+private fun FlowContent.substitutionControls(worldId: Int, families: List<SubstitutionFamily>) {
+    if (families.isEmpty()) return
+
+    div("import-review__swaps") {
+        span("section-label") { +"Swap a family" }
+        p("import-review__swaps-lead") {
+            +"Change your mind about a material before it becomes a gathering list. Only targets that can take every row are offered."
+        }
+        families.forEach { family ->
+            div("import-review__swap") {
+                span("import-review__swap-from") {
+                    +"All ${family.label} (${family.itemIds.size} ${if (family.itemIds.size == 1) "row" else "rows"})"
+                }
+                span("import-review__swap-arrow") {
+                    attributes["aria-hidden"] = "true"
+                    +"→"
+                }
+                select("form-control import-review__swap-to") {
+                    id = "swap-to-${family.token}"
+                    name = "to[${family.token}]"
+                    attributes["aria-label"] = "Swap all ${family.label} to"
+                    family.targets.forEach { target ->
+                        option {
+                            value = target.token
+                            +target.label
+                        }
+                    }
+                }
+                button(classes = "btn btn--ghost import-review__swap-apply") {
+                    // Not a submit button — this edits the form, it does not send it.
+                    type = ButtonType.button
+                    hxPost("/worlds/$worldId/projects/import-review/substitute")
+                    hxInclude("#import-review-form")
+                    hxTarget("#$MATERIALS_ID")
+                    hxSwap("outerHTML")
+                    attributes["hx-vals"] = """{"from": "${family.token}"}"""
+                    +"Swap"
+                }
+            }
+        }
+    }
+}
+
+private fun FlowContent.materialsTable(requirements: Map<Item, Int>, excluded: Set<String>) {
     val rows = requirements.entries.sortedWith(
         compareByDescending<Map.Entry<Item, Int>> { it.value }.thenBy { it.key.name }
     )
@@ -156,8 +262,15 @@ private fun FlowContent.materialsTable(requirements: Map<Item, Int>) {
                                 // Unchecked boxes are not submitted — that *is* the exclusion.
                                 name = "qty[${item.id}]"
                                 value = amount.toString()
-                                checked = true
+                                checked = item.id !in excluded
                                 attributes["aria-label"] = "Include ${item.name}"
+                            }
+                            // The row's quantity again, always submitted. Create ignores it;
+                            // a substitution needs it, because the rows you struck are absent
+                            // from `qty[...]` and would otherwise vanish across the swap.
+                            hiddenInput {
+                                name = "row[${item.id}]"
+                                value = amount.toString()
                             }
                         }
                         td {

--- a/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
@@ -44,14 +44,27 @@
     gap: var(--space-4);
 }
 
+/* One grid for the whole block, with the swap rows as `display: contents`, so the selects and
+   buttons line up in real columns — per-row flexbox only aligns within its own row, which
+   leaves the controls stepping raggedly wherever a family name is longer. */
 .import-review__swaps {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2);
+    display: grid;
+    grid-template-columns: max-content max-content minmax(12ch, 20ch) max-content;
+    align-items: center;
+    gap: var(--space-2) var(--space-3);
     padding: var(--space-3) var(--space-4);
     background: var(--bg-raised);
     border: 1px solid var(--border);
     border-radius: var(--radius);
+}
+
+.import-review__swaps > .section-label,
+.import-review__swaps-lead {
+    grid-column: 1 / -1;
+}
+
+.import-review__swap {
+    display: contents;
 }
 
 .import-review__swaps-lead {
@@ -62,18 +75,10 @@
     max-width: 70ch;
 }
 
-.import-review__swap {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: var(--space-2);
-}
-
 .import-review__swap-from {
     font-family: var(--font-ui);
     font-size: var(--text-sm);
     color: var(--text-primary);
-    min-width: 14ch;
 }
 
 .import-review__swap-arrow {
@@ -81,8 +86,7 @@
 }
 
 .import-review__swap-to {
-    width: auto;
-    min-width: 16ch;
+    width: 100%;
 }
 
 .import-review__summary {
@@ -143,13 +147,24 @@
         flex-direction: column;
     }
 
-    /* The swap row is label + select + button; side by side it overflows on a phone. */
+    /* The swap row is label + select + button; side by side it overflows on a phone, so the
+       grid collapses back to stacked blocks. */
+    .import-review__swaps {
+        display: flex;
+        flex-direction: column;
+        /* The grid centres items in their cell; in a column flex that reads as centred text. */
+        align-items: stretch;
+    }
+
     .import-review__swap {
+        display: flex;
         align-items: stretch;
         flex-direction: column;
+        gap: var(--space-2);
     }
 
     .import-review__swap-arrow {
         display: none;
     }
+
 }

--- a/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
@@ -36,6 +36,55 @@
     max-width: 420px;
 }
 
+/* MCO-304 — batch substitution. The swap block sits above the list because it rewrites it;
+   putting it below would read as an action on a decision already made. */
+.import-review__materials {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+}
+
+.import-review__swaps {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+}
+
+.import-review__swaps-lead {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    margin: 0 0 var(--space-2);
+    max-width: 70ch;
+}
+
+.import-review__swap {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+}
+
+.import-review__swap-from {
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+    min-width: 14ch;
+}
+
+.import-review__swap-arrow {
+    color: var(--text-muted);
+}
+
+.import-review__swap-to {
+    width: auto;
+    min-width: 16ch;
+}
+
 .import-review__summary {
     display: flex;
     align-items: baseline;
@@ -92,5 +141,15 @@
 
     .import-review__actions {
         flex-direction: column;
+    }
+
+    /* The swap row is label + select + button; side by side it overflows on a phone. */
+    .import-review__swap {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .import-review__swap-arrow {
+        display: none;
     }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/SubstituteReviewedListStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/SubstituteReviewedListStepTest.kt
@@ -1,0 +1,183 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.failure.AppFailure
+import io.ktor.http.Parameters
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * MCO-304 — reading the review form back, one family swap at a time.
+ */
+class SubstituteReviewedListStepTest {
+
+    private val woods = listOf("oak", "spruce", "birch", "jungle", "acacia")
+
+    private val catalog: List<Item> = buildList {
+        woods.forEach { wood ->
+            listOf("planks", "slab", "stairs").forEach { form ->
+                add(Item("minecraft:${wood}_$form", "${wood.replaceFirstChar { it.uppercase() }} $form"))
+            }
+        }
+        add(Item("minecraft:stone", "Stone"))
+    }
+
+    private val step = SubstituteReviewedListStep(catalog)
+
+    private fun form(vararg pairs: Pair<String, String>) = Parameters.build {
+        pairs.forEach { (key, value) -> append(key, value) }
+    }
+
+    private fun run(params: Parameters) = runBlocking { step.process(params) }
+
+    private fun succeed(params: Parameters): ReviewedList {
+        val result = run(params)
+        assertIs<Result.Success<ReviewedList>>(result, "expected success, got $result")
+        return result.value
+    }
+
+    @Test
+    fun `every row in the family moves and everything else stays`() {
+        val reviewed = succeed(
+            form(
+                "from" to "oak",
+                "to[oak]" to "spruce",
+                "row[minecraft:oak_planks]" to "64",
+                "qty[minecraft:oak_planks]" to "64",
+                "row[minecraft:stone]" to "12",
+                "qty[minecraft:stone]" to "12",
+            )
+        )
+
+        assertEquals(
+            mapOf("minecraft:spruce_planks" to 64, "minecraft:stone" to 12),
+            reviewed.requirements.mapKeys { it.key.id },
+        )
+        assertTrue(reviewed.excluded.isEmpty())
+    }
+
+    @Test
+    fun `a struck row survives the swap and is still struck`() {
+        // No qty[...] for the stairs — that is exactly what an unchecked box submits.
+        val reviewed = succeed(
+            form(
+                "from" to "oak",
+                "to[oak]" to "spruce",
+                "row[minecraft:oak_planks]" to "64",
+                "qty[minecraft:oak_planks]" to "64",
+                "row[minecraft:oak_stairs]" to "8",
+            )
+        )
+
+        assertEquals(
+            mapOf("minecraft:spruce_planks" to 64, "minecraft:spruce_stairs" to 8),
+            reviewed.requirements.mapKeys { it.key.id },
+        )
+        assertEquals(setOf("minecraft:spruce_stairs"), reviewed.excluded)
+    }
+
+    @Test
+    fun `when a kept row and a struck row merge, the merged row is kept`() {
+        // The struck oak planks land on the kept spruce planks. Striking a row the user had
+        // checked would be the surprising outcome; the quantity is visible either way.
+        val reviewed = succeed(
+            form(
+                "from" to "oak",
+                "to[oak]" to "spruce",
+                "row[minecraft:oak_planks]" to "64",
+                "row[minecraft:spruce_planks]" to "10",
+                "qty[minecraft:spruce_planks]" to "10",
+            )
+        )
+
+        assertEquals(mapOf("minecraft:spruce_planks" to 74), reviewed.requirements.mapKeys { it.key.id })
+        assertTrue(reviewed.excluded.isEmpty(), "the merged row stays checked")
+    }
+
+    @Test
+    fun `quantities merge rather than one row overwriting the other`() {
+        val reviewed = succeed(
+            form(
+                "from" to "oak",
+                "to[oak]" to "spruce",
+                "row[minecraft:oak_slab]" to "5",
+                "qty[minecraft:oak_slab]" to "5",
+                "row[minecraft:spruce_slab]" to "3",
+                "qty[minecraft:spruce_slab]" to "3",
+            )
+        )
+
+        assertEquals(8, reviewed.requirements.values.single())
+    }
+
+    @Test
+    fun `a missing target is refused`() {
+        val result = run(form("from" to "oak", "row[minecraft:oak_planks]" to "1"))
+
+        assertIs<Result.Failure<AppFailure>>(result)
+    }
+
+    @Test
+    fun `a missing family is refused`() {
+        val result = run(form("to[oak]" to "spruce", "row[minecraft:oak_planks]" to "1"))
+
+        assertIs<Result.Failure<AppFailure>>(result)
+    }
+
+    @Test
+    fun `an id outside the world catalog is refused rather than passed through`() {
+        val result = run(
+            form(
+                "from" to "oak",
+                "to[oak]" to "spruce",
+                "row[minecraft:not_a_real_item]" to "1",
+            )
+        )
+
+        assertIs<Result.Failure<AppFailure>>(result)
+    }
+
+    @Test
+    fun `a non-positive quantity is refused`() {
+        val result = run(
+            form(
+                "from" to "oak",
+                "to[oak]" to "spruce",
+                "row[minecraft:oak_planks]" to "0",
+            )
+        )
+
+        assertIs<Result.Failure<AppFailure>>(result)
+    }
+
+    @Test
+    fun `a form with no rows at all is refused`() {
+        val result = run(form("from" to "oak", "to[oak]" to "spruce"))
+
+        assertIs<Result.Failure<AppFailure>>(result)
+    }
+
+    @Test
+    fun `swapping to a form the target species lacks keeps the row where it is`() {
+        // Not reachable from the UI — findSubstitutionFamilies withholds partial targets — but
+        // a hand-rolled post must not cost the row.
+        val narrowCatalog = catalog + Item("minecraft:oak_sapling", "Oak Sapling")
+        val reviewed = runBlocking {
+            SubstituteReviewedListStep(narrowCatalog).process(
+                form(
+                    "from" to "oak",
+                    "to[oak]" to "spruce",
+                    "row[minecraft:oak_sapling]" to "4",
+                    "qty[minecraft:oak_sapling]" to "4",
+                )
+            )
+        }
+
+        assertIs<Result.Success<ReviewedList>>(reviewed)
+        assertEquals(mapOf("minecraft:oak_sapling" to 4), reviewed.value.requirements.mapKeys { it.key.id })
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/ItemFamiliesTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/ItemFamiliesTest.kt
@@ -1,0 +1,224 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.minecraft.Item
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * MCO-304 — family detection and batch swapping, against a catalog shaped like the real one.
+ */
+class ItemFamiliesTest {
+
+    private val woods = listOf(
+        "oak", "spruce", "birch", "jungle", "acacia", "mangrove", "cherry",
+        "bamboo", "crimson", "warped", "dark_oak", "pale_oak",
+    )
+    private val colours = listOf(
+        "white", "orange", "magenta", "yellow", "lime", "pink", "gray", "cyan",
+        "purple", "blue", "brown", "green", "red", "black", "light_blue", "light_gray",
+    )
+
+    /** A catalog with the shape that matters: two families, one of them with two-token members. */
+    private val catalog: List<Item> = buildList {
+        woods.forEach { wood ->
+            add(item("${wood}_planks"))
+            add(item("${wood}_slab"))
+            add(item("${wood}_stairs"))
+        }
+        // Not every species has a sapling — crimson and warped grow from fungi.
+        woods.filterNot { it == "crimson" || it == "warped" }.forEach { add(item("${it}_sapling")) }
+        colours.forEach { colour ->
+            add(item("${colour}_terracotta"))
+            add(item("${colour}_wool"))
+            add(item("${colour}_stained_glass_pane"))
+        }
+        add(item("terracotta"))
+        add(item("glass_pane"))
+        add(item("stone"))
+        add(item("cobblestone"))
+    }
+
+    private fun item(name: String) =
+        Item("minecraft:$name", name.split('_').joinToString(" ") { p -> p.replaceFirstChar { it.uppercase() } })
+
+    private fun id(name: String) = "minecraft:$name"
+
+    // ---- vocabulary ----------------------------------------------------------------
+
+    @Test
+    fun `the catalog spells out both families without being told about either`() {
+        val tokens = variantTokens(catalog)
+
+        assertTrue(woods.all { it in tokens }, "every wood species is a token: $tokens")
+        assertTrue(colours.all { it in tokens }, "every dye colour is a token: $tokens")
+    }
+
+    @Test
+    fun `two-token variants are found even though a single-token split hides them`() {
+        // dark_oak_planks keyed on one token lands under `oak_planks`, where its only company
+        // is pale_oak — too small to be a family. The second pass files it under `planks`.
+        val tokens = variantTokens(catalog)
+
+        assertTrue("dark_oak" in tokens)
+        assertTrue("pale_oak" in tokens)
+        assertTrue("light_blue" in tokens)
+        assertTrue("light_gray" in tokens)
+    }
+
+    @Test
+    fun `the second pass does not invent a compound colour token`() {
+        // white_stained_glass_pane already belongs to a full family under `stained_glass_pane`,
+        // so it must not also be filed as `white_stained` under `glass_pane` — that would split
+        // white wool and white panes into two different "white" families.
+        val tokens = variantTokens(catalog)
+
+        assertTrue(colours.none { "${it}_stained" in tokens }, "compound tokens leaked: $tokens")
+    }
+
+    @Test
+    fun `an empty catalog yields no vocabulary rather than an exception`() {
+        assertTrue(variantTokens(emptyList()).isEmpty())
+    }
+
+    // ---- families ------------------------------------------------------------------
+
+    @Test
+    fun `rows sharing a species become one family`() {
+        val families = findSubstitutionFamilies(
+            catalog,
+            listOf(id("oak_planks"), id("oak_stairs"), id("oak_slab"), id("stone")),
+        )
+
+        val oak = families.single()
+        assertEquals("oak", oak.token)
+        assertEquals("Oak", oak.label)
+        assertEquals(listOf(id("oak_planks"), id("oak_stairs"), id("oak_slab")), oak.itemIds)
+        assertTrue(oak.targets.any { it.token == "spruce" })
+    }
+
+    @Test
+    fun `a two-token species reads as itself, not as its second word`() {
+        val families = findSubstitutionFamilies(catalog, listOf(id("dark_oak_planks"), id("dark_oak_slab")))
+
+        assertEquals("dark_oak", families.single().token)
+        assertEquals("Dark Oak", families.single().label)
+    }
+
+    @Test
+    fun `a colour family works even though vanilla has no terracotta tag`() {
+        // The issue's headline example, and the reason this is derived from the catalog rather
+        // than from tags: there is no "any terracotta" ingredient anywhere in vanilla.
+        val families = findSubstitutionFamilies(catalog, listOf(id("blue_terracotta"), id("blue_wool")))
+
+        val blue = families.single()
+        assertEquals("blue", blue.token)
+        assertTrue(blue.targets.any { it.token == "red" })
+    }
+
+    @Test
+    fun `a target that cannot take every row is not offered`() {
+        // Crimson has planks and a slab but no sapling, so "all oak to crimson" would have to
+        // leave a row behind. Spruce takes all three.
+        val families = findSubstitutionFamilies(
+            catalog,
+            listOf(id("oak_planks"), id("oak_slab"), id("oak_sapling")),
+        )
+
+        val targets = families.single().targets.map { it.token }
+        assertTrue("spruce" in targets)
+        assertTrue("crimson" !in targets, "crimson has no sapling: $targets")
+    }
+
+    @Test
+    fun `a single row is not a batch and gets no family`() {
+        assertTrue(findSubstitutionFamilies(catalog, listOf(id("oak_planks"), id("stone"))).isEmpty())
+    }
+
+    @Test
+    fun `a list with nothing in common offers nothing`() {
+        assertTrue(findSubstitutionFamilies(catalog, listOf(id("stone"), id("cobblestone"))).isEmpty())
+    }
+
+    // ---- applying ------------------------------------------------------------------
+
+    @Test
+    fun `swapping rewrites every row in the family and leaves the rest alone`() {
+        val requirements = mapOf(
+            item("oak_planks") to 64,
+            item("oak_stairs") to 12,
+            item("stone") to 100,
+        )
+
+        val swapped = applySubstitution(catalog, requirements, fromToken = "oak", toToken = "spruce")
+
+        assertEquals(
+            mapOf(id("spruce_planks") to 64, id("spruce_stairs") to 12, id("stone") to 100),
+            swapped.mapKeys { it.key.id },
+        )
+    }
+
+    @Test
+    fun `swapping onto an id the list already has merges the two rows`() {
+        val requirements = mapOf(
+            item("oak_planks") to 64,
+            item("spruce_planks") to 10,
+        )
+
+        val swapped = applySubstitution(catalog, requirements, fromToken = "oak", toToken = "spruce")
+
+        assertEquals(mapOf(id("spruce_planks") to 74), swapped.mapKeys { it.key.id })
+    }
+
+    @Test
+    fun `a row with no counterpart under the target is kept, never dropped`() {
+        // Reachable only by a hand-rolled post — the UI does not offer crimson here — but the
+        // total quantity must survive whatever arrives.
+        val requirements = mapOf(item("oak_planks") to 64, item("oak_sapling") to 4)
+
+        val swapped = applySubstitution(catalog, requirements, fromToken = "oak", toToken = "crimson")
+
+        assertEquals(
+            mapOf(id("crimson_planks") to 64, id("oak_sapling") to 4),
+            swapped.mapKeys { it.key.id },
+        )
+        assertEquals(68, swapped.values.sum())
+    }
+
+    @Test
+    fun `a swap the list has nothing to do with changes nothing`() {
+        val requirements = mapOf(item("stone") to 5)
+
+        assertEquals(requirements, applySubstitution(catalog, requirements, "oak", "spruce"))
+    }
+
+    @Test
+    fun `dark oak is not caught by an oak swap`() {
+        val requirements = mapOf(item("oak_planks") to 1, item("dark_oak_planks") to 1)
+
+        val swapped = applySubstitution(catalog, requirements, fromToken = "oak", toToken = "spruce")
+
+        assertEquals(
+            mapOf(id("spruce_planks") to 1, id("dark_oak_planks") to 1),
+            swapped.mapKeys { it.key.id },
+        )
+    }
+
+    @Test
+    fun `light blue is not caught by a blue swap`() {
+        val requirements = mapOf(item("blue_wool") to 1, item("light_blue_wool") to 1)
+
+        val swapped = applySubstitution(catalog, requirements, fromToken = "blue", toToken = "red")
+
+        assertEquals(
+            mapOf(id("red_wool") to 1, id("light_blue_wool") to 1),
+            swapped.mapKeys { it.key.id },
+        )
+    }
+
+    @Test
+    fun `an id with no namespace is ignored rather than mis-split`() {
+        assertNull(findSubstitutionFamilies(catalog, listOf("oak_planks", "oak_slab")).firstOrNull())
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportReviewSubstitutionIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportReviewSubstitutionIT.kt
@@ -1,0 +1,245 @@
+package app.mcorg.presentation.handler.project
+
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.project.handleSubstituteInImportReview
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
+import app.mcorg.presentation.plugins.WorldAdminPlugin
+import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * MCO-304 — batch substitution on the import review screen, end to end: the form goes out,
+ * a rewritten materials section comes back, and nothing is written to the database.
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class ImportReviewSubstitutionIT : WithUser() {
+
+    private var worldId: Int = 0
+
+    private val woods = listOf("oak", "spruce", "birch", "jungle", "acacia")
+
+    @BeforeAll
+    fun setup() {
+        worldId = createWorld()
+        // A catalog wide enough for the vocabulary to recognise a family — the tokens are
+        // derived from the catalog's own shape, so a two-item catalog would find nothing.
+        woods.forEach { wood ->
+            seedItem("minecraft:${wood}_planks", "${wood.replaceFirstChar { it.uppercase() }} Planks")
+            seedItem("minecraft:${wood}_slab", "${wood.replaceFirstChar { it.uppercase() }} Slab")
+            seedItem("minecraft:${wood}_stairs", "${wood.replaceFirstChar { it.uppercase() }} Stairs")
+        }
+        seedItem("minecraft:stone", "Stone")
+    }
+
+    @Test
+    fun `swapping a family rewrites every row and leaves the rest alone`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "from=oak&to[oak]=spruce" +
+                    "&row[minecraft:oak_planks]=64&qty[minecraft:oak_planks]=64" +
+                    "&row[minecraft:oak_stairs]=12&qty[minecraft:oak_stairs]=12" +
+                    "&row[minecraft:stone]=100&qty[minecraft:stone]=100"
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        val body = response.bodyAsText()
+        assertContains(body, "row[minecraft:spruce_planks]")
+        assertContains(body, "row[minecraft:spruce_stairs]")
+        assertContains(body, "row[minecraft:stone]", message = "an unrelated row is untouched")
+        assertFalse(body.contains("minecraft:oak_planks"), "no oak survives the swap")
+        assertFalse(body.contains("minecraft:oak_stairs"), "no oak survives the swap")
+    }
+
+    @Test
+    fun `an excluded row survives the swap and stays excluded`() = testApplication {
+        setupRoutes()
+
+        // oak_stairs is struck — it has a `row[...]` but no `qty[...]`, exactly as the form
+        // sends an unchecked box. It must come back as spruce stairs, still unchecked.
+        val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "from=oak&to[oak]=spruce" +
+                    "&row[minecraft:oak_planks]=64&qty[minecraft:oak_planks]=64" +
+                    "&row[minecraft:oak_stairs]=12"
+            )
+        }
+
+        val body = response.bodyAsText()
+        assertContains(body, "row[minecraft:spruce_stairs]", message = "the struck row is not lost")
+        assertTrue(isChecked(body, "minecraft:spruce_planks"), "the kept row is still kept")
+        assertFalse(isChecked(body, "minecraft:spruce_stairs"), "the struck row is still struck")
+    }
+
+    @Test
+    fun `the swap control comes back describing the list's new state`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "from=oak&to[oak]=spruce" +
+                    "&row[minecraft:oak_planks]=64&qty[minecraft:oak_planks]=64" +
+                    "&row[minecraft:oak_slab]=8&qty[minecraft:oak_slab]=8"
+            )
+        }
+
+        val body = response.bodyAsText()
+        assertContains(body, "import-review-materials", message = "the fragment replaces itself")
+        assertContains(body, "All Spruce (2 rows)", message = "the family is now spruce")
+        assertContains(body, """name="to[spruce]"""")
+    }
+
+    @Test
+    fun `swapping onto an id already in the list merges the two rows`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "from=oak&to[oak]=spruce" +
+                    "&row[minecraft:oak_planks]=64&qty[minecraft:oak_planks]=64" +
+                    "&row[minecraft:spruce_planks]=10&qty[minecraft:spruce_planks]=10" +
+                    "&row[minecraft:oak_slab]=1&qty[minecraft:oak_slab]=1"
+            )
+        }
+
+        val body = response.bodyAsText()
+        assertContains(body, """name="row[minecraft:spruce_planks]" value="74"""")
+    }
+
+    @Test
+    fun `an unknown item id is refused`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("from=oak&to[oak]=spruce&row[minecraft:not_a_real_item]=1")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+    }
+
+    @Test
+    fun `a swap with no target is refused`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("from=oak&row[minecraft:oak_planks]=64&qty[minecraft:oak_planks]=64")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+    }
+
+    @Test
+    fun `a non-member cannot substitute in someone else's world`() = testApplication {
+        setupRoutes()
+        val outsider = createExtraUser("substitute-outsider")
+
+        val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
+            addAuthCookie(this, outsider)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("from=oak&to[oak]=spruce&row[minecraft:oak_planks]=64")
+        }
+
+        assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    /** Reads the rendered include-checkbox for one row back out of the fragment. */
+    private fun isChecked(body: String, itemId: String): Boolean {
+        val rowId = itemId.replace(Regex("[^a-zA-Z0-9]"), "-")
+        val tag = Regex("""<input[^>]*id="include-$rowId"[^>]*>""").find(body)
+        assertNotNull(tag, "no include checkbox rendered for $itemId")
+        return "checked" in tag.value
+    }
+
+    // ---- routing — mirrors WorldHandler ---------------------------------------------
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
+                install(UpdateActiveWorldPlugin)
+                route("/projects") {
+                    route("/import-review/substitute") {
+                        install(WorldAdminPlugin)
+                        post { call.handleSubstituteInImportReview() }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- fixtures --------------------------------------------------------------------
+
+    private fun createWorld(): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(
+                name = "Substitution IT World",
+                description = "test",
+                version = MinecraftVersion.fromString("1.21.4"),
+            )
+        )
+        (result as Result.Success).value
+    }
+
+    private fun seedItem(itemId: String, itemName: String) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert("INSERT INTO minecraft_version (version) VALUES ('1.21.4') ON CONFLICT DO NOTHING"),
+            parameterSetter = { _, _ -> }
+        ).process(Unit)
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                "INSERT INTO minecraft_items (version, item_id, item_name) VALUES ('1.21.4', ?, ?) ON CONFLICT DO NOTHING"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, itemId)
+                stmt.setString(2, itemName)
+            }
+        ).process(Unit)
+    }
+}


### PR DESCRIPTION
Phase 2 of MCO-289, on top of phase 1's review screen. Closes MCO-304.

Swap a whole family before the list becomes a project — **all oak → spruce**, **all blue terracotta → red**. Generalizes MCO-246's per-row variant swap and moves it to where it is cheap: nothing is persisted, so a swap is just another edit to an unsaved form. Both import doors get it (schematic upload and idea import).

## Why not tags

The issue asked to check `mc-data`'s tag extraction before inventing a family notion. **The check comes back negative for the case it was asked about.** A tag is only a graph node when some recipe or loot source references it as a *choice* ingredient (`VariantDiscovery`'s existing caveat, `mc-engine/CLAUDE.md`), and vanilla has no "any terracotta" ingredient anywhere — dyeing takes plain `minecraft:terracotta` plus a dye. So "all blue terracotta → red", the issue's own headline example, is invisible to tags. Doors are missing for the same reason.

Families are derived from the **world's item catalog** instead, read the way a tag would have been: ids that agree on everything except a leading token *are* a family, and vanilla naming says so consistently. Nothing is hardcoded — no colour list, no wood list — so a version that adds a wood species gets it for free.

The one non-obvious part is the two-token variants. A single-token split files `dark_oak_planks` under the key `oak_planks`, where its only company is `pale_oak` — too small to be a family. So an id whose single-token key landed in a group too small to be a family gets to try again one token deeper, which files `dark_oak` under `planks` alongside `oak`. The retry is *conditional*: applied unconditionally it would also file `white_stained` under `glass_pane`, and then a list holding both `white_wool` and `white_stained_glass_pane` would see two different "white" families instead of one. Both cases are pinned by tests.

## Behaviour worth agreeing with

- **Only targets that can take every row are offered.** "All oak → crimson" is withheld when crimson has no sapling, rather than quietly leaving three oak rows behind.
- **Excluded rows survive a swap.** An unchecked box submits nothing, so rows now carry a hidden `row[<id>]` mirror alongside the `qty[<id>]` checkbox. Create still reads only `qty[...]` — its contract is unchanged.
- **Kept wins on merge.** Where a struck row and a kept row land on the same id, the merged row stays checked. Striking a row the user had checked, or dropping the struck row's quantity, would either surprise them or lose a number they can't recover; a row that comes back checked is visible in the total and one click from struck again.
- **Nothing is ever dropped.** A row with no counterpart under the target token stays where it is.

Substitution is demand-side — it edits *what you want*, the scorer never sees it, and nothing here touches how the planner sources anything (MCO-289's standing principle).

## Tests

`./webapp/scripts/test.sh --database` — 414 tests, 0 failures.

- `ItemFamiliesTest` (17) — vocabulary derivation, `dark_oak`/`light_blue`, the compound-token trap, partial targets, merging, id-with-no-namespace
- `SubstituteReviewedListStepTest` (10) — form parsing, exclusion tracking, kept-wins-on-merge, each failure case
- `ImportReviewSubstitutionIT` (7) — endpoint success, validation failures, auth failure

## Notes for review

- New route `POST /worlds/{worldId}/projects/import-review/substitute`, guarded by `WorldAdminPlugin` at route level (the sibling `from-schematic` routes still validate in-pipeline; this one follows the documented rule).
- The `hx-post` URL is hand-assembled rather than built via `Link`, matching the rest of this file — worth fixing across the page as a whole if you'd rather.
- No `mc-engine` or scorer changes; `ItemFamilies` reads only the item catalog.
- HTMX round-trip is not exercised by the ITs (they post constructed bodies). Worth a `/verify` pass in a browser before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)