### PR TITLE
MCO-305: import review — warn early about unobtainable and expensive rows

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
@@ -77,6 +77,7 @@ suspend fun ApplicationCall.handleReviewSchematic() {
                     projectName = project.name,
                     requirements = project.requirements,
                     families = findSubstitutionFamilies(items, project.requirements.map { it.key.id }),
+                    warnings = computeImportWarnings(worldId, project.requirements),
                 )
             )
         }
@@ -304,8 +305,11 @@ data class MapSchematicToMaterialsStep(
          * placed-effect blocks (fire, soul_fire, bubble_column) are created in-world from
          * the block below them (a separate, already-counted cell) plus a reusable tool
          * (flint & steel / a water bucket), so they carry no material of their own.
+         *
+         * Air (via [NON_MATERIAL_FILL]) is shared with the idea door, so both import paths
+         * agree that empty space is not a material — see MCO-305.
          */
-        private val NON_MATERIAL_BLOCKS = setOf(
+        private val NON_MATERIAL_BLOCKS = NON_MATERIAL_FILL + setOf(
             "minecraft:piston_head",
             "minecraft:moving_piston",
             "minecraft:fire",

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -77,6 +77,7 @@ suspend fun ApplicationCall.handleReviewIdeaImport() {
                     projectName = idea.name,
                     requirements = idea.requirements,
                     families = findSubstitutionFamilies(items, idea.requirements.map { it.key.id }),
+                    warnings = computeImportWarnings(worldId, idea.requirements),
                     action = Link.Ideas.single(ideaId) + "/import",
                     hiddenFields = buildMap {
                         put("worldId", worldId.toString())
@@ -172,6 +173,10 @@ internal data class ApplyReviewedRequirementsStep(
         val requirements = mutableMapOf<Item, Int>()
 
         submittedRows.forEach { (itemId, rawAmount) ->
+            // The review screen never offers air, so this only catches a hand-rolled post —
+            // but "air is never a material" is worth enforcing where the list becomes final.
+            if (itemId in NON_MATERIAL_FILL) return@forEach
+
             val item = byId[itemId]
             if (item == null) {
                 errors.add(ValidationFailure.CustomValidation("materials", "Unknown item: $itemId"))
@@ -330,6 +335,10 @@ private data class ValidateItemIdsStep(val availableIds: List<Item>) : Step<Pair
         val errors = mutableListOf<ValidationFailure>()
 
         for ((itemId, amount) in requirements) {
+            // Air is dropped, not reported (MCO-305) — an idea recorded from a schematic can
+            // carry millions of air cells, and nobody has ever wanted them on a gathering list.
+            if (itemId in NON_MATERIAL_FILL) continue
+
             val item = availableIds.find { it.id == itemId }
 
             if (item == null) {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportWarnings.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportWarnings.kt
@@ -1,0 +1,183 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.engine.model.ItemSourceGraph
+import app.mcorg.pipeline.resources.getGraphForWorld
+
+/**
+ * MCO-305: the painful rows in an import, named *before* the project exists.
+ *
+ * Nothing here blocks an import. The whole point is that the exclude checkbox next to a
+ * command block or a stack of turtle eggs is an informed choice rather than a surprise
+ * three hours into gathering. Every warning is advisory and every warned row is still
+ * checked by default — we say what we know and leave the decision alone.
+ */
+enum class ImportWarningKind(val chip: String, val heading: String, val explanation: String) {
+    /**
+     * Blocks that occupy space in a build but are not a thing you gather. Air is filtered
+     * outright (see [NON_MATERIAL_FILL]); what is left here is fluids, placed effects and
+     * portal blocks, which are real cells in a schematic but carry no material of their own.
+     */
+    NON_MATERIAL(
+        chip = "Not a material",
+        heading = "Not really materials",
+        explanation = "These are placed in-world rather than gathered — a fluid, a portal or an effect block. Excluding them changes nothing about the build."
+    ),
+
+    /**
+     * No source in the item-source graph produces this id, which is the same condition the
+     * planner reports as its BLOCKED bucket and the `score-dump unobtainable` report lists.
+     * Command blocks, barriers and player heads land here.
+     */
+    UNOBTAINABLE(
+        chip = "Creative only",
+        heading = "Not obtainable in survival",
+        explanation = "Nothing in this Minecraft version produces these — they need creative mode or an operator command. The plan will show them as blocked."
+    ),
+
+    /**
+     * Obtainable, but the gathering will be miserable. This one is a judgement call rather
+     * than something the graph can answer: a wither skeleton skull *has* a source, and the
+     * source is a fortress grind. Curated deliberately, and kept short.
+     */
+    EXPENSIVE(
+        chip = "Slow to gather",
+        heading = "Expensive to gather",
+        explanation = "Obtainable, but each one is a real expedition. Worth knowing the quantity now rather than after the plan is built."
+    ),
+}
+
+data class ImportWarning(
+    val item: Item,
+    val amount: Int,
+    val kind: ImportWarningKind,
+)
+
+/**
+ * The warnings for one import, in a shape the review page can both summarise and index by row.
+ */
+data class ImportWarnings(val warnings: List<ImportWarning> = emptyList()) {
+    private val byItemId: Map<String, ImportWarning> = warnings.associateBy { it.item.id }
+
+    val isEmpty: Boolean get() = warnings.isEmpty()
+
+    fun forItem(itemId: String): ImportWarning? = byItemId[itemId]
+
+    /** Warnings of one kind, largest quantity first — the ones worth reading are the big ones. */
+    fun of(kind: ImportWarningKind): List<ImportWarning> =
+        warnings.filter { it.kind == kind }.sortedByDescending { it.amount }
+}
+
+/**
+ * Classifies an import's material list against the world's item-source graph.
+ *
+ * The graph fetch is the cached per-version one the planner already uses, so this costs a
+ * map lookup in the steady state. A world with no ingested version yields a null graph and
+ * no [ImportWarningKind.UNOBTAINABLE] warnings — silence beats guessing.
+ */
+suspend fun computeImportWarnings(worldId: Int, requirements: Map<Item, Int>): ImportWarnings =
+    classifyImportWarnings(requirements, getGraphForWorld(worldId))
+
+/** The pure half of [computeImportWarnings], split out so the rules are testable without a world. */
+internal fun classifyImportWarnings(requirements: Map<Item, Int>, graph: ItemSourceGraph?) =
+    ImportWarnings(requirements.mapNotNull { (item, amount) ->
+        classify(item, graph)?.let { ImportWarning(item, amount, it) }
+    })
+
+/**
+ * Graph truth outranks the curated list: if nothing produces an id, "creative only" is the
+ * more useful thing to say about it than "slow to gather", whatever the curation thinks.
+ */
+private fun classify(item: Item, graph: ItemSourceGraph?): ImportWarningKind? = when {
+    item.id in NON_MATERIAL_ITEM_IDS -> ImportWarningKind.NON_MATERIAL
+    graph != null && !graph.produces(item.id) -> ImportWarningKind.UNOBTAINABLE
+    item.id in EXPENSIVE_ITEM_IDS -> ImportWarningKind.EXPENSIVE
+    else -> null
+}
+
+/**
+ * Matches by id rather than by [Item] equality — an `Item` is a data class over (id, name),
+ * and the catalog's display name need not be byte-identical to the one baked into the graph
+ * node. Matching on the name would report perfectly obtainable items as creative-only.
+ */
+private fun ItemSourceGraph.produces(itemId: String): Boolean =
+    getItemNodesByStringId(itemId).any { getSourcesForItem(it.item).isNotEmpty() }
+
+/**
+ * Air is not a material, in any list, ever — so it is filtered rather than flagged (MCO-305).
+ *
+ * This is not a hypothetical: importing idea #3 produced a review list whose largest row was
+ * `Air (Block)` x 9,389,854, 90% of the build's entire material total. A warning would have
+ * been the polite thing to do and the wrong one; there is no world in which a user wants nine
+ * million air blocks on their gathering list, so the honest fix is to never offer them.
+ *
+ * Everything with any argument for keeping it stays in [NON_MATERIAL_ITEM_IDS] and is merely
+ * warned about — we would rather not silently edit someone's list without a reason this strong.
+ */
+val NON_MATERIAL_FILL = setOf(
+    "minecraft:air",
+    "minecraft:cave_air",
+    "minecraft:void_air",
+)
+
+/**
+ * Cells that are not a material of their own. Fluids are placed from a reusable bucket, the
+ * placed effects (fire, portals) are created in-world from blocks counted elsewhere, and the
+ * technical piston states belong to the piston. All warned rather than filtered — a build
+ * really does contain them, and striking a row is the user's call.
+ */
+private val NON_MATERIAL_ITEM_IDS = NON_MATERIAL_FILL + setOf(
+    "minecraft:water",
+    "minecraft:flowing_water",
+    "minecraft:lava",
+    "minecraft:flowing_lava",
+    "minecraft:bubble_column",
+    "minecraft:fire",
+    "minecraft:soul_fire",
+    "minecraft:nether_portal",
+    "minecraft:end_portal",
+    "minecraft:end_gateway",
+    "minecraft:piston_head",
+    "minecraft:moving_piston",
+)
+
+/**
+ * Obtainable, but each unit is an expedition rather than a mining trip. Curated on purpose —
+ * "expensive" is about the shape of the grind, which the graph does not model. Kept to items
+ * whose cost is obvious in hindsight and invisible in a material list.
+ *
+ * Items with no source at all are deliberately absent: they are found by the graph, not listed
+ * here, so this set never has to keep up with what a version happens to make craftable.
+ */
+private val EXPENSIVE_ITEM_IDS = setOf(
+    // Mob-drop grinds
+    "minecraft:wither_skeleton_skull",
+    "minecraft:nether_star",
+    "minecraft:beacon",
+    "minecraft:totem_of_undying",
+    "minecraft:shulker_shell",
+    "minecraft:shulker_box",
+    "minecraft:trident",
+    "minecraft:nautilus_shell",
+    "minecraft:heart_of_the_sea",
+    "minecraft:conduit",
+    // Structure loot
+    "minecraft:elytra",
+    "minecraft:enchanted_golden_apple",
+    "minecraft:echo_shard",
+    "minecraft:recovery_compass",
+    "minecraft:sponge",
+    "minecraft:wet_sponge",
+    // Dimension grinds
+    "minecraft:ancient_debris",
+    "minecraft:netherite_scrap",
+    "minecraft:netherite_ingot",
+    "minecraft:netherite_block",
+    "minecraft:dragon_breath",
+    // Slow to farm at any scale
+    "minecraft:turtle_egg",
+    "minecraft:sculk_catalyst",
+    "minecraft:ochre_froglight",
+    "minecraft:verdant_froglight",
+    "minecraft:pearlescent_froglight",
+)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/SubstituteInImportReviewPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/SubstituteInImportReviewPipeline.kt
@@ -45,6 +45,10 @@ suspend fun ApplicationCall.handleSubstituteInImportReview() {
                         catalog = items,
                         requirements = reviewed.requirements.map { it.key.id },
                     ),
+                    // Recomputed, not carried over: a swap changes which rows are painful.
+                    // Trading oak for crimson can retire an unobtainable row or introduce one,
+                    // and a stale strip would describe the list the user just replaced.
+                    warnings = computeImportWarnings(worldId, reviewed.requirements),
                 )
             )
         }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -2,6 +2,9 @@ package app.mcorg.presentation.templated.dsl.pages
 
 import app.mcorg.domain.model.minecraft.Item
 import app.mcorg.domain.model.user.TokenProfile
+import app.mcorg.pipeline.project.ImportWarning
+import app.mcorg.pipeline.project.ImportWarningKind
+import app.mcorg.pipeline.project.ImportWarnings
 import app.mcorg.pipeline.resources.SubstitutionFamily
 import app.mcorg.presentation.hxInclude
 import app.mcorg.presentation.hxPost
@@ -52,8 +55,11 @@ import kotlinx.html.tr
  *
  * Batch substitution (MCO-304) rewrites the list in place: the swap controls post the
  * current form back and swap [importReviewMaterials] for a rewritten copy, so a swap is
- * just another edit to an unsaved form. The unobtainable/expensive warning strip (MCO-305)
- * lands on this same screen.
+ * just another edit to an unsaved form.
+ *
+ * [warnings] (MCO-305) name the painful rows without standing in their way: a strip above
+ * the list and a chip on the row itself. Advisory only — every warned row arrives checked.
+ * They live *inside* the swappable section, because a swap changes which rows are painful.
  */
 fun importReviewPage(
     user: TokenProfile,
@@ -64,11 +70,13 @@ fun importReviewPage(
     action: String = "/worlds/$worldId/projects/from-schematic",
     hiddenFields: Map<String, String> = emptyMap(),
     families: List<SubstitutionFamily> = emptyList(),
+    warnings: ImportWarnings = ImportWarnings(),
 ): String = pageShell(
     pageTitle = "Seam — review import",
     user = user,
     stylesheets = listOf(
         "/static/styles/components/btn.css",
+        "/static/styles/components/callout.css",
         "/static/styles/components/form.css",
         "/static/styles/pages/import-review.css",
     ),
@@ -119,7 +127,13 @@ fun importReviewPage(
                     }
                 }
 
-                materialsSection(worldId, requirements, excluded = emptySet(), families = families)
+                materialsSection(
+                    worldId,
+                    requirements,
+                    excluded = emptySet(),
+                    families = families,
+                    warnings = warnings,
+                )
 
                 div("import-review__actions") {
                     button(classes = "btn btn--primary") {
@@ -138,8 +152,9 @@ fun importReviewPage(
 
 /**
  * The swappable part of the screen, rendered standalone so a substitution can replace it
- * (MCO-304). Everything a swap can change lives in here — the controls, the row set and the
- * quantities; the project name and the hidden carry-through fields sit outside and survive
+ * (MCO-304). Everything a swap can change lives in here — the controls, the row set, the
+ * quantities and the warnings (MCO-305), since swapping oak for crimson changes which rows
+ * are painful. The project name and the hidden carry-through fields sit outside and survive
  * untouched.
  */
 fun importReviewMaterials(
@@ -147,8 +162,9 @@ fun importReviewMaterials(
     requirements: Map<Item, Int>,
     excluded: Set<String>,
     families: List<SubstitutionFamily>,
+    warnings: ImportWarnings,
 ): String = createHTML().div {
-    materialsSectionBody(worldId, requirements, excluded, families)
+    materialsSectionBody(worldId, requirements, excluded, families, warnings)
 }
 
 private fun FlowContent.materialsSection(
@@ -156,9 +172,10 @@ private fun FlowContent.materialsSection(
     requirements: Map<Item, Int>,
     excluded: Set<String>,
     families: List<SubstitutionFamily>,
+    warnings: ImportWarnings,
 ) {
     div {
-        materialsSectionBody(worldId, requirements, excluded, families)
+        materialsSectionBody(worldId, requirements, excluded, families, warnings)
     }
 }
 
@@ -167,11 +184,13 @@ private fun DIV.materialsSectionBody(
     requirements: Map<Item, Int>,
     excluded: Set<String>,
     families: List<SubstitutionFamily>,
+    warnings: ImportWarnings,
 ) {
     id = MATERIALS_ID
     classes = setOf("import-review__materials")
+    warningStrip(warnings)
     substitutionControls(worldId, families)
-    materialsTable(requirements, excluded)
+    materialsTable(requirements, excluded, warnings)
 }
 
 private const val MATERIALS_ID = "import-review-materials"
@@ -229,7 +248,45 @@ private fun FlowContent.substitutionControls(worldId: Int, families: List<Substi
     }
 }
 
-private fun FlowContent.materialsTable(requirements: Map<Item, Int>, excluded: Set<String>) {
+/**
+ * One low-weight strip, one paragraph per kind of pain (MCO-305). It never blocks the import
+ * and it never unchecks anything — it exists so that striking a row is a decision rather than
+ * a discovery. Long lists are truncated: the per-row chips carry the full detail.
+ */
+private fun FlowContent.warningStrip(warnings: ImportWarnings) {
+    if (warnings.isEmpty) return
+
+    div("callout import-review__warnings") {
+        span("callout__icon") {
+            attributes["aria-hidden"] = "true"
+            +"!"
+        }
+        div("callout__body") {
+            ImportWarningKind.entries.forEach { kind ->
+                val flagged = warnings.of(kind)
+                if (flagged.isEmpty()) return@forEach
+                p("import-review__warning") {
+                    span("import-review__warning-heading") { +"${kind.heading}: " }
+                    +namesOf(flagged)
+                    +". ${kind.explanation}"
+                }
+            }
+        }
+    }
+}
+
+/** Up to four names, then a count — a strip that lists thirty items is a wall, not a warning. */
+private fun namesOf(flagged: List<ImportWarning>): String {
+    val shown = flagged.take(4).joinToString(", ") { "${it.item.name} (${it.amount})" }
+    val rest = flagged.size - 4
+    return if (rest > 0) "$shown and $rest more" else shown
+}
+
+private fun FlowContent.materialsTable(
+    requirements: Map<Item, Int>,
+    excluded: Set<String>,
+    warnings: ImportWarnings,
+) {
     val rows = requirements.entries.sortedWith(
         compareByDescending<Map.Entry<Item, Int>> { it.value }.thenBy { it.key.name }
     )
@@ -278,6 +335,12 @@ private fun FlowContent.materialsTable(requirements: Map<Item, Int>, excluded: S
                             label("import-review__item-name") {
                                 htmlFor = "include-$rowId"
                                 +item.name
+                            }
+                            warnings.forItem(item.id)?.let { warning ->
+                                span("import-review__flag") {
+                                    attributes["title"] = warning.kind.explanation
+                                    +warning.kind.chip
+                                }
                             }
                         }
                         td {

--- a/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
@@ -89,6 +89,42 @@
     width: 100%;
 }
 
+/* MCO-305 — the warning strip. Informational, never blocking, so it sits at the weight of a
+   note rather than an error: no fill of its own beyond the callout's, and muted body text. */
+.import-review__warnings {
+    align-items: flex-start;
+}
+
+.import-review__warning {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    max-width: 80ch;
+}
+
+.import-review__warning-heading {
+    font-family: var(--font-ui);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+/* The row-level echo of the strip. Small, uppercase, amber — readable next to the item name
+   without competing with it for the eye. */
+.import-review__flag {
+    display: inline-block;
+    margin-left: var(--space-2);
+    padding: 0 var(--space-2);
+    border: 1px solid var(--amber);
+    border-radius: var(--radius);
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--amber);
+    white-space: nowrap;
+    cursor: help;
+}
+
 .import-review__summary {
     display: flex;
     align-items: baseline;

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/ImportWarningsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/ImportWarningsTest.kt
@@ -1,0 +1,127 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftId
+import app.mcorg.domain.model.resources.ResourceSource
+import app.mcorg.engine.model.ItemSourceGraph
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * MCO-305 — the rules behind the review screen's warning strip, without a world attached.
+ */
+class ImportWarningsTest {
+
+    private val block = ResourceSource.SourceType.LootTypes.BLOCK
+
+    private fun item(name: String) = Item("minecraft:$name", name.replaceFirstChar { it.uppercase() })
+
+    /** A graph in which every listed id has exactly one block-loot producer. */
+    private fun graphProducing(vararg items: MinecraftId): ItemSourceGraph {
+        val builder = ItemSourceGraph.builder()
+        items.forEach { produced ->
+            val source = builder.addSourceNode(block, "blocks/${produced.id.substringAfter(':')}.json")
+            builder.addSourceToItemEdge(source, builder.addItemNode(produced), 1)
+        }
+        return builder.build()
+    }
+
+    @Test
+    fun `an id no source produces is flagged as creative-only`() {
+        val commandBlock = item("command_block")
+        val stone = item("stone")
+
+        val warnings = classifyImportWarnings(
+            mapOf(commandBlock to 4, stone to 100),
+            graphProducing(stone),
+        )
+
+        assertEquals(ImportWarningKind.UNOBTAINABLE, warnings.forItem(commandBlock.id)?.kind)
+        assertNull(warnings.forItem(stone.id), "an ordinary block with a source is not worth a word")
+    }
+
+    @Test
+    fun `an obtainable-but-painful id is flagged as slow to gather`() {
+        val skull = item("wither_skeleton_skull")
+
+        val warnings = classifyImportWarnings(mapOf(skull to 3), graphProducing(skull))
+
+        assertEquals(ImportWarningKind.EXPENSIVE, warnings.forItem(skull.id)?.kind)
+    }
+
+    @Test
+    fun `graph truth outranks the curated expensive list`() {
+        val skull = item("wither_skeleton_skull")
+
+        // Same curated id, but this version's graph has no source for it at all. "Creative
+        // only" is the more useful thing to say than "slow to gather".
+        val warnings = classifyImportWarnings(mapOf(skull to 3), graphProducing(item("stone")))
+
+        assertEquals(ImportWarningKind.UNOBTAINABLE, warnings.forItem(skull.id)?.kind)
+    }
+
+    @Test
+    fun `fluids and placed effects are flagged as non-materials, ahead of any graph verdict`() {
+        val water = item("water")
+        val fire = item("fire")
+
+        val warnings = classifyImportWarnings(
+            mapOf(water to 10, fire to 2),
+            graphProducing(water, fire),
+        )
+
+        assertEquals(ImportWarningKind.NON_MATERIAL, warnings.forItem(water.id)?.kind)
+        assertEquals(ImportWarningKind.NON_MATERIAL, warnings.forItem(fire.id)?.kind)
+    }
+
+    @Test
+    fun `a name mismatch between catalog and graph does not fake an unobtainable row`() {
+        // The graph node carries one display name and the world catalog another. Matching on
+        // Item equality (id *and* name) would report a perfectly craftable item as blocked.
+        val graph = graphProducing(Item("minecraft:oak_planks", "Oak Wood Planks"))
+
+        val warnings = classifyImportWarnings(mapOf(Item("minecraft:oak_planks", "Oak Planks") to 64), graph)
+
+        assertTrue(warnings.isEmpty)
+    }
+
+    @Test
+    fun `no graph means no unobtainable claims`() {
+        // A world whose version was never ingested. Silence beats guessing; the curated
+        // categories still apply, because they need no graph to be true.
+        val warnings = classifyImportWarnings(
+            mapOf(item("command_block") to 1, item("water") to 1, item("elytra") to 1),
+            null,
+        )
+
+        assertNull(warnings.forItem("minecraft:command_block"))
+        assertEquals(ImportWarningKind.NON_MATERIAL, warnings.forItem("minecraft:water")?.kind)
+        assertEquals(ImportWarningKind.EXPENSIVE, warnings.forItem("minecraft:elytra")?.kind)
+    }
+
+    @Test
+    fun `warnings of a kind come back largest first`() {
+        val warnings = classifyImportWarnings(
+            mapOf(item("water") to 5, item("lava") to 900, item("fire") to 60),
+            null,
+        )
+
+        assertEquals(
+            listOf("minecraft:lava", "minecraft:fire", "minecraft:water"),
+            warnings.of(ImportWarningKind.NON_MATERIAL).map { it.item.id },
+        )
+    }
+
+    @Test
+    fun `air is not classified here at all — it is filtered before the list is built`() {
+        // NON_MATERIAL_FILL exists so both import doors drop air outright; if it ever reached
+        // the review screen anyway, it should still read as a non-material rather than silently.
+        assertTrue("minecraft:air" in NON_MATERIAL_FILL)
+        assertEquals(
+            ImportWarningKind.NON_MATERIAL,
+            classifyImportWarnings(mapOf(item("air") to 9_389_854), null).forItem("minecraft:air")?.kind,
+        )
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
@@ -6,6 +6,7 @@ import app.mcorg.config.CacheManager
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.project.ImportWarningKind
 import app.mcorg.pipeline.project.handleImportIdea
 import app.mcorg.pipeline.project.handleReviewIdeaImport
 import app.mcorg.pipeline.world.CreateWorldInput
@@ -50,6 +51,7 @@ class ImportIdeaReviewIT : WithUser() {
 
     private var worldId: Int = 0
     private var ideaId: Int = 0
+    private var airyIdeaId: Int = 0
 
     @BeforeAll
     fun setup() {
@@ -57,10 +59,19 @@ class ImportIdeaReviewIT : WithUser() {
         seedItem("minecraft:iron_ingot", "Iron Ingot")
         seedItem("minecraft:oak_planks", "Oak Planks")
         seedItem("minecraft:redstone", "Redstone Dust")
+        seedItem("minecraft:air", "Air (Block)")
+        seedItem("minecraft:water", "Water")
         ideaId = createIdea("Iron Farm Idea")
         addRequirement(ideaId, "minecraft:iron_ingot", 64)
         addRequirement(ideaId, "minecraft:oak_planks", 32)
         addRequirement(ideaId, "minecraft:redstone", 8)
+
+        // The MCO-305 case, from a real idea: a schematic-derived idea whose largest row was
+        // nine million air blocks — 90% of the build's material total.
+        airyIdeaId = createIdea("Ghast Farm Roof")
+        addRequirement(airyIdeaId, "minecraft:air", 9_389_854)
+        addRequirement(airyIdeaId, "minecraft:water", 12)
+        addRequirement(airyIdeaId, "minecraft:oak_planks", 64)
     }
 
     // ---- review ------------------------------------------------------------------
@@ -102,6 +113,52 @@ class ImportIdeaReviewIT : WithUser() {
         }
 
         assertEquals(HttpStatusCode.Forbidden, response.status)
+    }
+
+    // ---- warn early (MCO-305) ------------------------------------------------------
+
+    @Test
+    fun `air never reaches the review screen`() = testApplication {
+        setupRoutes()
+
+        val response = client.get("/ideas/$airyIdeaId/import/review?worldId=$worldId") { addAuthCookie(this) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertFalse(body.contains("qty[minecraft:air]"), "air is filtered, not offered as a row")
+        assertFalse(body.contains("9389854"), "and its quantity goes with it")
+        assertContains(body, "qty[minecraft:oak_planks]", message = "the real materials still arrive")
+    }
+
+    @Test
+    fun `a non-material that is not air is flagged rather than removed`() = testApplication {
+        setupRoutes()
+
+        val response = client.get("/ideas/$airyIdeaId/import/review?worldId=$worldId") { addAuthCookie(this) }
+
+        val body = response.bodyAsText()
+        assertContains(body, "qty[minecraft:water]", message = "water stays on the list — striking it is the user's call")
+        assertContains(body, "Not really materials", message = "but the strip says what it is")
+        assertContains(body, ImportWarningKind.NON_MATERIAL.chip, message = "and so does the row")
+    }
+
+    @Test
+    fun `an import that includes air drops it instead of creating a resource row`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        // The review screen never renders an air row, so this is a hand-rolled post — the
+        // point being that "air is never a material" holds where the list becomes final too.
+        val response = client.post("/ideas/$airyIdeaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("worldId=$worldId&name=Roof&qty[minecraft:air]=9389854&qty[minecraft:oak_planks]=64")
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val projectId = response.headers["Location"]!!.substringAfterLast("/").toInt()
+
+        assertEquals(listOf("minecraft:oak_planks" to 64), readRequirements(projectId))
     }
 
     // ---- create ------------------------------------------------------------------


### PR DESCRIPTION
Phase 3 of MCO-289, on top of phase 1's review screen. Closes MCO-305.

A low-weight strip above the material list, plus a chip on the row itself, naming the rows that will hurt — *before* the project exists. Advisory only: nothing is blocked, and every warned row still arrives checked. The point is that striking a command block, or nine stacks of turtle eggs, is a decision rather than a discovery three hours into gathering. Both import doors get it.

## Three kinds

| Kind | Where the definition comes from |
|---|---|
| **Not obtainable in survival** — command blocks, barriers, player heads | The engine's, directly: no source in the graph produces the id. Same condition the planner reports as `BLOCKED` and the `score-dump unobtainable` report lists. |
| **Expensive oddities** — wither skulls, elytra, turtle eggs, netherite | Curated, deliberately. "This is a fortress grind" is not something the graph models — a wither skeleton skull *has* a source, and the source is the problem. |
| **Not really materials** — fluids, portals, placed effects | A small explicit set. |

Graph truth outranks curation: if nothing produces an id, "creative only" is the more useful thing to say about it than "slow to gather", whatever the curated list thinks. A world whose version was never ingested yields no unobtainable claims at all — silence beats guessing.

Matching is by **id**, not by `Item` equality. An `Item` is a data class over (id, name), and the catalog's display name need not be byte-identical to the one baked into the graph node; matching on the name would report perfectly craftable items as blocked. Pinned by a test.

## Air is filtered, not flagged

The issue leaned filter-for-air / warn-for-the-rest, and this does exactly that.

Importing idea #3 (`38kGhastFarmRoof`) produced a review list whose largest row was `Air (Block)` × **9,389,854** — 90% of the build's entire material total. A warning would have been the polite thing to do and the wrong one: there is no world in which someone wants nine million air blocks on a gathering list. The filter applies on the idea side where the list is built *and* where it becomes final, so a hand-rolled post can't reintroduce it, and the schematic path now shares the same set so both doors agree that empty space is not a material.

Everything with any argument for keeping it — water, lava, fire, portals — is merely warned about. We'd rather not silently edit someone's list without a reason that strong.

## Tests

`./webapp/scripts/test.sh --database` — 410 tests, 0 failures.

- `ImportWarningsTest` (8) — each kind, precedence between them, the name-mismatch trap, no-graph behaviour, ordering
- `ImportIdeaReviewIT` (+3) — air never reaches the review screen, a non-air non-material is flagged rather than removed, an import that includes air drops it

## Notes for review

- **`EXPENSIVE_ITEM_IDS` is a judgement call** and the thing most worth your eye — it's the only part of this that isn't derived from data. Kept short on purpose; items with *no* source are deliberately absent, since the graph finds those.
- The unobtainable path has unit coverage but no IT: the test database has no ingested graph, so an end-to-end assertion would need a full ingest. Worth a `/verify` pass against a real world.
- `mc-engine` is read-only here (`getSourcesForItem` / `getItemNodesByStringId`) — no graph or scorer changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)