### PR TITLE
chore(ci): pin all GitHub Actions to full commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,13 @@ updates:
           - "org.slf4j:*"
           - "ch.qos.logback:*"
 
+  # Every action is pinned to a full commit SHA, with the human-readable version in a
+  # trailing comment (`uses: actions/checkout@3d3c42e... # v7.0.1`). Tags — including
+  # major tags like @v4 — are mutable: a compromised maintainer can repoint them at new
+  # code, which is how the tj-actions/changed-files compromise exfiltrated CI secrets
+  # from ~23k repos in March 2025. A SHA is the only immutable ref. Dependabot bumps the
+  # SHA and rewrites the comment, so this costs nothing to maintain — keep new actions
+  # pinned the same way, and never reintroduce a branch ref like @master.
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/cleanup-dev.yml
+++ b/.github/workflows/cleanup-dev.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete Fly app
-        uses: superfly/fly-pr-review-apps@1.6.0
+        uses: superfly/fly-pr-review-apps@5d9f067254bebd0aaa77d908d6337b63f4d4f019 # 1.6.0
         with:
           name: mcorg-dev-${{ github.event.number }}
           org: mc-org
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Delete Neon Branch
-        uses: neondatabase/delete-branch-action@v3.2.1
+        uses: neondatabase/delete-branch-action@4468d825d5a88ef4012f1705a82f02ec3072f776 # v3.2.1
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
           branch: dev/pr-${{ github.event.number }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,16 +19,16 @@ jobs:
       run:
         working-directory: ./webapp
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '25'
 
       - name: Cache Maven packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
@@ -36,7 +36,7 @@ jobs:
             maven-${{ runner.os }}-
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: java-kotlin
           config-file: .github/codeql/codeql-config.yml
@@ -45,6 +45,6 @@ jobs:
         run: mvn clean compile -DskipTests
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:java-kotlin"

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -11,29 +11,29 @@ jobs:
       run:
         working-directory: ./webapp
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Cache Maven packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '25'
       - name: Compile and install modules
         run: mvn install -DskipTests -B
       - name: Upload local Maven artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: maven-local-modules
           path: ~/.m2/repository/app/mcorg
           retention-days: 1
       - name: Upload application JAR
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: app-jar
           path: webapp/mc-web/target/*-with-dependencies.jar

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -35,26 +35,26 @@ jobs:
       run:
         working-directory: ./webapp
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Cache Maven packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '25'
       - name: Restore local Maven artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: maven-local-modules
           path: ~/.m2/repository/app/mcorg
       - name: Cache Minecraft server data
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: webapp/mc-data/src/test/resources/servers/extracted
           key: minecraft-server-data-${{ hashFiles('webapp/mc-data/src/test/kotlin/app/mcorg/data/minecraft/extract/ServerFileDownloader.kt') }}
@@ -74,21 +74,21 @@ jobs:
       run:
         working-directory: ./webapp
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Cache Maven packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '25'
       - name: Restore local Maven artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: maven-local-modules
           path: ~/.m2/repository/app/mcorg
@@ -115,22 +115,22 @@ jobs:
       run:
         working-directory: ./webapp
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Cache Maven packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
       - name: Restore local Maven artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: maven-local-modules
           path: ~/.m2/repository/app/mcorg
 
       - name: Create Neon branch
-        uses: neondatabase/create-branch-action@v6.4.0
+        uses: neondatabase/create-branch-action@72ed4f69a12b6be9c16aebfad893f6a21e9aba8b # v6.4.0
         id: create-neon-branch
         with:
           project_id: ${{ vars.NEON_PROJECT_ID }}
@@ -139,7 +139,7 @@ jobs:
           role: ${{ env.DB_USERNAME }}
           api_key: ${{ secrets.NEON_API_KEY }}
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -152,23 +152,23 @@ jobs:
           DB_PASSWORD: ${{ steps.create-neon-branch.outputs.password }}
 
       - name: Download application JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: app-jar
           path: ./jar
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./jar
           file: ./webapp/Dockerfile.ci
@@ -178,7 +178,7 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
 
       - name: Setup flyctl
-        uses: superfly/flyctl-actions/setup-flyctl@master
+        uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
 
       - name: Create Fly preview app
         run: flyctl apps create mcorg-dev-${{ github.event.number }} --org mc-org || true
@@ -208,7 +208,7 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{secrets.GH_TOKEN_PR_COMMENTS}}
           script: |

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -34,21 +34,21 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Cache Maven packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
       - name: Restore local Maven artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: maven-local-modules
           path: ~/.m2/repository/app/mcorg
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '25'
@@ -62,23 +62,23 @@ jobs:
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
 
       - name: Download application JAR
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: app-jar
           path: ./jar
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./jar
           file: ./webapp/Dockerfile.ci
@@ -89,7 +89,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
       - run: flyctl deploy --image ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
Supersedes #366, which proposed pinning `github/codeql-action` to the exact tag `@v4.37.4`. An exact tag is still a mutable ref, so it buys reproducibility but not immutability — this does the whole sweep properly instead.

## Why

Tags are mutable. A major tag (`@v4`) and an exact tag (`@1.6.0`) can both be repointed at new code by a compromised maintainer. The [tj-actions/changed-files compromise](https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide) (March 2025) rewrote *all* version tags on an action used by ~23k repos and exfiltrated CI secrets; only SHA-pinned workflows were unaffected. GitHub's hardening guide calls a full commit SHA "the only way to use an action as an immutable release."

## What changed

All 41 live `uses:` refs across `cleanup-dev.yml`, `codeql.yml`, `compile.yml`, `dev.yml` and `prod.yml`, pinned to the commit each ref resolves to **today**, with the version kept in a trailing comment:

```yaml
uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
```

**No behaviour change** — every SHA is what the previous ref already pointed at. Each was resolved via the GitHub API (ref → commit, then tags on that commit), not by trusting the tag name.

The one that actually mattered: `superfly/flyctl-actions/setup-flyctl` was on **`@master`** — a moving *branch* ref, in the two jobs holding the Fly deploy token. Its HEAD is tagged `1.6`, so the pin is a no-op there as well.

Incidentally, `codeql-action@v4` resolves to **v4.37.6** today, so #366 was already stale.

## Ongoing cost

Roughly zero. `dependabot.yml` already groups all github-actions bumps into a single weekly PR, and Dependabot maintains both the SHA and the trailing comment. The tradeoff is up to a week of lag on CodeQL engine updates — worth watching only because the Kotlin 2.3.21 hold is waiting on a CodeQL extractor fix (github/codeql#21938).

The rationale is recorded as a comment in `dependabot.yml` so it survives the next bump.

## Not included

The four commented-out `uses:` lines in `dev.yml` (232, 234, 240, 259) are left as-is — dead code, and pinning it would just add diff noise.

## Verification

- All five workflow files and `dependabot.yml` parse as valid YAML
- Every live ref matches `@[0-9a-f]{40} #`; the only unpinned hits are the four commented lines
- CI on this PR exercises `compile.yml`, `dev.yml` and `codeql.yml` end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)