### PR TITLE
MCO-204: slim the idea schema to what Seam actually needs

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/domain/idea/schema/IdeaCategorySchema.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/domain/idea/schema/IdeaCategorySchema.kt
@@ -10,20 +10,12 @@ import app.mcorg.domain.model.minecraft.MinecraftVersionRange
 data class IdeaCategorySchema(
     val category: IdeaCategory,
     val fields: List<CategoryField>,
-    val subcategories: Map<String, List<CategoryField>> = emptyMap(),
 
     var versionRange: MinecraftVersionRange = MinecraftVersionRange.Unbounded
 ) {
     fun getField(key: String): CategoryField? = fields.find { it.key == key }
 
-    fun getSearchableFields(): List<CategoryField> = fields.filter { it.searchable }
-
     fun getFilterableFields(): List<CategoryField> = fields.filter { it.filterable }
 
     fun getRequiredFields(): List<CategoryField> = fields.filter { it.required }
-
-    fun getSubcategoryFields(subcategory: String): List<CategoryField>? = subcategories[subcategory]
-
-    fun getAllFields(): List<CategoryField> = fields + subcategories.values.flatten()
 }
-

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/domain/idea/schema/IdeaCategorySchemas.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/domain/idea/schema/IdeaCategorySchemas.kt
@@ -7,236 +7,99 @@ import app.mcorg.presentation.templated.dsl.SearchableSelectOption
 
 /**
  * Single Source of Truth for Idea Category Schemas.
- * All category-specific fields, filters, and validation rules are defined here.
  *
  * This configuration drives:
  * - Database JSONB structure
  * - Form generation and validation
  * - Search and filter UI generation
- * - API request/response handling
+ *
+ * **Deliberately loose (MCO-204).** Every category keeps only the handful of fields that are
+ * universal, genuinely filterable, or consumed by the product (item requirements, size, version).
+ * Everything else goes in the free-form [specs] block. Promote a spec to a first-class typed
+ * field when it shows up consistently in real submissions — not before. Designing a tight schema
+ * from a handful of hand-entered ideas is guessing, and guessing costs import speed.
+ *
+ * Note that name, description, author, labels, difficulty and version range live on the Idea
+ * itself — never duplicate them here.
  */
 object IdeaCategorySchemas {
 
-    fun IdeaCategorySchemaBuilder.sizeField(key: String = "size") = structField(key) {
-        label = "Size (X × Y × Z)"
-        required = true
-        fields {
-            numberField("x") {
-                label = "X Dimension"
-                required = true
+    /**
+     * Free-form label -> value block. Replaces the long tail of speculative typed fields.
+     * Not filterable by design: there is no fixed key set to filter on.
+     */
+    private fun IdeaCategorySchemaBuilder.specs() = typedMapField("specs") {
+        label = "Specs"
+        helpText = "Anything measurable about this design, e.g. \"TNT per piston: 10\" or \"Remaining fuse: 21gt\""
+        types {
+            textKey {
+                label = "Spec"
+                placeholder = "e.g., TNT per piston"
             }
-            numberField("y") {
-                label = "Y Dimension"
-                required = true
-            }
-            numberField("z") {
-                label = "Z Dimension"
-                required = true
+            textValue {
+                label = "Value"
+                placeholder = "e.g., 10"
             }
         }
     }
 
-    fun IdeaCategorySchemaBuilder.tileability(key: String = "tileability") = selectField(key) {
-        label = "Tileable Configuration"
+    /** Videos, schematic downloads, forum threads — wherever this design came from. */
+    private fun IdeaCategorySchemaBuilder.references() = listField("references") {
+        label = "Reference Links"
+        itemLabel = "Link"
+        helpText = "Comma-separated URLs"
+    }
+
+    /**
+     * Optional footprint. Sub-fields are optional too, so a partially known size still saves.
+     */
+    private fun IdeaCategorySchemaBuilder.sizeField() = structField("size") {
+        label = "Size (X × Y × Z)"
+        fields {
+            numberField("x") { label = "X Dimension" }
+            numberField("y") { label = "Y Dimension" }
+            numberField("z") { label = "Z Dimension" }
+        }
+    }
+
+    private fun IdeaCategorySchemaBuilder.tileable() = booleanField("tileable") {
+        label = "Tileable"
         filterable = true
-        options = listOf(
-            SearchableSelectOption(
-                value = "1",
-                label = "1",
-            ),
-            SearchableSelectOption(
-                value = "2",
-                label = "2",
-            ),
-            SearchableSelectOption(
-                value = "3",
-                label = "3",
-            ),
-            SearchableSelectOption(
-                value = "AB",
-                label = "AB",
-            ),
-            SearchableSelectOption(
-                value = "ABC",
-                label = "ABC",
-            ),
-            SearchableSelectOption(
-                value = "Not Tileable",
-                label = "Not Tileable",
-            )
-        )
+        defaultValue = false
+    }
+
+    private fun IdeaCategorySchemaBuilder.directional() = booleanField("directional") {
+        label = "Directional"
+        filterable = true
+        defaultValue = false
+        helpText = "Must face a specific direction"
     }
 
     val FARM = ideaCategory(IdeaCategory.FARM) {
-        // Farm version tracking
-        textField("farmVersion") {
-            label = "Farm Version"
-            searchable = true
-            helpText = "Version identifier for this farm design (e.g., v3.2, Mark-IV)"
-        }
-
-        typedMapField("productionRate") {
-            label = "Production Rate"
-            types {
-                textKey {
-                    label = "Mode"
-                    placeholder = "e.g., Normal, Fast, Eco"
-                }
-                typedMapValue {
-                    label = "Rate Details"
-                    types {
-                        selectKey {
-                            label = "Item"
-                            dynamicOptionsConfig = DynamicOptionsConfig.items()
-                        }
-                        rateValue {
-                            label = "Rate"
-                            min = 0.0
-                        }
-                    }
-                }
-            }
-        }
-
-        typedMapField("consumptionRate") {
-            label = "Consumption Rate"
-            types {
-                textKey {
-                    label = "Mode"
-                    placeholder = "e.g., Normal, Fast, Eco"
-                }
-                typedMapValue {
-                    label = "Rate Details"
-                    types {
-                        selectKey {
-                            label = "Item"
-                            dynamicOptionsConfig = DynamicOptionsConfig.items()
-                        }
-                        rateValue {
-                            label = "Rate"
-                            min = 0.0
-                        }
-                    }
-                }
-            }
-        }
-
         sizeField()
 
-        booleanField("stackable") {
-            label = "Stackable"
-            filterable = true
-            defaultValue = false
-        }
-
-        booleanField("tileable") {
-            label = "Tileable"
-            filterable = true
-            defaultValue = false
-        }
-
-        // Location requirements
-        numberField("yLevel") {
-            label = "Required Y-Level"
-            filterable = true
-            helpText = "Specific Y-level requirement (if any)"
-            min = -64.0
-            max = 320.0
-        }
-
-        booleanField("subChunkAligned") {
-            label = "Sub-chunk Aligned"
-            filterable = true
-            defaultValue = false
-            helpText = "Must be aligned to 16×16×16 sub-chunk boundaries"
-        }
-
-        multiSelectField("biomes") {
-            label = "Compatible Biomes"
-            filterable = true
-            options = listOf(
-                "Plains", "Forest", "Taiga", "Swamp", "Desert", "Savanna",
-                "Jungle", "Badlands", "Mushroom Fields", "Ocean", "River",
-                "Nether Wastes", "Crimson Forest", "Warped Forest", "Soul Sand Valley",
-                "Basalt Deltas", "The End", "Any"
-            )
-        }
-
-        typedMapField("mobRequirements") {
-            label = "Mob Requirements"
-            helpText = "Specific mobs required for farm operation"
+        /**
+         * The one structured field the engine will consume: MCO-294 matches bulk raw demand
+         * against farm output. Flat item -> rate; the old Mode -> (Item -> Rate) nesting was
+         * the single most tedious thing in the form and never got filled.
+         */
+        typedMapField("productionRate") {
+            label = "Production Rate"
+            helpText = "What this farm produces, per hour"
             types {
                 selectKey {
-                    label = "Mob Type"
-                    options = listOf(
-                        SearchableSelectOption(
-                            value = "zombie",
-                            label = "Zombie",
-                            searchTerms = listOf("zombie", "undead")
-                        ),
-                        SearchableSelectOption(
-                            value = "skeleton",
-                            label = "Skeleton",
-                            searchTerms = listOf("skeleton", "undead", "arrow")
-                        ),
-                        SearchableSelectOption(
-                            value = "creeper",
-                            label = "Creeper",
-                            searchTerms = listOf("creeper", "explosive")
-                        ),
-                        SearchableSelectOption(
-                            value = "spider",
-                            label = "Spider",
-                            searchTerms = listOf("spider", "arachnid")
-                        ),
-                        SearchableSelectOption(
-                            value = "witch",
-                            label = "Witch",
-                            searchTerms = listOf("witch", "potion", "alchemist")
-                        ),
-                        SearchableSelectOption(
-                            value = "any",
-                            label = "Any",
-                            searchTerms = listOf("any", "all", "generic")
-                        )
-                    )
+                    label = "Item"
+                    dynamicOptionsConfig = DynamicOptionsConfig.items()
                 }
-                numberValue {
-                    label = "Amount Required"
-                    min = 1.0
+                rateValue {
+                    label = "Rate"
+                    min = 0.0
                 }
             }
         }
 
-        // Player requirements
-        multiSelectField("playerSetup") {
-            label = "Player Setup Requirements"
-            options = listOf(
-                "Looting III Sword", "Fire Aspect II", "Sweeping Edge III",
-                "Strength II Potion", "Speed II Potion", "Regeneration",
-                "Full Diamond Armor", "Full Netherite Armor", "Elytra",
-                "Trident with Loyalty", "Bow with Power V", "Shield"
-            )
-        }
-
-        multiSelectField("beaconSetup") {
-            label = "Beacon Setup Requirements"
-            options = listOf(
-                "Speed I", "Speed II", "Haste I", "Haste II",
-                "Strength I", "Strength II", "Jump Boost I", "Jump Boost II",
-                "Regeneration I", "Regeneration II", "Resistance I", "Resistance II"
-            )
-        }
-
-        // Usage information
-        textField("howToUse") {
-            label = "How to Use"
-            searchable = true
-            multiline = true
-            required = true
-            maxLength = 1000
-            helpText = "Instructions for operating the farm"
-        }
+        tileable()
+        directional()
 
         booleanField("afkable") {
             label = "AFK-able"
@@ -245,330 +108,37 @@ object IdeaCategorySchemas {
             helpText = "Can be used while AFK"
         }
 
-        selectField("playersRequired") {
-            label = "Players Required"
-            filterable = true
-            required = true // listOf("0 (Automatic)", "1", "2", "3+")
-            options = listOf(
-                SearchableSelectOption(
-                    value = "0",
-                    label = "0 (Automatic)",
-                    searchTerms = listOf("0", "automatic", "auto")
-                ),
-                SearchableSelectOption(
-                    value = "1",
-                    label = "1",
-                    searchTerms = listOf("1", "one")
-                ),
-                SearchableSelectOption(
-                    value = "2",
-                    label = "2",
-                    searchTerms = listOf("2", "two")
-                ),
-                SearchableSelectOption(
-                    value = "3+",
-                    label = "3+",
-                    searchTerms = listOf("3+", "three or more", "three+", "many", "multiple")
-                )
-            )
-            defaultValue = "1"
-        }
-
-        listField("pros") {
-            label = "Pros"
-            itemLabel = "Advantage"
-            helpText = "List of advantages"
-        }
-
-        listField("cons") {
-            label = "Cons"
-            itemLabel = "Disadvantage"
-            helpText = "List of disadvantages"
-        }
-
-        booleanField("directional") {
-            label = "Directional"
-            filterable = true
-            defaultValue = false
-            helpText = "Must face a specific direction"
-        }
-
-        booleanField("locational") {
-            label = "Locational"
-            filterable = true
-            defaultValue = false
-            helpText = "Must be built in a specific location type"
-        }
-
-        // Tree farm subcategory
-        subcategory("treeFarm") {
-            multiSelectField("treeTypes") {
-                label = "Tree Types"
-                filterable = true
-                required = true
-                options = listOf(
-                    "Warped", "Crimson", "Birch", "Oak", "Dark Oak",
-                    "Spruce", "Cherry", "Azalea", "Jungle", "Acacia",
-                    "Brown Mushrooms", "Red Mushrooms", "Mangrove"
-                )
-            }
-        }
+        specs()
+        references()
     }
 
     val STORAGE = ideaCategory(IdeaCategory.STORAGE) {
-        // Complete storage systems
-        subcategory("completeSystem") {
-            percentageField("hopperLockPercentage") {
-                label = "Hopper Lock Percentage"
-                filterable = true
-            }
-
-            numberField("idleMspt") {
-                label = "Idle MSPT Usage"
-                filterable = true
-                min = 0.0
-                helpText = "Milliseconds per tick when idle"
-            }
-
-            numberField("activeMspt") {
-                label = "Active MSPT Usage"
-                filterable = true
-                min = 0.0
-                helpText = "Milliseconds per tick when active"
-            }
-
-            rateField("inputSpeed") {
-                label = "Input Speed"
-                filterable = true
-                unit = "items/hour"
-            }
-
-            numberField("inputBufferSize") {
-                label = "Input Buffer Size"
-                filterable = true
-                min = 0.0
-            }
-
-            numberField("chestHallSpaceItemAmount") {
-                label = "Chest Hall Space Item Amount"
-                filterable = true
-            }
-
-            numberField("chestHallSpacePerItem") {
-                label = "Chest Hall Space Per Item"
-                filterable = true
-            }
-
-            numberField("bulkItemAmount") {
-                label = "Bulk Item Amount"
-                filterable = true
-            }
-
-            numberField("bulkSpacePerItem") {
-                label = "Bulk Space Per Item"
-                filterable = true
-            }
-
-            numberField("multiItemCategories") {
-                label = "Multi Item Categories"
-                filterable = true
-            }
-
-            booleanField("unstackableSorter") {
-                label = "Unstackable Sorter"
-                filterable = true
-            }
-
-            booleanField("parallelUnloader") {
-                label = "Parallel Unloader"
-                filterable = true
-            }
-
-            multiSelectField("peripherals") {
-                label = "Peripherals"
-                filterable = true
-                options = listOf(
-                    "Furnace Array", "Crafting Station", "Nano Farms",
-                    "Auto-Smelting", "Auto-Crafting", "Potion Station"
-                )
-            }
-
-            booleanField("debugHelp") {
-                label = "Debug Help"
-                filterable = true
-                helpText = "Includes debugging features"
-            }
+        selectField("storageType") {
+            label = "Storage Type"
+            filterable = true
+            options = listOf(
+                SearchableSelectOption(value = "complete_system", label = "Complete System"),
+                SearchableSelectOption(value = "box_loader", label = "Box Loader"),
+                SearchableSelectOption(value = "box_unloader", label = "Box Unloader"),
+                SearchableSelectOption(value = "box_sorter", label = "Box Sorter"),
+                SearchableSelectOption(value = "item_transport", label = "Item Transport"),
+                SearchableSelectOption(value = "fixed_item_sorter", label = "Fixed Item Sorter"),
+                SearchableSelectOption(value = "multi_item_sorter", label = "Multi Item Sorter"),
+                SearchableSelectOption(value = "unstackable_sorter", label = "Unstackable Sorter"),
+                SearchableSelectOption(value = "chest_hall", label = "Chest Hall"),
+                SearchableSelectOption(value = "bulk_storage", label = "Bulk Storage"),
+                SearchableSelectOption(value = "temporary_storage", label = "Temporary Storage"),
+                SearchableSelectOption(value = "peripheral", label = "Peripheral"),
+                SearchableSelectOption(value = "other", label = "Other"),
+            )
         }
 
-        // Box loader
-        subcategory("boxLoader") {
+        sizeField()
+        tileable()
+        directional()
 
-
-            booleanField("noToggle") {
-                label = "No Toggle"
-                filterable = true
-            }
-
-            booleanField("noBuffer") {
-                label = "No Buffer"
-                filterable = true
-            }
-
-            numberField("prefillNeeded") {
-                label = "Prefill Needed"
-                filterable = true
-                min = 0.0
-            }
-
-            rateField("speed") {
-                label = "Speed"
-                filterable = true
-                unit = "items/hour"
-            }
-        }
-
-        // Box unloader
-        subcategory("boxUnloader") {
-            rateField("speed") {
-                label = "Speed"
-                filterable = true
-                unit = "items/hour"
-            }
-        }
-
-        // Box sorters
-        subcategory("boxSorter") {
-            tileability()
-
-            rateField("speed") {
-                label = "Speed"
-                filterable = true
-                unit = "items/hour"
-            }
-
-            percentageField("lockedHoppers") {
-                label = "Locked Hoppers Percentage"
-                filterable = true
-            }
-        }
-
-        // Item transport
-        subcategory("itemTransport") {
-            textField("type") {
-                label = "Transport Type"
-                searchable = true
-                required = true
-                helpText = "E.g., Aligner, Instant downward dropper, etc."
-            }
-        }
-
-        // Fixed item sorters
-        subcategory("fixedItemSorter") {
-            rateField("speed") {
-                label = "Speed"
-                filterable = true
-                unit = "items/hour"
-            }
-
-            tileability()
-        }
-
-        // Multi item sorter
-        subcategory("multiItemSorter") {
-            numberField("amountPerSlice") {
-                label = "Amount Per Slice"
-                filterable = true
-            }
-
-            booleanField("compatible64_16") {
-                label = "64/16 Compatible"
-                filterable = true
-            }
-
-            rateField("speed") {
-                label = "Speed"
-                filterable = true
-                unit = "items/hour"
-            }
-        }
-
-        // Unstackable sorter
-        subcategory("unstackableSorter") {
-            textField("whatItSorts") {
-                label = "What It Sorts"
-                searchable = true
-                required = true
-            }
-        }
-
-        // Chest hall
-        subcategory("chestHall") {
-            numberField("hoppersPerSlice") {
-                label = "Hoppers Per Slice"
-                filterable = true
-            }
-
-            percentageField("lockedPercentage") {
-                label = "Locked Percentage"
-                filterable = true
-            }
-
-            numberField("capacityForItemType") {
-                label = "Capacity For Item Type"
-                filterable = true
-            }
-
-            numberField("prefillAmount") {
-                label = "Prefill Amount"
-                filterable = true
-            }
-
-            numberField("itemTypesPerSlice") {
-                label = "Item Types Per Slice"
-                filterable = true
-            }
-        }
-
-        // Bulk storage
-        subcategory("bulkStorage") {
-            percentageField("hopperLock") {
-                label = "Hopper Lock Percentage"
-                filterable = true
-            }
-
-            numberField("capacity") {
-                label = "Capacity"
-                filterable = true
-            }
-
-            numberField("buffer") {
-                label = "Buffer"
-                filterable = true
-            }
-        }
-
-        // Temporary storage
-        subcategory("temporaryStorage") {
-            numberField("capacity") {
-                label = "Capacity"
-                filterable = true
-            }
-
-            percentageField("lockPercentage") {
-                label = "Lock Percentage"
-                filterable = true
-            }
-        }
-
-        // Peripherals
-        subcategory("peripheral") {
-            textField("type") {
-                label = "Peripheral Type"
-                searchable = true
-                required = true
-                helpText = "E.g., crafting, smelting, brewing, etc."
-            }
-        }
+        specs()
+        references()
     }
 
     val CART_TECH = ideaCategory(IdeaCategory.CART_TECH) {
@@ -577,316 +147,74 @@ object IdeaCategorySchemas {
             filterable = true
             required = true
             options = listOf(
-                SearchableSelectOption(
-                    value = "storage",
-                    label = "Storage",
-                ),
-                SearchableSelectOption(
-                    value = "transport",
-                    label = "Transport",
-                ),
-                SearchableSelectOption(
-                    value = "computational",
-                    label = "Computational",
-                ),
-                SearchableSelectOption(
-                    value = "farm_collection",
-                    label = "Farm Collection",
-                ),
-                SearchableSelectOption(
-                    value = "furnace_arrays",
-                    label = "Furnace Arrays",
-                ),
-                SearchableSelectOption(
-                    value = "item_whitelisters",
-                    label = "Item Whitelisters",
-                ),
-                SearchableSelectOption(
-                    value = "loading_unloading",
-                    label = "Loading/Unloading",
-                ),
-                SearchableSelectOption(
-                    value = "stackers_unstackers",
-                    label = "Stackers and Unstackers",
-                ),
-                SearchableSelectOption(
-                    value = "stationary",
-                    label = "Stationary",
-                ),
-                SearchableSelectOption(
-                    value = "villagers_plus_plus",
-                    label = "Villagers++",
-                ),
-                SearchableSelectOption(
-                    value = "other",
-                    label = "Other",
-                )
+                SearchableSelectOption(value = "storage", label = "Storage"),
+                SearchableSelectOption(value = "transport", label = "Transport"),
+                SearchableSelectOption(value = "computational", label = "Computational"),
+                SearchableSelectOption(value = "farm_collection", label = "Farm Collection"),
+                SearchableSelectOption(value = "furnace_arrays", label = "Furnace Arrays"),
+                SearchableSelectOption(value = "item_whitelisters", label = "Item Whitelisters"),
+                SearchableSelectOption(value = "loading_unloading", label = "Loading/Unloading"),
+                SearchableSelectOption(value = "stackers_unstackers", label = "Stackers and Unstackers"),
+                SearchableSelectOption(value = "stationary", label = "Stationary"),
+                SearchableSelectOption(value = "villagers_plus_plus", label = "Villagers++"),
+                SearchableSelectOption(value = "other", label = "Other"),
             )
         }
 
-        textField("description") {
-            label = "Description"
-            searchable = true
-            multiline = true
-            required = true
-        }
+        sizeField()
+        tileable()
+        directional()
+
+        specs()
+        references()
     }
 
     val TNT = ideaCategory(IdeaCategory.TNT) {
-        // TNT Dupers
-        subcategory("tntDuper") {
-            booleanField("movable") {
-                label = "Movable"
-                filterable = true
-            }
-
-            booleanField("flatNotYTileable") {
-                label = "Flat / Not Y Tileable"
-                filterable = true
-            }
-
-            numberField("amountOfTnt") {
-                label = "Amount of TNT"
-                filterable = true
-                min = 1.0
-            }
-
-            numberField("delayClock") {
-                label = "Delay Clock (ticks)"
-                filterable = true
-                min = 0.0
-            }
-
-            numberField("stackSize") {
-                label = "Stack Size"
-                filterable = true
-                min = 1.0
-            }
-        }
-
-        // TNT Compressors
-        subcategory("tntCompressor") {
-            numberField("amountOfTnt") {
-                label = "Amount of TNT"
-                filterable = true
-                required = true
-                min = 1.0
-            }
-        }
-
-        // Other TNT types
         selectField("tntType") {
             label = "TNT Type"
             filterable = true
             options = listOf(
-                SearchableSelectOption(
-                    value = "tnt_duper",
-                    label = "TNT Duper",
-                ),
-                SearchableSelectOption(
-                    value = "tnt_compressor",
-                    label = "TNT Compressor",
-                ),
-                SearchableSelectOption(
-                    value = "transport_cannon",
-                    label = "Transport Cannon",
-                ),
-                SearchableSelectOption(
-                    value = "digging_cannon",
-                    label = "Digging Cannon",
-                ),
-                SearchableSelectOption(
-                    value = "arrow_cannon",
-                    label = "Arrow Cannon",
-                ),
-                SearchableSelectOption(
-                    value = "weaponry",
-                    label = "Weaponry",
-                ),
-                SearchableSelectOption(
-                    value = "other",
-                    label = "Other",
-                )
+                SearchableSelectOption(value = "tnt_duper", label = "TNT Duper"),
+                SearchableSelectOption(value = "tnt_compressor", label = "TNT Compressor"),
+                SearchableSelectOption(value = "transport_cannon", label = "Transport Cannon"),
+                SearchableSelectOption(value = "digging_cannon", label = "Digging Cannon"),
+                SearchableSelectOption(value = "arrow_cannon", label = "Arrow Cannon"),
+                SearchableSelectOption(value = "weaponry", label = "Weaponry"),
+                SearchableSelectOption(value = "other", label = "Other"),
             )
         }
 
-        textField("description") {
-            label = "Description"
-            searchable = true
-            multiline = true
-        }
+        sizeField()
+        tileable()
+        directional()
+
+        specs()
+        references()
     }
 
     val SLIMESTONE = ideaCategory(IdeaCategory.SLIMESTONE) {
-        // Engine
-        subcategory("engine") {
-            numberField("directions") {
-                label = "Directions (1-4)"
-                filterable = true
-                min = 1.0
-                max = 4.0
-                helpText = "Number of directions the engine can move"
-            }
-
-            numberField("gtEngine") {
-                label = "GT Engine"
-                filterable = true
-                helpText = "Game tick engine count"
-            }
-        }
-
-        // 1-way extensions
-        subcategory("oneWayExtension") {
-            numberField("timings") {
-                label = "Timings"
-                filterable = true
-            }
-
-            numberField("gameTicks") {
-                label = "Game Ticks"
-                filterable = true
-            }
-        }
-
-        // 2-way extensions
-        subcategory("twoWayExtension") {
-            numberField("timings") {
-                label = "Timings"
-                filterable = true
-            }
-        }
-
-        // Return station
-        subcategory("returnStation") {
-            numberField("directions") {
-                label = "Directions (1-3)"
-                filterable = true
-                min = 1.0
-                max = 3.0
-            }
-        }
-
-        // Quarry
-        subcategory("quarry") {
-            numberField("speedPerSlice") {
-                label = "Speed Per Slice (minutes)"
-                filterable = true
-                min = 0.0
-                suffix = "minutes"
-            }
-
-            percentageField("collectionRate") {
-                label = "Collection Rate"
-                filterable = true
-                helpText = "Percentage of items collected"
-            }
-
-            numberField("trenchesUnder") {
-                label = "Trenches Under"
-                filterable = true
-            }
-
-            numberField("trenchesSide") {
-                label = "Trenches Side"
-                filterable = true
-            }
-
-            numberField("trenchesMain") {
-                label = "Trenches Main"
-                filterable = true
-            }
-        }
-
-        // Trenchers
-        subcategory("trencher") {
-            numberField("width") {
-                label = "Width"
-                filterable = true
-                required = true
-            }
-        }
-
-        // World Eater
-        subcategory("worldEater") {
-            numberField("mainTrenches") {
-                label = "Main Trenches"
-                filterable = true
-                required = true
-            }
-
-            numberField("sideTrenches") {
-                label = "Side Trenches"
-                filterable = true
-                required = true
-            }
-
-            booleanField("handlesAncientDebris") {
-                label = "Handles Ancient Debris"
-                filterable = true
-            }
-        }
-
-        // Bedrock breaker
-        subcategory("bedrockBreaker") {
-            booleanField("overhead") {
-                label = "Overhead"
-                filterable = true
-            }
-
-            booleanField("lossless") {
-                label = "Lossless"
-                filterable = true
-            }
-        }
-
         selectField("slimestoneType") {
             label = "Slimestone Type"
             filterable = true
             options = listOf(
-                SearchableSelectOption(
-                    value = "engine",
-                    label = "Engine",
-                ),
-                SearchableSelectOption(
-                    value = "one_way_extension",
-                    label = "1-Way Extension",
-                ),
-                SearchableSelectOption(
-                    value = "two_way_extension",
-                    label = "2-Way Extension",
-                ),
-                SearchableSelectOption(
-                    value = "return_station",
-                    label = "Return Station",
-                ),
-                SearchableSelectOption(
-                    value = "quarry",
-                    label = "Quarry",
-                ),
-                SearchableSelectOption(
-                    value = "trencher",
-                    label = "Trencher",
-                ),
-                SearchableSelectOption(
-                    value = "world_eater",
-                    label = "World Eater",
-                ),
-                SearchableSelectOption(
-                    value = "bedrock_breaker",
-                    label = "Bedrock Breaker",
-                ),
-                SearchableSelectOption(
-                    value = "other",
-                    label = "Other",
-                )
+                SearchableSelectOption(value = "engine", label = "Engine"),
+                SearchableSelectOption(value = "one_way_extension", label = "1-Way Extension"),
+                SearchableSelectOption(value = "two_way_extension", label = "2-Way Extension"),
+                SearchableSelectOption(value = "return_station", label = "Return Station"),
+                SearchableSelectOption(value = "quarry", label = "Quarry"),
+                SearchableSelectOption(value = "trencher", label = "Trencher"),
+                SearchableSelectOption(value = "world_eater", label = "World Eater"),
+                SearchableSelectOption(value = "bedrock_breaker", label = "Bedrock Breaker"),
+                SearchableSelectOption(value = "other", label = "Other"),
             )
         }
 
-        textField("description") {
-            label = "Description"
-            searchable = true
-            multiline = true
-        }
+        sizeField()
+        tileable()
+        directional()
+
+        specs()
+        references()
     }
 
     val OTHER = ideaCategory(IdeaCategory.OTHER) {
@@ -894,63 +222,21 @@ object IdeaCategorySchemas {
             label = "Contraption Type"
             filterable = true
             options = listOf(
-                SearchableSelectOption(
-                    value = "entity_transport",
-                    label = "Entity Transport",
-                ),
-                SearchableSelectOption(
-                    value = "furnaces",
-                    label = "Furnaces",
-                ),
-                SearchableSelectOption(
-                    value = "brewers",
-                    label = "Brewers",
-                ),
-                SearchableSelectOption(
-                    value = "instant_wires",
-                    label = "Instant Wires",
-                ),
-                SearchableSelectOption(
-                    value = "logic_computation",
-                    label = "Logic Computation",
-                ),
-                SearchableSelectOption(
-                    value = "other",
-                    label = "Other",
-                )
+                SearchableSelectOption(value = "entity_transport", label = "Entity Transport"),
+                SearchableSelectOption(value = "furnaces", label = "Furnaces"),
+                SearchableSelectOption(value = "brewers", label = "Brewers"),
+                SearchableSelectOption(value = "instant_wires", label = "Instant Wires"),
+                SearchableSelectOption(value = "logic_computation", label = "Logic Computation"),
+                SearchableSelectOption(value = "other", label = "Other"),
             )
         }
 
-        // Furnaces
-        numberField("furnaceAmount") {
-            label = "Amount of Furnaces"
-            filterable = true
-            min = 1.0
-        }
+        sizeField()
+        tileable()
+        directional()
 
-        // Brewers
-        numberField("brewingSpeed") {
-            label = "Brewing Speed"
-            filterable = true
-            helpText = "Potions per hour or similar metric"
-        }
-
-        textField("purpose") {
-            label = "Purpose"
-            searchable = true
-            required = true
-            multiline = true
-            helpText = "Describe what this contraption does"
-        }
-
-        multiSelectField("tags") {
-            label = "Custom Tags"
-            filterable = true
-            options = listOf(
-                "Decoration", "Redstone", "Command Blocks", "Data Packs",
-                "Aesthetics", "Utility", "Experiment", "Proof of Concept"
-            )
-        }
+        specs()
+        references()
     }
 
     val BUILD = ideaCategory(IdeaCategory.BUILD) {
@@ -960,30 +246,12 @@ object IdeaCategorySchemas {
             label = "Build Style"
             filterable = true
             options = listOf(
-                SearchableSelectOption(
-                    value = "modern",
-                    label = "Modern",
-                ),
-                SearchableSelectOption(
-                    value = "medieval",
-                    label = "Medieval",
-                ),
-                SearchableSelectOption(
-                    value = "fantasy",
-                    label = "Fantasy",
-                ),
-                SearchableSelectOption(
-                    value = "rustic",
-                    label = "Rustic",
-                ),
-                SearchableSelectOption(
-                    value = "industrial",
-                    label = "Industrial",
-                ),
-                SearchableSelectOption(
-                    value = "other",
-                    label = "Other",
-                )
+                SearchableSelectOption(value = "modern", label = "Modern"),
+                SearchableSelectOption(value = "medieval", label = "Medieval"),
+                SearchableSelectOption(value = "fantasy", label = "Fantasy"),
+                SearchableSelectOption(value = "rustic", label = "Rustic"),
+                SearchableSelectOption(value = "industrial", label = "Industrial"),
+                SearchableSelectOption(value = "other", label = "Other"),
             )
         }
 
@@ -995,6 +263,9 @@ object IdeaCategorySchemas {
                 "Metal", "Prismarine", "Nether Materials", "End Materials", "Other"
             )
         }
+
+        specs()
+        references()
     }
 
     // Schema registry
@@ -1013,4 +284,3 @@ object IdeaCategorySchemas {
 
     fun getAllSchemas(): Map<IdeaCategory, IdeaCategorySchema> = schemas
 }
-

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/domain/idea/schema/builders/IdeaCategorySchemaBuilder.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/domain/idea/schema/builders/IdeaCategorySchemaBuilder.kt
@@ -10,7 +10,6 @@ import app.mcorg.domain.model.idea.schema.IdeaCategorySchema
  */
 class IdeaCategorySchemaBuilder(private val category: IdeaCategory) {
     private val fields = mutableListOf<CategoryField>()
-    private val subcategories = mutableMapOf<String, MutableList<CategoryField>>()
 
     fun textField(key: String, block: TextFieldBuilder.() -> Unit = {}) {
         fields += TextFieldBuilder(key).apply(block).build()
@@ -48,48 +47,7 @@ class IdeaCategorySchemaBuilder(private val category: IdeaCategory) {
         fields += PercentageFieldBuilder(key).apply(block).build()
     }
 
-    /**
-     * Define a subcategory with its own fields
-     */
-    fun subcategory(name: String, block: SubcategoryBuilder.() -> Unit) {
-        val builder = SubcategoryBuilder(name)
-        builder.apply(block)
-        subcategories[name] = builder.fields
-    }
-
-    fun build() = IdeaCategorySchema(category, fields, subcategories)
-}
-
-/**
- * Builder for subcategories within a category
- */
-@Suppress("unused")
-class SubcategoryBuilder(val name: String) {
-    internal val fields = mutableListOf<CategoryField>()
-
-    fun textField(key: String, block: TextFieldBuilder.() -> Unit = {}) {
-        fields += TextFieldBuilder(key).apply(block).build()
-    }
-
-    fun numberField(key: String, block: NumberFieldBuilder.() -> Unit = {}) {
-        fields += NumberFieldBuilder(key).apply(block).build()
-    }
-
-    fun selectField(key: String, block: SelectFieldBuilder.() -> Unit) {
-        fields += SelectFieldBuilder(key).apply(block).build()
-    }
-
-    fun multiSelectField(key: String, block: MultiSelectFieldBuilder.() -> Unit) {
-        fields += MultiSelectFieldBuilder(key).apply(block).build()
-    }
-
-    fun booleanField(key: String, block: BooleanFieldBuilder.() -> Unit = {}) {
-        fields += BooleanFieldBuilder(key).apply(block).build()
-    }
-
-    fun rateField(key: String, block: RateFieldBuilder.() -> Unit = {}) {
-        fields += RateFieldBuilder(key).apply(block).build()
-    }
+    fun build() = IdeaCategorySchema(category, fields)
 }
 
 /**

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/IdeaSqlBuilder.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/IdeaSqlBuilder.kt
@@ -13,7 +13,7 @@ object IdeaSqlBuilder {
      */
     private val ALLOWED_CATEGORY_FIELD_KEYS: Set<String> by lazy {
         IdeaCategorySchemas.getAllSchemas().values
-            .flatMap { schema -> schema.getAllFields().map { it.key } }
+            .flatMap { schema -> schema.fields.map { it.key } }
             .toSet()
     }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/createfragments/GetCreateCategoryFieldsFragmentPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/createfragments/GetCreateCategoryFieldsFragmentPipeline.kt
@@ -12,10 +12,11 @@ import kotlinx.html.*
 import kotlinx.html.stream.createHTML
 
 suspend fun ApplicationCall.handleGetCreateCategoryFields() {
-    val categoryParam = request.queryParameters["category"]?.uppercase() ?: run {
+    // The category is a path parameter (/ideas/create/fields/{category}), so read it off the
+    // merged parameters — request.queryParameters never sees it.
+    val categoryParam = parameters["category"]?.uppercase() ?: run {
         respondHtml(createHTML().div {
-            p("subtle") {
-                style = "text-align: center;"
+            p("subtle wizard-field-placeholder") {
                 +"Select a category to see specific fields"
             }
         })
@@ -30,27 +31,25 @@ suspend fun ApplicationCall.handleGetCreateCategoryFields() {
         respondHtml(createHTML().div {
             classes += "stack stack--sm"
 
-            // Render all fields from the schema (not just filterable ones)
             schema.fields.forEach { field ->
                 renderCreateField(versionRange, field)
             }
 
-            // If no fields exist
             if (schema.fields.isEmpty()) {
-                p("subtle") {
-                    style = "text-align: center;"
+                p("subtle wizard-field-placeholder") {
                     +"No additional fields for this category"
                 }
             }
-        } + createHTML().p {
+        } + createHTML().p("form-error") {
+            // Clears any "Category is required" error now that one is picked. The id must match
+            // the paragraph draftCategoryFields renders, or HTMX drops the swap with oobErrorNoTarget.
             hxOutOfBands("true")
-            id = "validation-error-category"
+            id = "error-category"
         })
     } catch (_: IllegalArgumentException) {
         // Invalid category name
         respondHtml(createHTML().div {
-            p("subtle") {
-                style = "text-align: center;"
+            p("subtle wizard-field-placeholder") {
                 +"Invalid category"
             }
         })

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
@@ -357,7 +357,31 @@ private fun extractCategoryValue(field: CategoryField, params: Parameters, param
         }
         if (subMap.isNotEmpty()) CategoryValue.MapValue(subMap) else null
     }
-    is CategoryField.TypedMapField -> null
+    /**
+     * Rows arrive as parallel `key[]` / `value[]` arrays, matching the names
+     * [CategoryField.getCompleteKey] renders. A row is kept only when both sides are filled —
+     * the form always carries one blank row, and half a row is not an entry.
+     *
+     * Nested typed maps (a map whose value is itself a map) submit no `value[]` at this level,
+     * so they fall out as empty. No schema uses one today; reintroducing one means recursing here.
+     */
+    is CategoryField.TypedMapField -> {
+        val keys = params.getAll("$paramPrefix.key[]").orEmpty()
+        val values = params.getAll("$paramPrefix.value[]").orEmpty()
+        val entries = mutableMapOf<String, CategoryValue>()
+        keys.forEachIndexed { index, key ->
+            val raw = values.getOrNull(index)
+            if (key.isNotBlank() && !raw.isNullOrBlank()) {
+                val value = when (field.valueType) {
+                    is CategoryField.Number, is CategoryField.Rate, is CategoryField.Percentage ->
+                        raw.toIntOrNull()?.let { CategoryValue.IntValue(it) }
+                    else -> CategoryValue.TextValue(raw)
+                }
+                value?.let { entries[key] = it }
+            }
+        }
+        if (entries.isNotEmpty()) CategoryValue.MapValue(entries) else null
+    }
 }
 
 private fun mergeStageIntoDraft(draft: app.mcorg.domain.model.idea.IdeaDraft, stageJson: String): app.mcorg.domain.model.idea.IdeaDraft {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaCategoryDataStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaCategoryDataStep.kt
@@ -206,7 +206,9 @@ data class ValidateIdeaCategoryDataStep(private val category: IdeaCategory): Ste
                 is Result.Success -> {
                     when (valueResult) {
                         is Result.Success -> {
-                            if (keyResult.value !is CategoryValue.IgnoredValue) {
+                            // A key with no value is not an entry — and IgnoredValue has no
+                            // serial form, so storing it would blow up on write.
+                            if (keyResult.value !is CategoryValue.IgnoredValue && valueResult.value !is CategoryValue.IgnoredValue) {
                                 map[keys[i]] = valueResult.value
                             }
                         }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/IdeaCreateFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/IdeaCreateFields.kt
@@ -6,6 +6,7 @@ import app.mcorg.domain.model.minecraft.MinecraftVersionRange
 import app.mcorg.presentation.templated.dsl.iconButton
 import app.mcorg.presentation.templated.dsl.IconSize
 import app.mcorg.presentation.templated.dsl.Icons
+import kotlinx.html.ButtonType
 import kotlinx.html.DIV
 import kotlinx.html.InputType
 import kotlinx.html.classes
@@ -306,9 +307,15 @@ fun DIV.renderCreatePercentageField(field: CategoryField.Percentage, value: Cate
 }
 
 /**
- * Renders a map field (key-value pairs)
+ * Renders a map field (key-value pairs).
+ *
+ * Rows are added client-side by cloning the last row and blanking its inputs, rather than
+ * rendering a hidden `<template>` — a template would render every option of a dynamic select
+ * (e.g. the item list on a farm's production rate) a second time on every page load.
  */
 fun DIV.renderCreateTypedMapField(versionRange: MinecraftVersionRange, field: CategoryField.TypedMapField, values: CategoryValue.MapValue? = null) {
+    val containerId = "map-${field.key}"
+
     label {
         +field.label
         if (field.required) {
@@ -321,29 +328,52 @@ fun DIV.renderCreateTypedMapField(versionRange: MinecraftVersionRange, field: Ca
         }
     }
     div("map-field-container stack stack--xs") {
-        id = "map-${field.key}"
-        if (values != null && values.value.isNotEmpty()) {
-            values.value.forEach { (k, v) ->
-                div("cluster cluster--xs map-field-row") {
-                    renderCreateField(versionRange, field.keyType, CategoryValue.TextValue(k))
-                    renderCreateField(versionRange, field.valueType, v)
-                    iconButton(Icons.DELETE, "Remove Entry") {
-                        iconSize = IconSize.SMALL
-                        onClick = "this.closest('.map-field-row').remove(); return false;"
-                    }
-                }
-            }
+        id = containerId
+        values?.value?.forEach { (k, v) ->
+            mapFieldRow(versionRange, field, CategoryValue.TextValue(k), v)
         }
-        div("cluster cluster--xs map-field-row") {
-            renderCreateField(versionRange, field.keyType)
-            renderCreateField(versionRange, field.valueType)
-            iconButton(Icons.MENU_ADD, "Add Entry") {
-                iconSize = IconSize.SMALL
-                onClick = "alert('Not implemented yet'); return false;"
-            }
+        // Always leave one blank row so the field is usable without clicking "Add entry" first.
+        mapFieldRow(versionRange, field)
+    }
+    div("map-field-actions") {
+        iconButton(Icons.MENU_ADD, "Add Entry") {
+            iconSize = IconSize.SMALL
+            buttonBlock = { type = ButtonType.button }
+            onClick = addMapRowScript(containerId)
         }
     }
 }
+
+private fun DIV.mapFieldRow(
+    versionRange: MinecraftVersionRange,
+    field: CategoryField.TypedMapField,
+    key: CategoryValue? = null,
+    value: CategoryValue? = null,
+) {
+    div("cluster cluster--xs map-field-row") {
+        div("map-field-cell") { renderCreateField(versionRange, field.keyType, key) }
+        div("map-field-cell") { renderCreateField(versionRange, field.valueType, value) }
+        iconButton(Icons.DELETE, "Remove Entry") {
+            iconSize = IconSize.SMALL
+            buttonBlock = { type = ButtonType.button }
+            onClick = "this.closest('.map-field-row').remove(); return false;"
+        }
+    }
+}
+
+private fun addMapRowScript(containerId: String) = """
+    var container = document.getElementById('$containerId');
+    var last = container.lastElementChild;
+    if (!last) return false;
+    var row = last.cloneNode(true);
+    row.querySelectorAll('[id]').forEach(function (el) { el.removeAttribute('id'); });
+    row.querySelectorAll('input, textarea').forEach(function (el) {
+        if (el.type === 'checkbox' || el.type === 'radio') { el.checked = false; } else { el.value = ''; }
+    });
+    row.querySelectorAll('select').forEach(function (el) { el.selectedIndex = 0; });
+    container.appendChild(row);
+    return false;
+""".trimIndent().replace("\n", " ")
 
 fun DIV.renderCreateStructField(versionRange: MinecraftVersionRange, field: CategoryField.StructField, values: CategoryValue.MapValue? = null) {
     field.fields.forEach { subField ->

--- a/webapp/mc-web/src/main/resources/db/migration/V2_51_0__slim_idea_category_data.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_51_0__slim_idea_category_data.sql
@@ -1,0 +1,19 @@
+-- Migration V2_51_0: Slim the idea category schema (MCO-204)
+--
+-- The per-category schemas dropped their long tail of speculative typed fields (~20 FARM
+-- fields, 12 STORAGE subcategories, 8 SLIMESTONE subcategories, TNT duper/compressor blocks)
+-- in favour of a free-form `specs` label -> value block. Anything still stored under a
+-- retired key would fail schema lookup on render and be silently skipped.
+--
+-- There is no production idea data worth preserving, so this clears category data outright
+-- rather than attempting to fold retired keys into `specs`.
+
+UPDATE ideas
+SET category_data = '{}'::jsonb
+WHERE category_data IS NOT NULL
+  AND category_data <> '{}'::jsonb;
+
+-- In-progress drafts carry the same shape under data->'categoryData'.
+UPDATE idea_drafts
+SET data = data - 'categoryData'
+WHERE data ? 'categoryData';

--- a/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
@@ -195,6 +195,35 @@
     margin-top: var(--space-4);
 }
 
+.wizard-field-placeholder {
+    text-align: center;
+}
+
+/* --- Free-form key/value fields (specs, production rate) --- */
+
+.map-field-container {
+    margin-top: var(--space-2);
+}
+
+.map-field-row {
+    align-items: flex-end;
+}
+
+.map-field-cell {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 0;
+    min-width: 0;
+}
+
+.map-field-row .btn--icon-only {
+    flex: 0 0 auto;
+}
+
+.map-field-actions {
+    margin-top: var(--space-2);
+}
+
 /* --- Review stage --- */
 
 .review-row {

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/GetIdeasByCategoryStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/GetIdeasByCategoryStepTest.kt
@@ -146,6 +146,11 @@ class GetIdeasByCategoryStepTest : WithUser() {
         assertEquals("AFK Iron Farm", result.value.items.first().name)
     }
 
+    /**
+     * The slim schema has no filterable numeric field yet — a numeric spec gets promoted to one
+     * once real submissions justify it. This covers the SQL builder's range branch in the
+     * meantime, using a schema key that holds a scalar here.
+     */
     @Test
     fun `should filter by number range in category field`() = runBlocking {
         // Given: Farm ideas with different production rates
@@ -180,85 +185,85 @@ class GetIdeasByCategoryStepTest : WithUser() {
 
     @Test
     fun `should filter by select field`() = runBlocking {
-        // Given: Farm ideas with different player requirements
+        // Given: Storage ideas of different types
         createTestIdea(
-            name = "Auto Farm",
-            category = IdeaCategory.FARM,
-            categoryData = """{"playersRequired": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.TextValue", "value": "0"}}"""
+            name = "Chest Hall",
+            category = IdeaCategory.STORAGE,
+            categoryData = """{"storageType": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.TextValue", "value": "chest_hall"}}"""
         )
         createTestIdea(
-            name = "Solo Farm",
-            category = IdeaCategory.FARM,
-            categoryData =  """{"playersRequired": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.TextValue", "value": "1"}}"""
+            name = "Box Loader",
+            category = IdeaCategory.STORAGE,
+            categoryData =  """{"storageType": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.TextValue", "value": "box_loader"}}"""
         )
         createTestIdea(
-            name = "Co-op Farm",
-            category = IdeaCategory.FARM,
-            categoryData = """{"playersRequired": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.TextValue", "value": "2"}}"""
+            name = "Bulk Storage",
+            category = IdeaCategory.STORAGE,
+            categoryData = """{"storageType": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.TextValue", "value": "bulk_storage"}}"""
         )
 
-        // When: Filtering for single player farms
+        // When: Filtering for chest halls
         val filters = IdeaSearchFilters(
-            category = IdeaCategory.FARM,
-            categoryFilters = mapOf("playersRequired" to FilterValue.SelectValue("1"))
+            category = IdeaCategory.STORAGE,
+            categoryFilters = mapOf("storageType" to FilterValue.SelectValue("chest_hall"))
         )
         val result = SearchIdeasStep.process(filters)
 
-        // Then: Only solo farm returned
+        // Then: Only the chest hall returned
         assertTrue(result is Result.Success)
         assertEquals(1, result.value.items.size)
-        assertEquals("Solo Farm", result.value.items.first().name)
+        assertEquals("Chest Hall", result.value.items.first().name)
     }
 
     @Test
     fun `should filter by multi-select field`() = runBlocking {
-        // Given: Farm ideas with different biome compatibility
+        // Given: Builds using different materials
         createTestIdea(
-            name = "Plains Farm",
-            category = IdeaCategory.FARM,
-            categoryData = """{"biomes": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MultiSelectValue", "values": ["Plains", "Forest"]}}"""
+            name = "Stone Keep",
+            category = IdeaCategory.BUILD,
+            categoryData = """{"materials": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MultiSelectValue", "values": ["Stone", "Wood"]}}"""
         )
         createTestIdea(
-            name = "Desert Farm",
-            category = IdeaCategory.FARM,
-            categoryData = """{"biomes": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MultiSelectValue", "values": ["Desert", "Savanna"]}}"""
+            name = "Glass Tower",
+            category = IdeaCategory.BUILD,
+            categoryData = """{"materials": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MultiSelectValue", "values": ["Glass", "Metal"]}}"""
         )
         createTestIdea(
-            name = "Universal Farm",
-            category = IdeaCategory.FARM,
-            categoryData = """{"biomes": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MultiSelectValue", "values": ["Plains", "Desert", "Forest", "Savanna", "Jungle"]}}"""
+            name = "Mixed Villa",
+            category = IdeaCategory.BUILD,
+            categoryData = """{"materials": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MultiSelectValue", "values": ["Stone", "Glass", "Wood", "Metal", "Concrete"]}}"""
         )
 
-        // When: Filtering for farms that work in Plains or Desert
+        // When: Filtering for builds using stone or glass
         val filters = IdeaSearchFilters(
-            category = IdeaCategory.FARM,
-            categoryFilters = mapOf("biomes" to FilterValue.MultiSelectValue(listOf("Plains", "Desert")))
+            category = IdeaCategory.BUILD,
+            categoryFilters = mapOf("materials" to FilterValue.MultiSelectValue(listOf("Stone", "Glass")))
         )
         val result = SearchIdeasStep.process(filters)
 
-        // Then: All three farms returned (each contains at least one matching biome)
+        // Then: All three builds returned (each contains at least one matching material)
         assertTrue(result is Result.Success)
         assertEquals(3, result.value.items.size)
     }
 
     @Test
     fun `should filter by text field with case-insensitive search`() = runBlocking {
-        // Given: Storage ideas with different types
+        // Given: Storage ideas of different types
         createTestIdea(
             name = "Item Sorter A",
             category = IdeaCategory.STORAGE,
-            categoryData = """{"type": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.TextValue", "value": "sorter"}}"""
+            categoryData = """{"storageType": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.TextValue", "value": "fixed_item_sorter"}}"""
         )
         createTestIdea(
             name = "Box Loader",
             category = IdeaCategory.STORAGE,
-            categoryData = """{"type": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.TextValue", "value": "loader"}}"""
+            categoryData = """{"storageType": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.TextValue", "value": "box_loader"}}"""
         )
 
-        // When: Searching for "SORTER" (case-insensitive)
+        // When: Searching for "SORTER" (case-insensitive substring)
         val filters = IdeaSearchFilters(
             category = IdeaCategory.STORAGE,
-            categoryFilters = mapOf("type" to FilterValue.TextValue("sorter"))
+            categoryFilters = mapOf("storageType" to FilterValue.TextValue("SORTER"))
         )
         val result = SearchIdeasStep.process(filters)
 

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/IdeaFilterParserTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/IdeaFilterParserTest.kt
@@ -83,51 +83,53 @@ class IdeaFilterParserTest {
     }
 
     @Test
-    fun `parse number range category filter`() {
-        val params = parametersOf(
-            "category" to listOf("FARM"),
-            "categoryFilters[yLevel_min]" to listOf("-15"),
-            "categoryFilters[yLevel_max]" to listOf("120")
-        )
-        val filters = IdeaFilterParser.parse(params)
-
-        assertEquals(1, filters.categoryFilters.size)
-        val rateFilter = filters.categoryFilters["yLevel"]
-        assertTrue(rateFilter is FilterValue.NumberRange)
-        assertEquals(-15.0, rateFilter.min)
-        assertEquals(120.0, rateFilter.max)
-    }
-
-    @Test
     fun `parse select category filter`() {
         val params = parametersOf(
-            "category" to listOf("FARM"),
-            "categoryFilters[playersRequired]" to listOf("1")
+            "category" to listOf("STORAGE"),
+            "categoryFilters[storageType]" to listOf("chest_hall")
         )
         val filters = IdeaFilterParser.parse(params)
 
         assertEquals(1, filters.categoryFilters.size)
-        val playersFilter = filters.categoryFilters["playersRequired"]
-        assertTrue(playersFilter is FilterValue.SelectValue)
-        assertEquals("1", playersFilter.value)
+        val storageTypeFilter = filters.categoryFilters["storageType"]
+        assertTrue(storageTypeFilter is FilterValue.SelectValue)
+        assertEquals("chest_hall", storageTypeFilter.value)
     }
 
     @Test
     fun `parse multi-select category filter`() {
         val params = parametersOf(
-            "category" to listOf("FARM"),
-            "categoryFilters[biomes][]" to listOf("Plains", "Forest", "Desert")
+            "category" to listOf("BUILD"),
+            "categoryFilters[materials][]" to listOf("Stone", "Wood", "Glass")
         )
         val filters = IdeaFilterParser.parse(params)
 
         assertEquals(1, filters.categoryFilters.size)
-        val biomesFilter = filters.categoryFilters["biomes"]
-        assertTrue(biomesFilter is FilterValue.MultiSelectValue)
-        val values = biomesFilter.values
+        val materialsFilter = filters.categoryFilters["materials"]
+        assertTrue(materialsFilter is FilterValue.MultiSelectValue)
+        val values = materialsFilter.values
         assertEquals(3, values.size)
-        assertTrue(values.contains("Plains"))
-        assertTrue(values.contains("Forest"))
-        assertTrue(values.contains("Desert"))
+        assertTrue(values.contains("Stone"))
+        assertTrue(values.contains("Wood"))
+        assertTrue(values.contains("Glass"))
+    }
+
+    /**
+     * The slim schema (MCO-204) retired the speculative typed fields, so filters naming them
+     * must be dropped rather than passed through to the JSONB query.
+     */
+    @Test
+    fun `ignore filters for fields the schema no longer defines`() {
+        val params = parametersOf(
+            "category" to listOf("FARM"),
+            "categoryFilters[yLevel_min]" to listOf("-15"),
+            "categoryFilters[yLevel_max]" to listOf("120"),
+            "categoryFilters[playersRequired]" to listOf("1"),
+            "categoryFilters[biomes][]" to listOf("Plains")
+        )
+        val filters = IdeaFilterParser.parse(params)
+
+        assertTrue(filters.categoryFilters.isEmpty())
     }
 
     @Test
@@ -138,7 +140,7 @@ class IdeaFilterParserTest {
             "difficulty[]" to listOf("START_OF_GAME", "END_GAME"),
             "minRating" to listOf("4.0"),
             "categoryFilters[afkable]" to listOf("true"),
-            "categoryFilters[yLevel_min]" to listOf("64")
+            "categoryFilters[tileable]" to listOf("true")
         )
         val filters = IdeaFilterParser.parse(params)
 

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaCategoryDataStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaCategoryDataStepTest.kt
@@ -2,7 +2,6 @@ package app.mcorg.pipeline.idea.validators
 
 import app.mcorg.domain.model.idea.IdeaCategory
 import app.mcorg.domain.model.idea.schema.CategoryValue
-import app.mcorg.domain.model.idea.schema.IdeaCategorySchemas
 import app.mcorg.domain.model.minecraft.Item
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.failure.ValidationFailure
@@ -20,31 +19,17 @@ import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+/**
+ * Covers the slim category schema (MCO-204): a handful of filterable fields per category
+ * plus the free-form `specs` block. Nothing but the CART_TECH discriminator is required —
+ * import speed is the point.
+ */
 class ValidateIdeaCategoryDataStepTest {
 
-    private val requiredFarmFields = IdeaCategorySchemas.FARM.fields.count { it.required }
-
-    private fun createParameters(vararg pairs: Pair<String, List<String>>, type: IdeaCategory = IdeaCategory.FARM): Parameters {
+    private fun createParameters(vararg pairs: Pair<String, List<String>>): Parameters {
         val builder = ParametersBuilder()
         pairs.forEach { (key, values) ->
             values.forEach { value -> builder.append(key, value) }
-        }
-        if (type == IdeaCategory.FARM) {
-            if (!builder.build().contains("categoryData.size.x")) {
-                builder.append("categoryData.size.x", "16")
-            }
-            if (!builder.build().contains("categoryData.size.y")) {
-                builder.append("categoryData.size.y", "10")
-            }
-            if (!builder.build().contains("categoryData.size.z")) {
-                builder.append("categoryData.size.z", "16")
-            }
-            if (!builder.build().contains("categoryData.howToUse")) {
-                builder.append("categoryData.howToUse", "Default usage instructions")
-            }
-            if (!builder.build().contains("categoryData.playersRequired")) {
-                builder.append("categoryData.playersRequired", "1")
-            }
         }
         return builder.build()
     }
@@ -64,95 +49,269 @@ class ValidateIdeaCategoryDataStepTest {
         }
     }
 
+    // --- Booleans ---
+
     @Test
-    fun `text field with valid value returns success`() {
-        val params = createParameters(
-            "categoryData.farmVersion" to listOf("v3.2")
-        )
+    fun `boolean field with true returns success`() {
+        val params = createParameters("categoryData.afkable" to listOf("true"))
         val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
 
         val result = TestUtils.executeAndAssertSuccess(step, params)
 
-        assertEquals(CategoryValue.TextValue("v3.2"), result["farmVersion"])
+        assertEquals(CategoryValue.BooleanValue(true), result["afkable"])
     }
 
     @Test
-    fun `text field exceeding max length returns failure`() {
-        val longText = "a".repeat(1001)
-        val params = createParameters(
-            "categoryData.howToUse" to listOf(longText)
-        )
+    fun `boolean field with on returns success as true`() {
+        val params = createParameters("categoryData.tileable" to listOf("on"))
         val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
 
-        val result = TestUtils.executeAndAssertFailure(step, params)
-        assertTrue(result.any { it is ValidationFailure.InvalidFormat && it.parameterName == "categoryData.howToUse" })
+        val result = TestUtils.executeAndAssertSuccess(step, params)
+
+        assertEquals(CategoryValue.BooleanValue(true), result["tileable"])
     }
 
     @Test
-    fun `required text field missing returns failure`() {
-        val params = Parameters.Empty
+    fun `boolean field with invalid value returns failure`() {
+        val params = createParameters("categoryData.afkable" to listOf("maybe"))
         val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
 
         val result = TestUtils.executeAndAssertFailure(step, params)
 
         assertTrue(result.any {
-            it is ValidationFailure.MissingParameter && it.parameterName == "howToUse"
+            it is ValidationFailure.InvalidFormat && it.message?.contains("Boolean value expected") == true
         })
     }
 
-    @Test
-    fun `number field with valid integer returns success`() {
-        val params = createParameters(
-            "categoryData.yLevel" to listOf("64")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-
-        assertEquals(CategoryValue.IntValue(64), result["yLevel"])
-    }
-
-    @Test
-    fun `number field with non-integer returns failure`() {
-        val params = createParameters(
-            "categoryData.yLevel" to listOf("not-a-number")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertFailure(step, params)
-
-        assertTrue(result.any { it is ValidationFailure.InvalidFormat && it.parameterName == "categoryData.yLevel" })
-    }
-
-    @Test
-    fun `number field below minimum returns failure`() {
-        val params = createParameters(
-            "categoryData.yLevel" to listOf("-100")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertFailure(step, params)
-
-        assertTrue(result.any {
-            it is ValidationFailure.InvalidFormat && it.message?.contains("must be at least") == true
-        })
-    }
+    // --- Selects ---
 
     @Test
     fun `select field with valid option returns success`() {
-        val params = createParameters(
-            "categoryData.playersRequired" to listOf("1")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
+        val params = createParameters("categoryData.storageType" to listOf("chest_hall"))
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.STORAGE)
 
         val result = TestUtils.executeAndAssertSuccess(step, params)
-        assertEquals(CategoryValue.TextValue("1"), result["playersRequired"])
+
+        assertEquals(CategoryValue.TextValue("chest_hall"), result["storageType"])
     }
 
     @Test
     fun `select field with invalid option returns failure`() {
+        val params = createParameters("categoryData.storageType" to listOf("invalid-option"))
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.STORAGE)
+
+        val result = TestUtils.executeAndAssertFailure(step, params)
+
+        assertTrue(result.any {
+            it is ValidationFailure.InvalidFormat && it.message?.contains("Invalid option") == true
+        })
+    }
+
+    @Test
+    fun `required select missing returns failure`() {
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.CART_TECH)
+
+        val result = TestUtils.executeAndAssertFailure(step, Parameters.Empty)
+
+        assertEquals(1, result.size)
+        assertTrue(result.any {
+            it is ValidationFailure.MissingParameter && it.parameterName == "cartTechType"
+        })
+    }
+
+    // --- Multi-select ---
+
+    @Test
+    fun `multi-select field with valid options returns success`() {
+        val params = createParameters("categoryData.materials[]" to listOf("Stone", "Wood", "Glass"))
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.BUILD)
+
+        val result = TestUtils.executeAndAssertSuccess(step, params)
+
+        val materials = assertIs<CategoryValue.MultiSelectValue>(result["materials"]).values
+        assertEquals(setOf("Stone", "Wood", "Glass"), materials)
+    }
+
+    @Test
+    fun `multi-select field with invalid option returns failure`() {
+        val params = createParameters("categoryData.materials[]" to listOf("Stone", "Unobtanium"))
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.BUILD)
+
+        val result = TestUtils.executeAndAssertFailure(step, params)
+
+        assertTrue(result.any {
+            it is ValidationFailure.InvalidFormat && it.message?.contains("Invalid option for multi-select") == true
+        })
+    }
+
+    @Test
+    fun `blank values in multi-select are filtered out`() {
+        val params = createParameters("categoryData.materials[]" to listOf("Stone", "", "Glass", "  "))
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.BUILD)
+
+        val result = TestUtils.executeAndAssertSuccess(step, params)
+
+        val materials = assertIs<CategoryValue.MultiSelectValue>(result["materials"]).values
+        assertEquals(setOf("Stone", "Glass"), materials)
+    }
+
+    // --- Size struct (optional, including its sub-fields) ---
+
+    @Test
+    fun `struct field with all sub-values returns success`() {
         val params = createParameters(
-            "categoryData.playersRequired" to listOf("invalid-option")
+            "categoryData.size.x" to listOf("16"),
+            "categoryData.size.y" to listOf("10"),
+            "categoryData.size.z" to listOf("16")
+        )
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
+
+        val result = TestUtils.executeAndAssertSuccess(step, params)
+
+        val size = assertIs<CategoryValue.MapValue>(result["size"]).value
+        assertEquals(CategoryValue.IntValue(16), size["x"])
+        assertEquals(CategoryValue.IntValue(10), size["y"])
+        assertEquals(CategoryValue.IntValue(16), size["z"])
+    }
+
+    @Test
+    fun `struct field keeps the sub-values that were provided`() {
+        val params = createParameters(
+            "categoryData.size.x" to listOf("16"),
+            "categoryData.size.y" to listOf(""),
+            "categoryData.size.z" to listOf("")
+        )
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
+
+        val result = TestUtils.executeAndAssertSuccess(step, params)
+
+        val size = assertIs<CategoryValue.MapValue>(result["size"]).value
+        assertEquals(mapOf<String, CategoryValue>("x" to CategoryValue.IntValue(16)), size)
+    }
+
+    @Test
+    fun `struct field with no sub-values is omitted entirely`() {
+        val params = createParameters(
+            "categoryData.size.x" to listOf(""),
+            "categoryData.size.y" to listOf(""),
+            "categoryData.size.z" to listOf("")
+        )
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
+
+        val result = TestUtils.executeAndAssertSuccess(step, params)
+
+        assertNull(result["size"])
+    }
+
+    @Test
+    fun `number sub-field with non-integer returns failure`() {
+        val params = createParameters("categoryData.size.x" to listOf("not-a-number"))
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
+
+        val result = TestUtils.executeAndAssertFailure(step, params)
+
+        assertTrue(result.any {
+            it is ValidationFailure.InvalidFormat && it.parameterName == "categoryData.size.x"
+        })
+    }
+
+    // --- Specs block: the free-form label -> value replacement for typed fields ---
+
+    @Test
+    fun `specs with matching labels and values returns success`() {
+        val params = createParameters(
+            "categoryData.specs.key[]" to listOf("TNT per piston", "Remaining fuse"),
+            "categoryData.specs.value[]" to listOf("10", "21gt")
+        )
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.TNT)
+
+        val result = TestUtils.executeAndAssertSuccess(step, params)
+
+        val specs = assertIs<CategoryValue.MapValue>(result["specs"]).value
+        assertEquals(CategoryValue.TextValue("10"), specs["TNT per piston"])
+        assertEquals(CategoryValue.TextValue("21gt"), specs["Remaining fuse"])
+    }
+
+    @Test
+    fun `specs with mismatched labels and values returns failure`() {
+        val params = createParameters(
+            "categoryData.specs.key[]" to listOf("a", "b", "c"),
+            "categoryData.specs.value[]" to listOf("1", "2")
+        )
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.TNT)
+
+        val result = TestUtils.executeAndAssertFailure(step, params)
+
+        assertTrue(result.any {
+            it is ValidationFailure.InvalidFormat && it.message?.contains("Mismatched number of keys and values") == true
+        })
+    }
+
+    @Test
+    fun `specs rows with a blank label are skipped`() {
+        val params = createParameters(
+            "categoryData.specs.key[]" to listOf("Width", "", "Precision"),
+            "categoryData.specs.value[]" to listOf("15", "ignored", "1e-9")
+        )
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.TNT)
+
+        val result = TestUtils.executeAndAssertSuccess(step, params)
+
+        val specs = assertIs<CategoryValue.MapValue>(result["specs"]).value
+        assertEquals(2, specs.size)
+        assertEquals(CategoryValue.TextValue("15"), specs["Width"])
+        assertEquals(CategoryValue.TextValue("1e-9"), specs["Precision"])
+    }
+
+    @Test
+    fun `specs rows with a blank value are skipped`() {
+        val params = createParameters(
+            "categoryData.specs.key[]" to listOf("Width", "Precision"),
+            "categoryData.specs.value[]" to listOf("15", "")
+        )
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.TNT)
+
+        val result = TestUtils.executeAndAssertSuccess(step, params)
+
+        val specs = assertIs<CategoryValue.MapValue>(result["specs"]).value
+        assertEquals(mapOf<String, CategoryValue>("Width" to CategoryValue.TextValue("15")), specs)
+    }
+
+    @Test
+    fun `entirely blank specs block is omitted`() {
+        val params = createParameters(
+            "categoryData.specs.key[]" to listOf(""),
+            "categoryData.specs.value[]" to listOf("")
+        )
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.TNT)
+
+        val result = TestUtils.executeAndAssertSuccess(step, params)
+
+        assertNull(result["specs"])
+    }
+
+    // --- Production rate: item -> rate, the one field the engine consumes ---
+
+    @Test
+    fun `production rate maps items to rates`() {
+        val params = createParameters(
+            "categoryData.productionRate.key[]" to listOf("minecraft:iron_ingot", "minecraft:diamond"),
+            "categoryData.productionRate.value[]" to listOf("2000", "500")
+        )
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
+
+        val result = TestUtils.executeAndAssertSuccess(step, params)
+
+        val rates = assertIs<CategoryValue.MapValue>(result["productionRate"]).value
+        assertEquals(CategoryValue.IntValue(2000), rates["minecraft:iron_ingot"])
+        assertEquals(CategoryValue.IntValue(500), rates["minecraft:diamond"])
+    }
+
+    @Test
+    fun `production rate with an unknown item returns failure`() {
+        val params = createParameters(
+            "categoryData.productionRate.key[]" to listOf("minecraft:unobtanium"),
+            "categoryData.productionRate.value[]" to listOf("2000")
         )
         val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
 
@@ -163,283 +322,47 @@ class ValidateIdeaCategoryDataStepTest {
         })
     }
 
+    // --- Reference links ---
+
     @Test
-    fun `multi-select field with valid options returns success`() {
+    fun `references parse as a comma-separated list`() {
         val params = createParameters(
-            "categoryData.biomes[]" to listOf("Plains", "Forest", "Desert")
+            "categoryData.references" to listOf("https://youtu.be/abc, https://example.com/schematic")
         )
         val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
 
         val result = TestUtils.executeAndAssertSuccess(step, params)
 
-        val biomes = assertIs<CategoryValue.MultiSelectValue>(result["biomes"]).values
-        assertEquals(3, biomes.size)
-        assertTrue(biomes.contains("Plains"))
-        assertTrue(biomes.contains("Forest"))
-        assertTrue(biomes.contains("Desert"))
+        val references = assertIs<CategoryValue.MultiSelectValue>(result["references"]).values
+        assertEquals(setOf("https://youtu.be/abc", "https://example.com/schematic"), references)
     }
 
+    // --- Retired fields and general parameter handling ---
+
     @Test
-    fun `multi-select field with invalid option returns failure`() {
-        val params = createParameters(
-            "categoryData.biomes[]" to listOf("Plains", "InvalidBiome")
-        )
+    fun `retired field returns unknown field failure`() {
+        val params = createParameters("categoryData.playersRequired" to listOf("1"))
         val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
 
         val result = TestUtils.executeAndAssertFailure(step, params)
 
-        assertTrue(result.any { it is ValidationFailure.InvalidFormat })
-    }
-
-    @Test
-    fun `multi-select field with empty array returns success`() {
-        val params = createParameters(
-            "categoryData.biomes[]" to emptyList()
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        TestUtils.executeAndAssertSuccess(step, params)
-    }
-
-    @Test
-    fun `boolean field with true returns success`() {
-        val params = createParameters(
-            "categoryData.afkable" to listOf("true")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-
-        assertEquals(CategoryValue.BooleanValue(true), result["afkable"])
-    }
-
-    @Test
-    fun `boolean field with on returns success as true`() {
-        val params = createParameters(
-            "categoryData.stackable" to listOf("on")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-
-        assertEquals(CategoryValue.BooleanValue(true), result["stackable"])
-    }
-
-    @Test
-    fun `boolean field with invalid value returns failure`() {
-        val params = createParameters(
-            "categoryData.afkable" to listOf("maybe")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertFailure(step, params)
-
-        assertTrue(result.any {
-            it is ValidationFailure.InvalidFormat && it.message?.contains("Boolean value expected") == true
-        })
-    }
-
-    @Test
-    fun `rate field with valid integer returns success`() {
-        val params = createParameters(
-            "categoryData.yLevel" to listOf("60")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-
-        assertEquals(CategoryValue.IntValue(60), result["yLevel"])
-    }
-
-    @Test
-    fun `percentage field with valid decimal returns success`() {
-        val params = createParameters(
-            "categoryData.hopperLockPercentage" to listOf("75"),
-            type = IdeaCategory.STORAGE
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.STORAGE)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-        assertEquals(CategoryValue.IntValue(75), result["hopperLockPercentage"])
-    }
-
-    @Test
-    fun `percentage field outside range returns failure`() {
-        val params = createParameters(
-            "categoryData.hopperLockPercentage" to listOf("150"),
-            type = IdeaCategory.STORAGE
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.STORAGE)
-
-        val result = TestUtils.executeAndAssertFailure(step, params)
-        assertTrue(result.any {
-            it is ValidationFailure.InvalidFormat && it.message?.contains("must be between") == true
-        })
-    }
-
-    @Test
-    fun `map field with key options returns success`() {
-        val params = createParameters(
-            "categoryData.size.x" to listOf("16"),
-            "categoryData.size.y" to listOf("10"),
-            "categoryData.size.z" to listOf("16")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-        val size = assertIs<CategoryValue.MapValue>(result["size"]).value
-        assertEquals(CategoryValue.IntValue(16), size["x"])
-        assertEquals(CategoryValue.IntValue(10), size["y"])
-        assertEquals(CategoryValue.IntValue(16), size["z"])
-    }
-
-    @Test
-    fun `map field with invalid key option returns failure`() {
-        val params = ParametersBuilder().apply {
-            append("categoryData.width", "16")
-            append("categoryData.howToUse", "Default usage instructions")
-            append("categoryData.playersRequired", "1")
-        }.build()
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertFailure(step, params)
-        assertTrue(result.any {
-            it is ValidationFailure.CustomValidation && it.message.contains("Unknown field provided: width")
-        })
-    }
-
-    @Test
-    fun `map field with blank required values get error`() {
-        val params = createParameters(
-            "categoryData.size.x" to listOf("16"),
-            "categoryData.size.y" to listOf(""),
-            "categoryData.size.z" to listOf("16")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertFailure(step, params)
         assertEquals(1, result.size)
-        assertIs<ValidationFailure.MissingParameter>(result.first())
-    }
-
-    @Test
-    fun `free-form map field with matching keys and values returns success`() {
-        val params = createParameters(
-            "categoryData.mobRequirements.key[]" to listOf("zombie", "skeleton"),
-            "categoryData.mobRequirements.value[]" to listOf("10", "5")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-        val mobReqs = assertIs<CategoryValue.MapValue>(result["mobRequirements"]).value
-        assertEquals(CategoryValue.IntValue(10), mobReqs["zombie"])
-        assertEquals(CategoryValue.IntValue(5), mobReqs["skeleton"])
-    }
-
-    @Test
-    fun `free-form map field with mismatched keys and values returns failure`() {
-        val params = createParameters(
-            "categoryData.mobRequirements.key[]" to listOf("zombie", "skeleton", "creeper"),
-            "categoryData.mobRequirements.value[]" to listOf("10", "5")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertFailure(step, params)
-        assertTrue(result.any {
-            it is ValidationFailure.InvalidFormat && it.message?.contains("Mismatched number of keys and values for typed map field") == true
-        })
-    }
-
-    @Test
-    fun `free-form map field filters out blank keys`() {
-        val params = createParameters(
-            "categoryData.mobRequirements.key[]" to listOf("zombie", "", "skeleton"),
-            "categoryData.mobRequirements.value[]" to listOf("10", "3", "5")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-        val mobReqs = assertIs<CategoryValue.MapValue>(result["mobRequirements"]).value
-        assertEquals(2, mobReqs.size)
-        assertEquals(CategoryValue.IntValue(10), mobReqs["zombie"])
-        assertEquals(CategoryValue.IntValue(5), mobReqs["skeleton"])
-    }
-
-    @Test
-    fun `list field with allowed values returns success`() {
-        val params = createParameters(
-            "categoryData.playerSetup[]" to listOf("Looting III Sword", "Shield")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-        val setup = assertIs<CategoryValue.MultiSelectValue>(result["playerSetup"]).values
-        assertEquals(2, setup.size)
-        assertTrue(setup.contains("Looting III Sword"))
-        assertTrue(setup.contains("Shield"))
-    }
-
-    @Test
-    fun `list field with invalid allowed value returns failure`() {
-        val params = createParameters(
-            "categoryData.playerSetup[]" to listOf("Looting III Sword", "Invalid Item")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertFailure(step, params)
-        assertTrue(result.any {
-            it is ValidationFailure.InvalidFormat && it.message?.contains("Invalid option for multi-select") == true
-        })
-    }
-
-    @Test
-    fun `list field without allowed values as comma-separated returns success`() {
-        val params = createParameters(
-            "categoryData.pros" to listOf("Fast, Efficient, Cheap")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-        val pros = assertIs<CategoryValue.MultiSelectValue>(result["pros"]).values
-        assertEquals(3, pros.size)
-        assertTrue(pros.contains("Fast"))
-        assertTrue(pros.contains("Efficient"))
-        assertTrue(pros.contains("Cheap"))
-    }
-
-    @Test
-    fun `multiple fields of different types return success`() {
-        val params = createParameters(
-            "categoryData.farmVersion" to listOf("v3.2"),
-            "categoryData.afkable" to listOf("true"),
-            "categoryData.playersRequired" to listOf("1"),
-            "categoryData.biomes[]" to listOf("Plains", "Forest"),
-            "categoryData.size.x" to listOf("16"),
-            "categoryData.size.y" to listOf("10"),
-            "categoryData.size.z" to listOf("16"),
-            "categoryData.howToUse" to listOf("Stand here and wait")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-
-        assertEquals(6, result.size)
-        assertEquals(CategoryValue.TextValue("v3.2"), result["farmVersion"])
-        assertEquals(CategoryValue.BooleanValue(true), result["afkable"])
+        val error = assertIs<ValidationFailure.CustomValidation>(result.first())
+        assertContains(error.message, "Unknown field provided: playersRequired")
     }
 
     @Test
     fun `unknown field returns failure`() {
         val params = createParameters(
             "categoryData.unknownField" to listOf("some value"),
-            "categoryData.farmVersion" to listOf("v3.2")
+            "categoryData.afkable" to listOf("true")
         )
         val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
 
         val result = TestUtils.executeAndAssertFailure(step, params)
+
         assertEquals(1, result.size)
-        val error = result.first()
-        assertIs<ValidationFailure.CustomValidation>(error)
+        val error = assertIs<ValidationFailure.CustomValidation>(result.first())
         assertContains(error.message, "Unknown field provided: unknownField")
     }
 
@@ -448,198 +371,110 @@ class ValidateIdeaCategoryDataStepTest {
         val params = createParameters(
             "title" to listOf("Iron Farm"),
             "description" to listOf("A simple iron farm"),
-            "categoryData.farmVersion" to listOf("v3.2")
+            "categoryData.afkable" to listOf("true")
         )
         val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
 
         val result = TestUtils.executeAndAssertSuccess(step, params)
-        assertEquals(requiredFarmFields + 1, result.size)
-        assertEquals(CategoryValue.TextValue("v3.2"), result["farmVersion"])
+
+        assertEquals(1, result.size)
+        assertEquals(CategoryValue.BooleanValue(true), result["afkable"])
     }
 
     @Test
     fun `single value field submitted as array ignores value`() {
-        val params = createParameters(
-            "categoryData.farmVersion[]" to listOf("v3.2", "v3.3")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-        assertNull(result["farmVersion"])
-    }
-
-    @Test
-    fun `map field submitted as single value returns failure`() {
-        val params = ParametersBuilder().apply {
-            append("categoryData.size", "16x16x16")
-            append("categoryData.howToUse", "Default usage instructions")
-            append("categoryData.playersRequired", "1")
-        }.build()
-
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertFailure(step, params)
-        assertEquals(result.size, 3)
-        result.forEach {
-            assertIs<ValidationFailure.MissingParameter>(it)
-            assertTrue { it.parameterName.contains("x") || it.parameterName.contains("y") || it.parameterName.contains("z")  }
-        }
-    }
-
-    @Test
-    fun `empty parameters returns success with empty map when no required fields`() {
-        val params = Parameters.Empty
+        val params = createParameters("categoryData.storageType[]" to listOf("chest_hall", "bulk_storage"))
         val step = ValidateIdeaCategoryDataStep(IdeaCategory.STORAGE)
 
         val result = TestUtils.executeAndAssertSuccess(step, params)
-        assertTrue(result.isEmpty())
+
+        assertNull(result["storageType"])
     }
 
     @Test
     fun `multiple values for single value field returns failure`() {
-        val params = createParameters(
-            "categoryData.farmVersion" to listOf("v3.2", "v3.3")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
+        val params = createParameters("categoryData.storageType" to listOf("chest_hall", "bulk_storage"))
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.STORAGE)
 
         val result = TestUtils.executeAndAssertFailure(step, params)
+
         assertTrue(result.any {
             it is ValidationFailure.InvalidFormat && it.message?.contains("Expected single value") == true
         })
     }
 
     @Test
-    fun `blank values in multi-select are filtered out`() {
-        val params = createParameters(
-            "categoryData.biomes[]" to listOf("Plains", "", "Forest", "  ")
-        )
+    fun `empty parameters succeed for categories with no required fields`() {
         val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
 
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-        val biomes = assertIs<CategoryValue.MultiSelectValue>(result["biomes"]).values
-        assertEquals(2, biomes.size)
-        assertTrue(biomes.contains("Plains"))
-        assertTrue(biomes.contains("Forest"))
+        val result = TestUtils.executeAndAssertSuccess(step, Parameters.Empty)
+
+        assertTrue(result.isEmpty())
     }
 
     @Test
-    fun `list field returns list type for allowed values`() {
-        val params = createParameters(
-            "categoryData.playerSetup[]" to listOf("Looting III Sword", "Shield")
-        )
+    fun `a fully blank form stores nothing`() {
+        val params = ParametersBuilder().apply {
+            append("categoryData.size.x", "")
+            append("categoryData.size.y", "")
+            append("categoryData.size.z", "")
+            append("categoryData.productionRate.key[]", "")
+            append("categoryData.productionRate.value[]", "")
+            append("categoryData.tileable", "")
+            append("categoryData.directional", "")
+            append("categoryData.afkable", "")
+            append("categoryData.specs.key[]", "")
+            append("categoryData.specs.value[]", "")
+            append("categoryData.references", "")
+        }.build()
         val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
 
         val result = TestUtils.executeAndAssertSuccess(step, params)
-        assertIs<CategoryValue.MultiSelectValue>(result["playerSetup"])
-    }
 
-    @Test
-    fun `multi-select returns set type`() {
-        val params = createParameters(
-            "categoryData.biomes[]" to listOf("Plains", "Forest")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-        assertIs<CategoryValue.MultiSelectValue>(result["biomes"])
+        assertTrue(result.isEmpty(), "Expected no category data, got $result")
     }
 
     @Test
     fun `all validation failures are collected before returning`() {
         val params = createParameters(
-            "categoryData.yLevel" to listOf("not-a-number"),
-            "categoryData.playersRequired" to listOf("invalid-option"),
-            "categoryData.biomes[]" to listOf("InvalidBiome")
+            "categoryData.size.x" to listOf("not-a-number"),
+            "categoryData.storageType" to listOf("invalid-option"),
+            "categoryData.tileable" to listOf("maybe")
         )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
+        val step = ValidateIdeaCategoryDataStep(IdeaCategory.STORAGE)
 
         val result = TestUtils.executeAndAssertFailure(step, params)
-        assertTrue(result.size >= 3)
+
+        assertEquals(3, result.size)
     }
 
     @Test
-    fun `complex farm is decoded`() {
+    fun `a complete farm submission is decoded`() {
         val params = createParameters(
-            "categoryData.productionRate.key[]" to listOf("Normal Mode"),
-            "categoryData.productionRate.value.key[]" to listOf("minecraft:iron_ingot", "minecraft:diamond"),
-            "categoryData.productionRate.value.value[]" to listOf("2000", "500"),
             "categoryData.size.x" to listOf("10"),
             "categoryData.size.y" to listOf("20"),
             "categoryData.size.z" to listOf("30"),
-            "categoryData.howToUse" to listOf("Use as needed"),
+            "categoryData.productionRate.key[]" to listOf("minecraft:iron_ingot"),
+            "categoryData.productionRate.value[]" to listOf("2000"),
+            "categoryData.tileable" to listOf("true"),
+            "categoryData.afkable" to listOf("true"),
+            "categoryData.specs.key[]" to listOf("Villagers"),
+            "categoryData.specs.value[]" to listOf("3"),
+            "categoryData.references" to listOf("https://youtu.be/abc")
         )
-
         val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
 
         val result = TestUtils.executeAndAssertSuccess(step, params)
 
-        val productionRate = assertIs<CategoryValue.MapValue>(result["productionRate"]).value
-        assertEquals(1, productionRate.size)
-        val normalRate = assertIs<CategoryValue.MapValue>(productionRate["Normal Mode"]).value
-        assertEquals(2, normalRate.size)
-        assertEquals(CategoryValue.IntValue(2000), normalRate["minecraft:iron_ingot"])
-        assertEquals(CategoryValue.IntValue(500), normalRate["minecraft:diamond"])
-
+        assertEquals(
+            setOf("size", "productionRate", "tileable", "afkable", "specs", "references"),
+            result.keys
+        )
         val size = assertIs<CategoryValue.MapValue>(result["size"]).value
-        assertEquals(CategoryValue.IntValue(10), size["x"])
         assertEquals(CategoryValue.IntValue(20), size["y"])
-        assertEquals(CategoryValue.IntValue(30), size["z"])
-
-        assertEquals(CategoryValue.TextValue("Use as needed"), result["howToUse"])
-    }
-
-    @Test
-    fun `empty parameters returns errors for each required field`() {
-        val params = Parameters.Empty
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertFailure(step, params)
-        assertEquals(requiredFarmFields, result.size)
-        result.forEach {
-            assertIs<ValidationFailure.MissingParameter>(it)
-        }
-    }
-
-    @Test
-    fun `Empty, non-required values are ignored`() {
-        val params = ParametersBuilder().apply {
-            append("categoryData.farmVersion", "")
-            append("categoryData.productionRate.key[]", "")
-            append("categoryData.productionRate.value.key[]", "")
-            append("categoryData.productionRate.value.value[]", "")
-            append("categoryData.consumptionRate.key[]", "")
-            append("categoryData.consumptionRate.value.key[]", "")
-            append("categoryData.consumptionRate.value.value[]", "")
-            append("categoryData.size.x", "16")
-            append("categoryData.size.y", "10")
-            append("categoryData.size.z", "16")
-            append("categoryData.stackable", "")
-            append("categoryData.tileable", "")
-            append("categoryData.yLevel", "")
-            append("categoryData.subChunkAligned", "")
-            append("categoryData.biomes[]", "")
-            append("categoryData.mobRequirements.key[]", "")
-            append("categoryData.mobRequirements.value[]", "")
-            append("categoryData.playerSetup[]", "")
-            append("categoryData.beaconSetup[]", "")
-            append("categoryData.howToUse", "Default usage instructions")
-            append("categoryData.afkable", "")
-            append("categoryData.playersRequired", "1")
-            append("categoryData.pros", "")
-            append("categoryData.cons", "")
-            append("categoryData.directional", "")
-            append("categoryData.locational", "")
-        }.build()
-
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-
-        assertEquals(3, result.size)
-        assertEquals(CategoryValue.TextValue("Default usage instructions"), result["howToUse"])
-        val size = assertIs<CategoryValue.MapValue>(result["size"]).value
-        assertEquals(CategoryValue.IntValue(10), size["y"])
-        assertEquals(CategoryValue.IntValue(16), size["z"])
-        assertEquals(CategoryValue.TextValue("1"), result["playersRequired"])
+        val rates = assertIs<CategoryValue.MapValue>(result["productionRate"]).value
+        assertEquals(CategoryValue.IntValue(2000), rates["minecraft:iron_ingot"])
+        val specs = assertIs<CategoryValue.MapValue>(result["specs"]).value
+        assertEquals(CategoryValue.TextValue("3"), specs["Villagers"])
     }
 }
-

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/idea/DraftLifecycleIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/idea/DraftLifecycleIT.kt
@@ -38,6 +38,9 @@ import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import io.ktor.server.testing.testApplication
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -286,6 +289,50 @@ class DraftLifecycleIT : WithUser() {
         assertContains(body, "wizard-stage")
         // Should show AUTHOR_INFO stage content
         assertContains(body, "Author")
+    }
+
+    /**
+     * The specs block is the whole point of the slim schema (MCO-204), and it is a typed map —
+     * which the stage extractor used to drop on the floor, so nothing a user typed there ever
+     * reached the draft (and therefore never reached the published idea).
+     */
+    @Test
+    fun `POST drafts-draftId-stage persists typed map fields`() = testApplication {
+        val ideaCreator = createExtraUser("idea_creator")
+        val draftId = runBlocking { (CreateDraftStep(ideaCreator.id).process(Unit) as Result.Success).value }
+
+        routing {
+            install(AuthPlugin)
+            route("/ideas/drafts/{draftId}") {
+                install(IdeaCreatorPlugin)
+                post("/stage") { call.handleUpdateDraftStage() }
+            }
+        }
+
+        val response = client.submitForm(
+            url = "/ideas/drafts/$draftId/stage",
+            formParameters = Parameters.build {
+                append("currentStage", "CATEGORY_FIELDS")
+                append("category", "TNT")
+                append("categoryData.specs.key[]", "TNT per piston")
+                append("categoryData.specs.value[]", "10")
+                append("categoryData.specs.key[]", "Remaining fuse")
+                append("categoryData.specs.value[]", "21gt")
+                // The form always carries a trailing blank row — it must not become an entry.
+                append("categoryData.specs.key[]", "")
+                append("categoryData.specs.value[]", "")
+            }
+        ) { addAuthCookie(this, ideaCreator) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val draft = runBlocking { (GetDraftStep().process(GetDraftInput(draftId, ideaCreator.id)) as Result.Success).value }
+        val specs = Json.parseToJsonElement(draft.data)
+            .jsonObject["categoryData"]!!.jsonObject["specs"]!!.jsonObject["value"]!!.jsonObject
+
+        assertEquals(2, specs.size)
+        assertEquals("10", specs["TNT per piston"]!!.jsonObject["value"]!!.jsonPrimitive.content)
+        assertEquals("21gt", specs["Remaining fuse"]!!.jsonObject["value"]!!.jsonPrimitive.content)
     }
 
     @Test


### PR DESCRIPTION
Closes MCO-204.

The per-category idea schemas were designed up front from a handful of hand-entered ideas — ~20 FARM fields, 12 STORAGE subcategories, 8 SLIMESTONE subcategories — and [MCO-201](https://linear.app/evegul/issue/MCO-201) showed that even the small TNT slice doesn't fit the source material. None of it is read by the product: the engine consumes item requirements, size and version, and the idea detail page never renders category data at all. It was pure import friction, so it goes.

## The slim schema

`IdeaCategorySchemas.kt`: **1016 → 289 lines**.

| Category | Fields |
|---|---|
| FARM | `size`, `productionRate` (item → rate), `tileable`, `directional`, `afkable`, `specs`, `references` |
| STORAGE | `storageType` *(replaces 12 subcategories)*, `size`, `tileable`, `directional`, `specs`, `references` |
| CART_TECH | `cartTechType` **(required)**, `size`, `tileable`, `directional`, `specs`, `references` |
| TNT / SLIMESTONE / OTHER | their type select, `size`, `tileable`, `directional`, `specs`, `references` |
| BUILD | `size`, `buildStyle`, `materials`, `specs`, `references` |

`specs` is a free-form label → value block (`typedMapField` with a text key and text value) — it absorbs the long tail: "TNT per piston: 10", "Remaining fuse: 21gt", "Precision: 1e-9". **Promote a spec to a first-class typed field when it shows up consistently in real submissions, not before.**

`productionRate` survives, flattened to item → rate — it's the one structured field [MCO-294](https://linear.app/evegul/issue/MCO-294) will match bulk raw demand against. The old Mode → (Item → Rate) nesting was the most tedious thing in the form and never got filled.

Dropped everywhere: all subcategory blocks, per-category `description`/`purpose`/`howToUse` (duplicates `Idea.description`), `pros`/`cons`, `biomes`, `mobRequirements`, `playerSetup`/`beaconSetup`, `yLevel`, `subChunkAligned`, `locational`, `stackable`, `farmVersion`, `playersRequired`, OTHER's `tags` (duplicates `Idea.labels`). Only the CART_TECH discriminator stays required — `size` and `howToUse` were required before, which is friction on exactly the thing we're speeding up.

The `subcategory {}` builder goes with them. Nothing consumed `IdeaCategorySchema.subcategories`, and calls inside a `subcategory {}` block silently resolved against the *outer* receiver, so `percentageField` and `tileability()` were landing in the top-level field list all along.

## Bugs this surfaced

The slim schema did not work until three pre-existing bugs were fixed. All three were found by driving the wizard, not by reading it:

- **`handleGetCreateCategoryFields` read `category` off `request.queryParameters`**, but it's a path parameter (`/ideas/create/fields/{category}`) — picking a category in the wizard rendered nothing, ever.
- **The typed-map "Add entry" button was `alert('Not implemented yet')`**, capping every map field at one row. A one-row `specs` block is pointless, so rows now clone client-side; a hidden `<template>` would re-render the entire item list for `productionRate` on every page load.
- **`extractCategoryValue` returned `null` for `TypedMapField`** (`DraftHandlers.kt`), so drafts silently discarded everything typed into a map — and publish reads the draft's stored `categoryData`, so specs would never have reached a published idea. Covered now by a new IT.

Also fixed the OOB category-error id (it targeted an element that doesn't exist, logging `oobErrorNoTarget` on every category pick) and stopped `validateTypedMapField` storing `IgnoredValue`, which has no serial form and would throw on write.

## Migration

`V2_51_0` clears `ideas.category_data` and strips `categoryData` from in-progress drafts, rather than folding retired keys into `specs` — confirmed with @evengul that there's no production idea data worth preserving.

## Note for reviewers

**No filterable numeric field survives anywhere** — `yLevel`, MSPT, speeds and percentages were the only ones. `IdeaSqlBuilder`'s range branch is now only reachable by constructing `IdeaSearchFilters` directly, which is what its test does; the parser can't produce one until a spec gets promoted. That's the intended end state, not an oversight.

## Testing

- 732 unit + 418 database tests pass. `ValidateIdeaCategoryDataStepTest` rewritten against the slim schema; `IdeaFilterParserTest` and `GetIdeasByCategoryStepTest` moved onto surviving fields, plus a test asserting filters naming retired fields are dropped rather than passed through to the JSONB query.
- New: `DraftLifecycleIT.POST drafts-draftId-stage persists typed map fields`.
- Driven end to end against the running app: picked Farm → slim fields render, added a second spec row, saved, review showed `Specs: Remaining fuse: 21gt, TNT per piston: 10 per shot`, reloaded → both rows prefilled with a fresh blank row. Zero console errors, no server errors. Checked at 1440 and 375.

## Follow-up

[MCO-309](https://linear.app/evegul/issue/MCO-309) — the idea detail page never renders `categoryData` at all, so `specs` stays write-only outside the wizard's review stage. Predates this change; matters more now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
