### PR TITLE
MCO-310: one page to create an idea, not six

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DeserializeDraftStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DeserializeDraftStep.kt
@@ -55,17 +55,18 @@ object DeserializeDraftStep : Step<IdeaDraft, AppFailure.ValidationError, Create
 
         val errors = mutableListOf<ValidationFailure>()
 
+        // What a *private* design must have: a name, a kind, and a difficulty. Nothing else.
+        // A personal note is allowed to be a name and a category — quality bars belong to
+        // publishing to the hub, which is a separate step, not to storing your own design.
         if (data.name.isNullOrBlank()) errors.add(ValidationFailure.MissingParameter("name"))
-        if (data.description.isNullOrBlank()) errors.add(ValidationFailure.MissingParameter("description"))
         if (data.difficulty == null) errors.add(ValidationFailure.MissingParameter("difficulty"))
         if (data.category == null) errors.add(ValidationFailure.MissingParameter("category"))
         if (data.author == null) errors.add(ValidationFailure.MissingParameter("author"))
         if (data.versionRange == null) errors.add(ValidationFailure.MissingParameter("versionRange"))
 
+        // Not required: after the MCO-204 slimming almost every category field is optional, so
+        // demanding a non-empty block meant a minimal idea could never be saved.
         val categoryData = data.categoryData
-        if (data.category != null && (categoryData == null || categoryData.isEmpty())) {
-            errors.add(ValidationFailure.MissingParameter("categoryData"))
-        }
 
         if (errors.isNotEmpty()) {
             return Result.failure(AppFailure.ValidationError(errors))
@@ -74,7 +75,7 @@ object DeserializeDraftStep : Step<IdeaDraft, AppFailure.ValidationError, Create
         return Result.success(
             CreateIdeaInput(
                 name = data.name!!,
-                description = data.description!!,
+                description = data.description.orEmpty(),
                 category = data.category!!,
                 difficulty = data.difficulty!!,
                 labels = emptyList(),

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DeserializeDraftStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DeserializeDraftStep.kt
@@ -41,6 +41,13 @@ val IdeaDraft.name: String?
         null
     }
 
+/**
+ * A draft nobody has typed anything into yet. Opening the create flow mints one of these, so
+ * without this check a few aborted visits leave a list of identical "Untitled Draft" rows.
+ */
+val IdeaDraft.isUntouched: Boolean
+    get() = data.isBlank() || data.trim() == "{}"
+
 object DeserializeDraftStep : Step<IdeaDraft, AppFailure.ValidationError, CreateIdeaInput> {
     override suspend fun process(input: IdeaDraft): Result<AppFailure.ValidationError, CreateIdeaInput> {
         val data = try {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
@@ -8,6 +8,8 @@ import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.minecraftfiles.GetSupportedVersionsStep
 import app.mcorg.presentation.handler.handlePipeline
 import app.mcorg.presentation.templated.idea.createwizard.DraftWizardStage
+import app.mcorg.presentation.templated.idea.createwizard.draftFormFragment
+import app.mcorg.presentation.templated.idea.createwizard.draftFormPage
 import app.mcorg.presentation.templated.idea.createwizard.draftWizardPage
 import app.mcorg.presentation.templated.idea.createwizard.wizardProgressHtml
 import app.mcorg.presentation.templated.idea.createwizard.wizardStageContent
@@ -16,9 +18,11 @@ import app.mcorg.pipeline.idea.commonsteps.GetIdeaStep
 import app.mcorg.presentation.utils.clientRedirect
 import app.mcorg.presentation.utils.getIdeaId
 import app.mcorg.presentation.utils.getUser
+import app.mcorg.presentation.utils.redirectClientOrBrowser
 import app.mcorg.presentation.utils.respondHtml
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
+import io.ktor.http.ParametersBuilder
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.request.receiveParameters
 import kotlinx.html.div
@@ -54,7 +58,9 @@ suspend fun ApplicationCall.handleGetDraftList() {
     handlePipeline(
         onSuccess = { outcome ->
             when (outcome) {
-                is DraftListOutcome.Redirect -> clientRedirect(outcome.url)
+                // Reached by a plain link from the hub, so this must be a real redirect for a
+                // browser and an HX-Redirect for HTMX — not the HTMX-only form (MCO-310).
+                is DraftListOutcome.Redirect -> redirectClientOrBrowser(outcome.url)
                 is DraftListOutcome.ShowList -> respondHtml(draftListPage(user, outcome.drafts))
             }
         }
@@ -99,17 +105,12 @@ suspend fun ApplicationCall.handleGetDraftWizard() {
     val draftId = parameters["draftId"]?.toIntOrNull() ?: run {
         respondHtml("<p>Invalid draft ID</p>"); return
     }
-    val stageParam = parameters["stage"]?.let {
-        runCatching { DraftWizardStage.valueOf(it) }.getOrNull()
-    }
 
     val supportedVersions = GetSupportedVersionsStep.getSupportedVersions()
 
     handlePipeline(
         onSuccess = { draft ->
-            val stage = stageParam
-                ?: runCatching { DraftWizardStage.valueOf(draft.currentStage) }.getOrDefault(DraftWizardStage.BASIC_INFO)
-            respondHtml(draftWizardPage(user, draft, stage, supportedVersions))
+            respondHtml(draftFormPage(user, draft, supportedVersions))
         }
     ) {
         GetDraftStep().run(GetDraftInput(draftId, user.id))
@@ -217,12 +218,55 @@ suspend fun ApplicationCall.handleDeleteDraft() {
 
 /**
  * POST /ideas/drafts/:draftId/publish
- * Validate + create idea + delete draft + redirect.
+ *
+ * The single-page form (MCO-310) posts every field at once, so this saves what was submitted before
+ * validating it — there is no longer a per-stage save that ran first. On failure it re-renders the
+ * form in place with the errors and the user's own input still in it.
+ *
+ * Despite the route name this produces a *private* idea; publishing to the hub is a separate,
+ * privileged step (MCO-291).
  */
 suspend fun ApplicationCall.handlePublishDraft() {
     val user = getUser()
     val draftId = parameters["draftId"]?.toIntOrNull() ?: run {
         respondHtml("<p>Invalid draft ID</p>"); return
+    }
+    // A bodyless POST means "publish what is already stored" — merging empty params would clobber
+    // fields the draft already holds, so only save when a form was actually submitted.
+    val params = runCatching { receiveParameters() }.getOrNull()
+
+    if (params != null) {
+        val saved = UpdateDraftStep().process(
+            UpdateDraftInput(draftId, user.id, buildFormJson(params, user.minecraftUsername), DraftWizardStage.REVIEW.name)
+        )
+        if (saved is Result.Failure) {
+            respondHtml("<p>Draft not found</p>", HttpStatusCode.NotFound)
+            return
+        }
+    }
+
+    val validationErrors = params?.let { submitted ->
+        DraftWizardStage.entries.flatMap { stage ->
+            (ValidateStageStep.process(ValidateStageInput(stage, submitted)) as? Result.Success)?.value ?: emptyList()
+        }
+    } ?: emptyList()
+
+    if (validationErrors.isNotEmpty()) {
+        val draft = GetDraftStep().process(GetDraftInput(draftId, user.id)).getOrNull()
+        if (draft == null) {
+            respondHtml("<p>Draft not found</p>", HttpStatusCode.NotFound)
+            return
+        }
+        respondHtml(
+            draftFormFragment(
+                draft = draft,
+                supportedVersions = GetSupportedVersionsStep.getSupportedVersions(),
+                errors = validationErrors,
+                defaultAuthorName = user.minecraftUsername,
+            ),
+            HttpStatusCode.UnprocessableEntity
+        )
+        return
     }
 
     handlePipeline(
@@ -233,6 +277,52 @@ suspend fun ApplicationCall.handlePublishDraft() {
         val draft = GetDraftStep().run(GetDraftInput(draftId, user.id))
         PublishDraftStep().run(PublishDraftInput(draft, user.id))
     }
+}
+
+/**
+ * POST /ideas/drafts/:draftId/save
+ *
+ * Keeps what has been typed without validating or turning it into an idea, so a half-finished
+ * design survives being interrupted. Nothing is required here — that is the point.
+ */
+suspend fun ApplicationCall.handleSaveDraftForm() {
+    val user = getUser()
+    val draftId = parameters["draftId"]?.toIntOrNull() ?: run {
+        respondHtml("<p>Invalid draft ID</p>"); return
+    }
+    val params = receiveParameters()
+
+    handlePipeline(
+        onSuccess = { redirectClientOrBrowser("/ideas/create") }
+    ) {
+        UpdateDraftStep().run(
+            UpdateDraftInput(draftId, user.id, buildFormJson(params, user.minecraftUsername), DraftWizardStage.REVIEW.name)
+        )
+    }
+}
+
+/**
+ * Every field on the single-page form, merged into one draft-shaped JSON object. Reuses the
+ * per-stage builders rather than duplicating their parsing — the stages are gone from the UI but
+ * remain a useful grouping for parsing and validation.
+ */
+private fun buildFormJson(params: Parameters, fallbackAuthorName: String): String {
+    val effective = if (params["authorName"].isNullOrBlank()) {
+        // "Credited to you" unless you say otherwise — the author field is optional on the form.
+        ParametersBuilder().apply {
+            params.names().filter { it != "authorName" }.forEach { name ->
+                params.getAll(name)?.forEach { append(name, it) }
+            }
+            append("authorName", fallbackAuthorName)
+        }.build()
+    } else {
+        params
+    }
+
+    val merged = DraftWizardStage.entries
+        .map { Json.parseToJsonElement(buildStageJson(it, effective)).jsonObject }
+        .fold(mutableMapOf<String, JsonElement>()) { acc, obj -> acc.apply { putAll(obj) } }
+    return JsonObject(merged).toString()
 }
 
 /**
@@ -341,8 +431,11 @@ private fun extractCategoryValue(field: CategoryField, params: Parameters, param
         params[paramPrefix]?.takeIf { it.isNotBlank() }?.let { CategoryValue.TextValue(it) }
     is CategoryField.Number, is CategoryField.Rate, is CategoryField.Percentage ->
         params[paramPrefix]?.toIntOrNull()?.let { CategoryValue.IntValue(it) }
+    // Only record a ticked box. An unticked one posts nothing, and storing that as an explicit
+    // "No" put three rows the author never asserted onto every minimally-filled idea's detail
+    // page. Absence already means false, since category data is rebuilt from the form on save.
     is CategoryField.BooleanField ->
-        CategoryValue.BooleanValue(params[paramPrefix] == "true")
+        CategoryValue.BooleanValue(true).takeIf { params[paramPrefix] == "true" }
     is CategoryField.MultiSelect ->
         params.getAll("$paramPrefix[]")?.toSet()?.takeIf { it.isNotEmpty() }
             ?.let { CategoryValue.MultiSelectValue(it) }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
@@ -66,11 +66,13 @@ suspend fun ApplicationCall.handleGetDraftList() {
         }
     ) {
         val draftList = GetDraftsStep(user.id).run(Unit)
-        if (draftList.isEmpty()) {
-            val draftId = CreateDraftStep(user.id).run(Unit)
-            DraftListOutcome.Redirect("/ideas/drafts/$draftId/edit")
-        } else {
-            DraftListOutcome.ShowList(draftList)
+        val untouched = draftList.firstOrNull { it.isUntouched }
+        when {
+            draftList.isEmpty() -> DraftListOutcome.Redirect("/ideas/drafts/${CreateDraftStep(user.id).run(Unit)}/edit")
+            // Every blank draft is the same blank draft — send them back to it rather than
+            // showing a list of indistinguishable "Untitled Draft" rows.
+            draftList.all { it.isUntouched } -> DraftListOutcome.Redirect("/ideas/drafts/${untouched!!.id}/edit")
+            else -> DraftListOutcome.ShowList(draftList)
         }
     }
 }
@@ -92,7 +94,10 @@ suspend fun ApplicationCall.handleCreateDraft() {
             clientRedirect("/ideas/drafts/$draftId/edit")
         }
     ) {
-        CreateDraftStep(user.id).run(Unit)
+        // Reuse a blank draft if one is already lying around, so repeated "New Draft" clicks do
+        // not stack up identical empty rows.
+        GetDraftsStep(user.id).run(Unit).firstOrNull { it.isUntouched }?.id
+            ?: CreateDraftStep(user.id).run(Unit)
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaDescriptionStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaDescriptionStep.kt
@@ -7,14 +7,13 @@ import io.ktor.http.*
 
 object ValidateIdeaDescriptionStep : Step<Parameters, ValidationFailure, String> {
     override suspend fun process(input: Parameters): Result<ValidationFailure, String> {
-        val description = input["description"]?.trim()
+        val description = input["description"]?.trim().orEmpty()
 
-        if (description.isNullOrBlank()) {
-            return Result.Failure(ValidationFailure.MissingParameter("description"))
-        }
-
-        if (description.length !in 20..5000) {
-            return Result.Failure(ValidationFailure.InvalidLength("description", 20, 5000))
+        // Optional, and with no lower bound. A private design may be a name and a category; a
+        // twenty-character minimum is a rule about what deserves to be on the community hub, and
+        // that belongs to publishing rather than to saving your own note.
+        if (description.length > 5000) {
+            return Result.Failure(ValidationFailure.InvalidLength("description", 0, 5000))
         }
 
         return Result.Success(description)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/IdeaHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/IdeaHandler.kt
@@ -10,6 +10,7 @@ import app.mcorg.pipeline.idea.draft.handleDeleteDraft
 import app.mcorg.pipeline.idea.draft.handleGetDraftList
 import app.mcorg.pipeline.idea.draft.handleGetDraftWizard
 import app.mcorg.pipeline.idea.draft.handlePublishDraft
+import app.mcorg.pipeline.idea.draft.handleSaveDraftForm
 import app.mcorg.pipeline.idea.draft.handleRevertIdeaToDraft
 import app.mcorg.pipeline.idea.draft.handleUpdateDraftStage
 import app.mcorg.pipeline.idea.handleClearCategoryFilters
@@ -94,6 +95,9 @@ class IdeaHandler {
                     }
                     post("/stage") {
                         call.handleUpdateDraftStage()
+                    }
+                    post("/save") {
+                        call.handleSaveDraftForm()
                     }
                     post("/publish") {
                         call.handlePublishDraft()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftAuthorFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftAuthorFields.kt
@@ -22,7 +22,7 @@ import kotlinx.serialization.json.Json
 
 private val json = Json { ignoreUnknownKeys = true; isLenient = true }
 
-fun FlowContent.draftAuthorFields(draft: IdeaDraft) {
+fun FlowContent.draftAuthorFields(draft: IdeaDraft, defaultName: String = "") {
     val data = runCatching { json.decodeFromString(DraftData.serializer(), draft.data) }.getOrDefault(DraftData())
     val author = data.author
     val authorType = when (author) {
@@ -34,12 +34,10 @@ fun FlowContent.draftAuthorFields(draft: IdeaDraft) {
         label {
             htmlFor = "draft-author-type"
             +"Author Type"
-            span("required-indicator") { +"*" }
         }
         select(classes = "form-control") {
             id = "draft-author-type"
             name = "authorType"
-            required = true
             hxGet("/ideas/create/author-fields")
             hxTrigger("change")
             hxTarget("#author-fields-container")
@@ -63,8 +61,8 @@ fun FlowContent.draftAuthorFields(draft: IdeaDraft) {
         id = "author-fields-container"
         when (author) {
             is Author.Team -> teamAuthorFields(author)
-            is Author.SingleAuthor -> singleAuthorFields(author)
-            else -> singleAuthorFields()
+            is Author.SingleAuthor -> singleAuthorFields(author, defaultName)
+            else -> singleAuthorFields(defaultName = defaultName)
         }
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftBasicInfoFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftBasicInfoFields.kt
@@ -52,7 +52,7 @@ fun FlowContent.draftBasicInfoFields(draft: IdeaDraft) {
             id = "draft-description"
             name = "description"
             required = true
-            rows = "6"
+            rows = "4"
             minLength = "20"
             maxLength = "5000"
             placeholder = "Describe your contraption, how it works, and what makes it unique..."

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftBasicInfoFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftBasicInfoFields.kt
@@ -20,6 +20,22 @@ import kotlinx.serialization.json.Json
 
 private val json = Json { ignoreUnknownKeys = true; isLenient = true }
 
+/**
+ * Chip-sized labels. `toPrettyEnumName()` yields "Technical Understanding Recommended", which is
+ * wider than the three game-stage options put together and wraps the row into a mess.
+ *
+ * Laying these out side by side exposes something the dropdown hid: this enum is two axes in one —
+ * how far into the game you are, and how much redstone knowledge it takes. They are not mutually
+ * exclusive in reality, so a single-choice control cannot express "end game and technical".
+ */
+private fun IdeaDifficulty.shortLabel(): String = when (this) {
+    IdeaDifficulty.START_OF_GAME -> "Start of game"
+    IdeaDifficulty.MID_GAME -> "Mid game"
+    IdeaDifficulty.END_GAME -> "End game"
+    IdeaDifficulty.TECHNICAL_UNDERSTANDING_RECOMMENDED -> "Technical (recommended)"
+    IdeaDifficulty.TECHNICAL_UNDERSTANDING_REQUIRED -> "Technical (required)"
+}
+
 fun FlowContent.draftBasicInfoFields(draft: IdeaDraft) {
     val data = runCatching { json.decodeFromString(DraftData.serializer(), draft.data) }.getOrDefault(DraftData())
 
@@ -46,16 +62,15 @@ fun FlowContent.draftBasicInfoFields(draft: IdeaDraft) {
         label {
             htmlFor = "draft-description"
             +"Description"
-            span("required-indicator") { +"*" }
         }
+        // Optional, and no minimum length: a private design is allowed to be a name and a
+        // category. Requirements for putting one on the hub come later, and separately.
         textArea(classes = "form-control") {
             id = "draft-description"
             name = "description"
-            required = true
             rows = "4"
-            minLength = "20"
             maxLength = "5000"
-            placeholder = "Describe your contraption, how it works, and what makes it unique..."
+            placeholder = "How it works, what makes it good, anything you'd want to remember later…"
             +(data.description ?: "")
         }
         p("form-error") { id = "error-description" }
@@ -63,19 +78,23 @@ fun FlowContent.draftBasicInfoFields(draft: IdeaDraft) {
 
     div {
         label {
-            htmlFor = "draft-difficulty"
             +"Difficulty"
             span("required-indicator") { +"*" }
         }
-        select(classes = "form-control") {
-            id = "draft-difficulty"
-            name = "difficulty"
-            required = true
+        // Radios rather than a select: five options is few enough to show at once, it matches the
+        // category picker directly below, and it saves a click on a field that is always answered.
+        div("category-select") {
             IdeaDifficulty.entries.forEach { difficulty ->
-                option {
-                    value = difficulty.name
-                    selected = (data.difficulty == difficulty) || (data.difficulty == null && difficulty == IdeaDifficulty.MID_GAME)
-                    +difficulty.toPrettyEnumName()
+                label("filter-radio-label") {
+                    input(type = InputType.radio) {
+                        classes += "category-radio"
+                        name = "difficulty"
+                        value = difficulty.name
+                        checked = (data.difficulty == difficulty) ||
+                                (data.difficulty == null && difficulty == IdeaDifficulty.MID_GAME)
+                        required = true
+                    }
+                    +difficulty.shortLabel()
                 }
             }
         }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftCategoryFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftCategoryFields.kt
@@ -23,7 +23,18 @@ import kotlinx.serialization.json.Json
 
 private val json = Json { ignoreUnknownKeys = true; isLenient = true }
 
+/**
+ * Category picker plus its schema fields, together. Kept for callers that want both in one place;
+ * the single-page create form (MCO-310) uses the two halves separately, because the picker is
+ * required and belongs up front while the schema fields are optional detail.
+ */
 fun FlowContent.draftCategoryFields(draft: IdeaDraft) {
+    draftCategorySelect(draft)
+    draftCategorySchemaFields(draft)
+}
+
+/** The required "what kind of thing is this" picker. */
+fun FlowContent.draftCategorySelect(draft: IdeaDraft) {
     val data = runCatching { json.decodeFromString(DraftData.serializer(), draft.data) }.getOrDefault(DraftData())
     val selectedCategory = data.category
     val versionRange = data.versionRange ?: MinecraftVersionRange.Unbounded
@@ -70,14 +81,25 @@ fun FlowContent.draftCategoryFields(draft: IdeaDraft) {
         }
         p("form-error") { id = "error-category" }
     }
+}
 
-    val schema = selectedCategory?.let { IdeaCategorySchemas.getSchema(it) }
+/**
+ * The chosen category's own fields. Swapped in by the picker's `hx-get`, so the container id is
+ * global and this can live in a different part of the page from the picker.
+ */
+fun FlowContent.draftCategorySchemaFields(draft: IdeaDraft) {
+    val data = runCatching { json.decodeFromString(DraftData.serializer(), draft.data) }.getOrDefault(DraftData())
+    val versionRange = data.versionRange ?: MinecraftVersionRange.Unbounded
+    val schema = data.category?.let { IdeaCategorySchemas.getSchema(it) }
+
     div("wizard-category-fields") {
         id = "category-specific-fields"
         if (schema != null) {
             schema.fields.forEach { field ->
                 renderCreateField(versionRange, field, data.categoryData?.get(field.key))
             }
+        } else {
+            p("subtle") { +"Pick a category above to see the fields that fit it." }
         }
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftFormPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftFormPage.kt
@@ -1,0 +1,164 @@
+package app.mcorg.presentation.templated.idea.createwizard
+
+import app.mcorg.domain.model.idea.IdeaDraft
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.user.TokenProfile
+import app.mcorg.pipeline.failure.ValidationFailure
+import app.mcorg.pipeline.idea.draft.name
+import app.mcorg.pipeline.idea.draft.toMessage
+import app.mcorg.presentation.hxPost
+import app.mcorg.presentation.hxSwap
+import app.mcorg.presentation.hxTarget
+import app.mcorg.presentation.templated.dsl.appHeader
+import app.mcorg.presentation.templated.dsl.container
+import app.mcorg.presentation.templated.dsl.pageShell
+import kotlinx.html.ButtonType
+import kotlinx.html.FlowContent
+import kotlinx.html.FormEncType
+import kotlinx.html.a
+import kotlinx.html.button
+import kotlinx.html.details
+import kotlinx.html.div
+import kotlinx.html.form
+import kotlinx.html.h1
+import kotlinx.html.h2
+import kotlinx.html.id
+import kotlinx.html.main
+import kotlinx.html.p
+import kotlinx.html.span
+import kotlinx.html.stream.createHTML
+import kotlinx.html.summary
+
+/**
+ * The single-page create form (MCO-310).
+ *
+ * Replaces a six-stage wizard in which three stages were pass-throughs: Author was one field that
+ * we can usually fill in ourselves, Version was one pre-defaulted dropdown, and Items validated
+ * nothing at all. Only name, description, difficulty and category are actually required, so those
+ * are the only things visible up front — everything else is optional detail behind a disclosure.
+ *
+ * Submitting produces a *private* idea (MCO-291), which is why nothing here says "publish".
+ */
+fun draftFormPage(
+    user: TokenProfile,
+    draft: IdeaDraft,
+    supportedVersions: List<MinecraftVersion.Release>,
+    errors: List<ValidationFailure> = emptyList(),
+): String = pageShell(
+    pageTitle = "Seam — New Idea",
+    user = user,
+    stylesheets = listOf(
+        "/static/styles/components/btn.css",
+        "/static/styles/components/callout.css",
+        "/static/styles/components/form.css",
+        "/static/styles/components/item-search.css",
+        "/static/styles/pages/idea-wizard.css",
+    )
+) {
+    appHeader(
+        user = user,
+        breadcrumbBlock = {
+            link("Ideas", "/ideas").link("Drafts", "/ideas/create").current(draft.name ?: "New idea")
+        }
+    )
+    main {
+        container {
+            div("idea-form-head") {
+                h1("idea-form__title") { +(draft.name ?: "New idea") }
+                p("idea-form__subtitle") {
+                    +"Name, description and category are all you need. Everything else is optional, and it stays private until you publish it to the hub."
+                }
+            }
+            div {
+                id = FORM_ID
+                draftFormContent(draft, supportedVersions, errors, user.minecraftUsername)
+            }
+        }
+    }
+}
+
+/** The form on its own, for re-rendering in place when validation fails. */
+fun draftFormFragment(
+    draft: IdeaDraft,
+    supportedVersions: List<MinecraftVersion.Release>,
+    errors: List<ValidationFailure>,
+    defaultAuthorName: String,
+): String = createHTML().div {
+    id = FORM_ID
+    draftFormContent(draft, supportedVersions, errors, defaultAuthorName)
+}
+
+private const val FORM_ID = "idea-form"
+
+private fun FlowContent.draftFormContent(
+    draft: IdeaDraft,
+    supportedVersions: List<MinecraftVersion.Release>,
+    errors: List<ValidationFailure>,
+    defaultAuthorName: String,
+) {
+    form {
+        encType = FormEncType.applicationXWwwFormUrlEncoded
+        hxPost("/ideas/drafts/${draft.id}/publish")
+        hxTarget("#$FORM_ID")
+        hxSwap("outerHTML")
+
+        if (errors.isNotEmpty()) {
+            div("callout callout--error") {
+                span("callout__icon") { +"⚠" }
+                div("callout__body") {
+                    errors.forEach { error -> p { +error.toMessage() } }
+                }
+            }
+        }
+
+        div("idea-form__required") {
+            draftBasicInfoFields(draft)
+            draftCategorySelect(draft)
+        }
+
+        optionalSection("Design details", "Size, production rate, and anything else measurable") {
+            draftCategorySchemaFields(draft)
+        }
+
+        optionalSection("Materials", "What it takes to build — or drop in a .litematic") {
+            draftItemRequirementFields(draft)
+        }
+
+        optionalSection("Versions and credit", "Defaults to all versions, credited to you") {
+            draftVersionFields(draft, supportedVersions)
+            draftAuthorFields(draft, defaultAuthorName)
+        }
+
+        div("idea-form__actions") {
+            button(classes = "btn btn--primary") {
+                type = ButtonType.submit
+                +"Save Idea"
+            }
+            // Posts the same fields to a route that skips validation, so "later" actually keeps
+            // what you typed instead of quietly dropping it on the way out.
+            button(classes = "btn btn--ghost") {
+                type = ButtonType.button
+                hxPost("/ideas/drafts/${draft.id}/save")
+                +"Save for later"
+            }
+        }
+    }
+}
+
+/**
+ * A collapsed `<details>` block. Native disclosure rather than scripted accordions: it keeps the
+ * fields in the form (so they still post) and stays keyboard- and search-accessible for free.
+ */
+private fun FlowContent.optionalSection(
+    title: String,
+    hint: String,
+    block: FlowContent.() -> Unit,
+) {
+    details("idea-form__section") {
+        summary("idea-form__section-summary") {
+            h2("idea-form__section-title") { +title }
+            span("idea-form__section-hint") { +hint }
+        }
+        div("idea-form__section-body") { block() }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftFormPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftFormPage.kt
@@ -66,7 +66,7 @@ fun draftFormPage(
             div("idea-form-head") {
                 h1("idea-form__title") { +(draft.name ?: "New idea") }
                 p("idea-form__subtitle") {
-                    +"Name, description and category are all you need. Everything else is optional, and it stays private until you publish it to the hub."
+                    +"A name and a category are all you need. Everything else is optional, and it stays private until you publish it to the hub."
                 }
             }
             div {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftItemRequirementFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftItemRequirementFields.kt
@@ -51,8 +51,10 @@ fun FlowContent.draftItemRequirementFields(draft: IdeaDraft) {
     }
 
     // --- Manual item search ---
-    div("wizard-item-add") {
-        div("item-search-combo") {
+    // Search, quantity and the action on one line: they are one gesture ("add 64 iron"), and
+    // stacking them made a three-step ritual out of it.
+    div("wizard-item-add item-add-line") {
+        div("item-search-combo item-add-line__search") {
             label { htmlFor = "item-search"; +"Add Item" }
             div("item-search-field") {
                 input(type = InputType.text, classes = "form-control") {
@@ -75,27 +77,25 @@ fun FlowContent.draftItemRequirementFields(draft: IdeaDraft) {
             }
         }
 
-        div("item-add-row") {
-            div {
-                label { htmlFor = "item-amount"; +"Quantity" }
-                input(type = InputType.number, classes = "form-control") {
-                    id = "item-amount"
-                    min = "1"
-                    max = "2000000000"
-                    value = "1"
-                }
+        div("item-add-line__qty") {
+            label { htmlFor = "item-amount"; +"Quantity" }
+            input(type = InputType.number, classes = "form-control") {
+                id = "item-amount"
+                min = "1"
+                max = "2000000000"
+                value = "1"
             }
-            button(classes = "btn btn--secondary btn--sm") {
-                type = ButtonType.button
-                attributes["onclick"] = addItemScript()
-                +"Add Item"
-            }
+        }
+        button(classes = "btn btn--secondary item-add-line__action") {
+            type = ButtonType.button
+            attributes["onclick"] = addItemScript()
+            +"Add"
         }
     }
 
     // --- Litematica upload ---
     div("wizard-litematica-upload") {
-        p("form-help-text") { +"Or import items from a .litematic schematic file:" }
+        p("form-help-text") { +"Or drop in a .litematic and take the whole material list from it:" }
         // Deliberately NOT a nested <form>. These fields now live inside the single-page create
         // form (MCO-310), and an inner <form> makes the HTML parser close the outer one early —
         // silently orphaning every field and button that follows, including submit. HTMX can post

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftItemRequirementFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftItemRequirementFields.kt
@@ -96,19 +96,20 @@ fun FlowContent.draftItemRequirementFields(draft: IdeaDraft) {
     // --- Litematica upload ---
     div("wizard-litematica-upload") {
         p("form-help-text") { +"Or import items from a .litematic schematic file:" }
-        form {
-            encType = FormEncType.multipartFormData
+        // Deliberately NOT a nested <form>. These fields now live inside the single-page create
+        // form (MCO-310), and an inner <form> makes the HTML parser close the outer one early —
+        // silently orphaning every field and button that follows, including submit. HTMX can post
+        // multipart straight from the input instead.
+        input(type = InputType.file, classes = "form-control") {
+            name = "litematicFile"
+            accept = ".litematic"
             hxPost("/ideas/create/litematic")
             hxTarget("#draft-item-list")
             hxSwap("beforeend")
+            hxTrigger("change")
             attributes["hx-encoding"] = "multipart/form-data"
-            input(type = InputType.file, classes = "form-control") {
-                name = "litematicFile"
-                accept = ".litematic"
-                attributes["onchange"] = "this.closest('form').requestSubmit()"
-            }
-            p("form-error") { id = "error-litematicFile" }
         }
+        p("form-error") { id = "error-litematicFile" }
     }
 
     // --- Item list ---

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/IdeaAuthorFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/IdeaAuthorFields.kt
@@ -17,19 +17,26 @@ import kotlinx.html.label
 import kotlinx.html.p
 import kotlinx.html.span
 
-fun DIV.singleAuthorFields(data: Author.SingleAuthor? = null) {
+/**
+ * [defaultName] pre-fills the field for a first-time author — almost always the signed-in user
+ * crediting themselves, which was a whole wizard stage's worth of typing for no information
+ * (MCO-310). Still editable, since a design can be someone else's.
+ */
+fun DIV.singleAuthorFields(data: Author.SingleAuthor? = null, defaultName: String = "") {
     label {
         htmlFor = "author-name"
         +"Author Name"
-        span("required-indicator") { +"*" }
     }
     input {
         id = "author-name"
         name = "authorName"
         type = InputType.text
         classes += "form-control"
-        required = true
-        value = data?.name ?: ""
+        // Deliberately NOT `required`. This field lives inside a collapsed <details> on the create
+        // form, and a required control the browser cannot focus blocks submission with no visible
+        // message at all — the form simply does nothing. Left empty it falls back to the signed-in
+        // user, which is what the section already promises (MCO-310).
+        value = data?.name ?: defaultName
         placeholder = "Your name or username"
     }
     p("validation-error-message") {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/IdeaCreateFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/IdeaCreateFields.kt
@@ -254,7 +254,9 @@ fun DIV.renderCreateRateField(field: CategoryField.Rate, value: CategoryValue.In
             if (field.required) required = true
             field.min?.let { attributes["min"] = it.toString() }
             field.max?.let { attributes["max"] = it.toString() }
-            placeholder = field.unit
+            // The unit is already shown as a suffix beside the input; repeating it as the
+            // placeholder printed "items/hour   items/hour" on every rate row.
+            placeholder = "e.g., 1200"
             value?.let {
                 this.value = it.value.toString()
             }
@@ -375,10 +377,19 @@ private fun addMapRowScript(containerId: String) = """
     return false;
 """.trimIndent().replace("\n", " ")
 
+/**
+ * Sub-fields side by side under one heading rather than as full-width rows of their own. The only
+ * struct in the schema is `size`, and X / Y / Z read as one measurement — three stacked rows made a
+ * footprint look like three unrelated questions.
+ */
 fun DIV.renderCreateStructField(versionRange: MinecraftVersionRange, field: CategoryField.StructField, values: CategoryValue.MapValue? = null) {
-    field.fields.forEach { subField ->
-        val value = values?.value?.get(subField.key)
-        renderCreateField(versionRange, subField, value)
+    label { +field.label }
+    div("struct-field-row") {
+        field.fields.forEach { subField ->
+            div("struct-field-cell") {
+                renderCreateField(versionRange, subField, values?.value?.get(subField.key))
+            }
+        }
     }
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/IdeaCreateFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/IdeaCreateFields.kt
@@ -9,7 +9,9 @@ import app.mcorg.presentation.templated.dsl.Icons
 import kotlinx.html.ButtonType
 import kotlinx.html.DIV
 import kotlinx.html.InputType
+import kotlinx.html.button
 import kotlinx.html.classes
+import kotlinx.html.onClick
 import kotlinx.html.div
 import kotlinx.html.id
 import kotlinx.html.input
@@ -115,7 +117,8 @@ fun DIV.renderCreateNumberField(field: CategoryField.Number, value: CategoryValu
             field.min?.let { attributes["min"] = it.toString() }
             field.max?.let { attributes["max"] = it.toString() }
             field.step?.let { attributes["step"] = it.toString() }
-            placeholder = field.label
+            // No placeholder: it was a copy of the label sitting directly above it, which read as
+            // "X Dimension" twice on every size field and told the reader nothing.
             value?.let {
                 this.value = it.value.toString()
             }
@@ -329,6 +332,12 @@ fun DIV.renderCreateTypedMapField(versionRange: MinecraftVersionRange, field: Ca
             }
         }
     }
+    // Column headings once, rather than the key/value labels repeating on every single row. The
+    // per-row labels still exist for screen readers, just visually hidden.
+    div("map-field-head") {
+        span("map-field-head__cell") { +field.keyType.label }
+        span("map-field-head__cell") { +field.valueType.label }
+    }
     div("map-field-container stack stack--xs") {
         id = containerId
         values?.value?.forEach { (k, v) ->
@@ -338,10 +347,10 @@ fun DIV.renderCreateTypedMapField(versionRange: MinecraftVersionRange, field: Ca
         mapFieldRow(versionRange, field)
     }
     div("map-field-actions") {
-        iconButton(Icons.MENU_ADD, "Add Entry") {
-            iconSize = IconSize.SMALL
-            buttonBlock = { type = ButtonType.button }
+        button(classes = "btn btn--ghost btn--sm") {
+            type = ButtonType.button
             onClick = addMapRowScript(containerId)
+            +"+ Add row"
         }
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/utils/htmxResponseUtils.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/utils/htmxResponseUtils.kt
@@ -9,6 +9,22 @@ suspend fun ApplicationCall.clientRedirect(path: String) {
     respond(HttpStatusCode.OK)
 }
 
+/**
+ * Redirect that survives an ordinary link click.
+ *
+ * [clientRedirect] answers `200` with an empty body and an `HX-Redirect` header, which only a
+ * running HTMX request knows how to follow. Reached by a plain `<a href>` it renders a blank page —
+ * exactly what a first-time user got from "New Idea" before MCO-310. Use this wherever the caller
+ * might be either.
+ */
+suspend fun ApplicationCall.redirectClientOrBrowser(path: String) {
+    if (request.headers["HX-Request"] == "true") {
+        clientRedirect(path)
+    } else {
+        respondRedirect(path)
+    }
+}
+
 suspend fun ApplicationCall.respondBadRequest(errorHtml: String = "An error occurred",
                                               target: String = "#error-message",
                                               swap: String = "innerHTML") {

--- a/webapp/mc-web/src/main/resources/static/styles/components/form.css
+++ b/webapp/mc-web/src/main/resources/static/styles/components/form.css
@@ -78,7 +78,9 @@ select.form-control option {
 /* --- Labels (scoped to avoid global override) --- */
 
 .wizard-stage-form label:not(.filter-radio-label):not(.filter-checkbox-label),
-.wizard-fields label:not(.filter-radio-label):not(.filter-checkbox-label) {
+.wizard-fields label:not(.filter-radio-label):not(.filter-checkbox-label),
+.idea-form__required label:not(.filter-radio-label):not(.filter-checkbox-label),
+.idea-form__section-body label:not(.filter-radio-label):not(.filter-checkbox-label) {
     display: block;
     font-family: var(--font-ui);
     font-size: var(--text-sm);

--- a/webapp/mc-web/src/main/resources/static/styles/design-tokens.css
+++ b/webapp/mc-web/src/main/resources/static/styles/design-tokens.css
@@ -148,6 +148,22 @@ main {
     display: none;
 }
 
+/*
+ * Hidden on screen, still announced by screen readers. For labels that a visible column heading
+ * already covers — `display: none` would remove them from the accessibility tree entirely.
+ */
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}
+
 .flex {
     display: flex;
 }

--- a/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
@@ -343,9 +343,17 @@
     margin-top: var(--space-2);
 }
 
-/* Add-an-item is one gesture, so it sits on one line. */
+/*
+ * Add-an-item is one gesture, so it sits on one line.
+ *
+ * Selector has to out-specify `.idea-form__section-body > div`, which stacks every field group into
+ * a column. Losing that fight turns `align-items: flex-end` into right-alignment and makes each
+ * `flex-basis` a height, which is exactly as bad as it sounds.
+ */
+.idea-form__section-body > .item-add-line,
 .item-add-line {
     display: flex;
+    flex-direction: row;
     gap: var(--space-3);
     align-items: flex-end;
     flex-wrap: wrap;

--- a/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
@@ -233,6 +233,20 @@
     flex-direction: column;
 }
 
+/* Struct sub-fields (X / Y / Z) on one line — one measurement, not three questions. */
+.struct-field-row {
+    display: flex;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+}
+
+.struct-field-cell {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 120px;
+    min-width: 0;
+}
+
 /* --- Actions --- */
 
 .idea-form__actions {

--- a/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
@@ -118,6 +118,130 @@
 
 /* --- Stage container --- */
 
+/* ==========================================================================
+   SINGLE-PAGE CREATE FORM (MCO-310)
+   ========================================================================== */
+
+.idea-form-head {
+    margin-top: var(--space-5);
+    margin-bottom: var(--space-5);
+}
+
+.idea-form__title {
+    font-family: var(--font-ui);
+    font-size: var(--text-heading);
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 var(--space-2) 0;
+}
+
+.idea-form__subtitle {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    max-width: 60ch;
+    margin: 0;
+}
+
+/* The only fields visible before any disclosure is opened. */
+.idea-form__required {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: var(--space-5);
+}
+
+.idea-form__required > div {
+    display: flex;
+    flex-direction: column;
+}
+
+/* --- Optional sections --- */
+
+.idea-form__section {
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    margin-top: var(--space-4);
+}
+
+.idea-form__section-summary {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    padding: var(--space-4) var(--space-5);
+    cursor: pointer;
+    list-style: none;
+    position: relative;
+}
+
+/* Replace the default triangle with a rotating chevron of our own. */
+.idea-form__section-summary::-webkit-details-marker {
+    display: none;
+}
+
+.idea-form__section-summary::after {
+    content: "›";
+    position: absolute;
+    right: var(--space-5);
+    top: 50%;
+    transform: translateY(-50%);
+    font-family: var(--font-ui);
+    font-size: var(--text-base);
+    color: var(--text-muted);
+    transition: transform var(--transition-base);
+}
+
+.idea-form__section[open] .idea-form__section-summary::after {
+    transform: translateY(-50%) rotate(90deg);
+}
+
+.idea-form__section-summary:hover .idea-form__section-title {
+    color: var(--accent);
+}
+
+.idea-form__section-title {
+    font-family: var(--font-ui);
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+    transition: color var(--transition-base);
+}
+
+.idea-form__section-hint {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    padding-right: var(--space-5);
+}
+
+.idea-form__section-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-5);
+    padding: 0 var(--space-5) var(--space-5);
+    border-top: 1px solid var(--border);
+    padding-top: var(--space-5);
+}
+
+.idea-form__section-body > div {
+    display: flex;
+    flex-direction: column;
+}
+
+/* --- Actions --- */
+
+.idea-form__actions {
+    display: flex;
+    gap: var(--space-3);
+    align-items: center;
+    margin-top: var(--space-5);
+}
+
 .wizard-stage-container {
     display: flex;
     flex-direction: column;

--- a/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
@@ -343,6 +343,60 @@
     margin-top: var(--space-2);
 }
 
+/* Add-an-item is one gesture, so it sits on one line. */
+.item-add-line {
+    display: flex;
+    gap: var(--space-3);
+    align-items: flex-end;
+    flex-wrap: wrap;
+}
+
+.item-add-line__search {
+    flex: 1 1 260px;
+    min-width: 0;
+}
+
+.item-add-line__qty {
+    display: flex;
+    flex-direction: column;
+    flex: 0 0 110px;
+}
+
+.item-add-line__action {
+    flex: 0 0 auto;
+}
+
+.map-field-head {
+    display: flex;
+    gap: var(--space-2);
+    /* Leave room for the per-row remove button so the headings line up with their columns. */
+    padding-right: 44px;
+    margin-bottom: var(--space-1);
+}
+
+.map-field-head__cell {
+    flex: 1 1 0;
+    min-width: 0;
+    font-family: var(--font-ui);
+    font-size: var(--text-label);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+}
+
+/* The column headings above say this once; repeating it per row is noise. */
+.map-field-row label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}
+
 .map-field-row {
     align-items: flex-end;
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/draft/DeserializeDraftStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/draft/DeserializeDraftStepTest.kt
@@ -155,12 +155,12 @@ class DeserializeDraftStepTest {
     }
 
     @Test
-    fun `missing description returns validation error`() = runBlocking {
+    fun `a description is optional and becomes empty (MCO-310)`() = runBlocking {
+        // A private design may be a name and a category. Requiring twenty characters of prose is a
+        // rule about what belongs on the community hub, and that is a separate step.
         val result = DeserializeDraftStep.process(makeDraft(missingDescription()))
-        assertIs<Result.Failure<*>>(result)
-        val error = (result as Result.Failure).error
-        assertIs<AppFailure.ValidationError>(error)
-        assertTrue(error.errors.any { it is ValidationFailure.MissingParameter && it.parameterName == "description" })
+        assertIs<Result.Success<*>>(result)
+        assertTrue((result as Result.Success).value.description.isEmpty())
     }
 
     @Test
@@ -200,12 +200,12 @@ class DeserializeDraftStepTest {
     }
 
     @Test
-    fun `missing categoryData with category set returns validation error`() = runBlocking {
+    fun `category data is optional (MCO-310)`() = runBlocking {
+        // After the MCO-204 slimming nearly every category field is optional, so demanding a
+        // non-empty block meant a minimally-filled idea could never be saved at all.
         val result = DeserializeDraftStep.process(makeDraft(missingCategoryData()))
-        assertIs<Result.Failure<*>>(result)
-        val error = (result as Result.Failure).error
-        assertIs<AppFailure.ValidationError>(error)
-        assertTrue(error.errors.any { it is ValidationFailure.MissingParameter && it.parameterName == "categoryData" })
+        assertIs<Result.Success<*>>(result)
+        assertTrue((result as Result.Success).value.categoryData.isEmpty())
     }
 
     @Test
@@ -214,8 +214,8 @@ class DeserializeDraftStepTest {
         assertIs<Result.Failure<*>>(result)
         val error = (result as Result.Failure).error
         assertIs<AppFailure.ValidationError>(error)
-        // name, description, difficulty, category, author, versionRange all missing
-        assertTrue(error.errors.size >= 6)
+        // name, difficulty, category, author, versionRange — description is no longer required
+        assertTrue(error.errors.size >= 5)
     }
 
     @Test
@@ -226,7 +226,6 @@ class DeserializeDraftStepTest {
         assertIs<AppFailure.ValidationError>(error)
         val fieldNames = error.errors.filterIsInstance<ValidationFailure.MissingParameter>().map { it.parameterName }
         assertContains(fieldNames, "name")
-        assertContains(fieldNames, "description")
         assertContains(fieldNames, "difficulty")
         assertContains(fieldNames, "category")
         assertContains(fieldNames, "author")

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/idea/DraftLifecycleIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/idea/DraftLifecycleIT.kt
@@ -29,8 +29,10 @@ import app.mcorg.test.postgres.DatabaseTestExtension
 import io.ktor.client.request.delete
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.Parameters
 import io.ktor.server.routing.delete
@@ -181,12 +183,35 @@ class DraftLifecycleIT : WithUser() {
             }
         }
 
+        // A real redirect, because "New Idea" on the hub is an ordinary link. Answering 200 with
+        // an HX-Redirect header rendered a blank page for anyone without drafts yet (MCO-310).
         val response = client.get("/ideas/create") { addAuthCookie(this, ideaCreator) }
+        assertEquals(HttpStatusCode.Found, response.status)
+        val location = response.headers[HttpHeaders.Location]
+        assertNotNull(location)
+        assertContains(location, "/ideas/drafts/")
+        assertContains(location, "/edit")
+    }
+
+    @Test
+    fun `GET ideas-create still answers HTMX with an HX-Redirect`() = testApplication {
+        val ideaCreator = createExtraUser("idea_creator")
+        val client = createClient { followRedirects = false }
+
+        routing {
+            install(AuthPlugin)
+            route("/ideas/create") {
+                get { call.handleGetDraftList() }
+            }
+        }
+
+        val response = client.get("/ideas/create") {
+            addAuthCookie(this, ideaCreator)
+            header("HX-Request", "true")
+        }
+
         assertEquals(HttpStatusCode.OK, response.status)
-        val hxRedirect = response.headers["HX-Redirect"]
-        assertNotNull(hxRedirect)
-        assertContains(hxRedirect, "/ideas/drafts/")
-        assertContains(hxRedirect, "/edit")
+        assertNotNull(response.headers["HX-Redirect"])
     }
 
     @Test
@@ -219,8 +244,8 @@ class DraftLifecycleIT : WithUser() {
 
         // Creating is open to everyone now; only putting a design on the hub is privileged.
         val response = client.get("/ideas/create") { addAuthCookie(this) }
-        assertEquals(HttpStatusCode.OK, response.status)
-        assertNotNull(response.headers["HX-Redirect"])
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertNotNull(response.headers[HttpHeaders.Location])
     }
 
     @Test
@@ -243,7 +268,7 @@ class DraftLifecycleIT : WithUser() {
     }
 
     @Test
-    fun `GET drafts-draftId-edit shows wizard page`() = testApplication {
+    fun `GET drafts-draftId-edit shows every field on one page (MCO-310)`() = testApplication {
         val ideaCreator = createExtraUser("idea_creator")
         val draftId = runBlocking { (CreateDraftStep(ideaCreator.id).process(Unit) as Result.Success).value }
 
@@ -258,7 +283,18 @@ class DraftLifecycleIT : WithUser() {
         assertEquals(HttpStatusCode.OK, response.status)
         val body = response.bodyAsText()
         assertContains(body, "app-header")
-        assertContains(body, "wizard-stage")
+
+        // Required fields up front...
+        assertContains(body, "idea-form__required")
+        assertContains(body, """name="name"""")
+        assertContains(body, """name="category"""")
+        // ...and the optional ones present in the same form rather than on later screens.
+        assertContains(body, """name="versionRangeType"""")
+        assertContains(body, """name="authorName"""")
+
+        // A nested <form> here would make the parser close the outer one early and orphan the
+        // submit button — the fields would render but nothing could be submitted.
+        assertEquals(1, Regex("<form").findAll(body).count())
     }
 
     @Test

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/idea/DraftLifecycleIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/idea/DraftLifecycleIT.kt
@@ -217,7 +217,13 @@ class DraftLifecycleIT : WithUser() {
     @Test
     fun `GET ideas-create shows draft list when drafts exist`() = testApplication {
         val ideaCreator = createExtraUser("idea_creator")
-        runBlocking { CreateDraftStep(ideaCreator.id).process(Unit) }
+        val draftId = runBlocking { (CreateDraftStep(ideaCreator.id).process(Unit) as Result.Success).value }
+        // A draft only earns a place in the list once it holds something.
+        runBlocking {
+            UpdateDraftStep().process(
+                UpdateDraftInput(draftId, ideaCreator.id, """{"name":"Half-written farm"}""", "BASIC_INFO")
+            )
+        }
 
         routing {
             install(AuthPlugin)
@@ -229,6 +235,43 @@ class DraftLifecycleIT : WithUser() {
         val response = client.get("/ideas/create") { addAuthCookie(this, ideaCreator) }
         assertEquals(HttpStatusCode.OK, response.status)
         assertContains(response.bodyAsText(), "My Drafts")
+    }
+
+    @Test
+    fun `GET ideas-create reopens a blank draft instead of listing it (MCO-310)`() = testApplication {
+        val ideaCreator = createExtraUser("idea_creator")
+        val draftId = runBlocking { (CreateDraftStep(ideaCreator.id).process(Unit) as Result.Success).value }
+        val client = createClient { followRedirects = false }
+
+        routing {
+            install(AuthPlugin)
+            route("/ideas/create") {
+                get { call.handleGetDraftList() }
+            }
+        }
+
+        // Every blank draft is the same blank draft. Listing them produced a column of
+        // indistinguishable "Untitled Draft" rows after a couple of aborted visits.
+        val response = client.get("/ideas/create") { addAuthCookie(this, ideaCreator) }
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertContains(response.headers[HttpHeaders.Location]!!, "/ideas/drafts/$draftId/edit")
+    }
+
+    @Test
+    fun `POST ideas-create reuses a blank draft rather than making another (MCO-310)`() = testApplication {
+        val ideaCreator = createExtraUser("idea_creator")
+        val draftId = runBlocking { (CreateDraftStep(ideaCreator.id).process(Unit) as Result.Success).value }
+
+        routing {
+            install(AuthPlugin)
+            route("/ideas/create") {
+                post { call.handleCreateDraft() }
+            }
+        }
+
+        val response = client.post("/ideas/create") { addAuthCookie(this, ideaCreator) }
+        assertContains(response.headers["HX-Redirect"]!!, "/ideas/drafts/$draftId/edit")
+        assertEquals(1, runBlocking { (GetDraftsStep(ideaCreator.id).process(Unit) as Result.Success).value.size })
     }
 
     @Test


### PR DESCRIPTION
Submission throughput is the binding constraint on the idea bank — MCO-294 has nothing to match against until real designs exist. This is the flow half of that; MCO-291 already removed the role gate on creating.

## The audit

Of the wizard's six stages, three were pass-throughs:

| Stage | What it actually required |
|---|---|
| Basic Info | name, description, difficulty — **the real content** |
| Author | **one field**, asking who you are when we already know |
| Version | **one dropdown, pre-defaulted** to "All Versions" |
| Items | **no validation at all** |
| Category | category + schema fields; post-MCO-204 only CART_TECH has a required field |
| Review | no validation — a summary and a button |

Driving it by hand: one word typed into Author, Continue on Version's default, Continue on an empty Items stage. Six screens for what is name + description + category.

## What it is now

One page. Required fields up front, everything else behind three collapsed `<details>` sections — native disclosure, so the fields still post and stay keyboard- and find-in-page accessible. Author pre-fills from your Minecraft username, and an empty author still credits you, which is what the section promises. Submitting produces a *private* idea, so nothing here says "publish".

**Difficulty is a radio group** rather than a select: five options fits one row, it matches the category picker below it, and it saves a click on a field that is always answered. Worth noting what this exposed — `IdeaDifficulty` is two axes in one (how far into the game you are, and how much redstone knowledge it takes), so a single-choice control cannot express "end game *and* technical". The dropdown hid that. Not changed here.

**Description is no longer required, and neither is category data.** A private design may be a name and a category; a twenty-character minimum is a rule about what belongs on the community hub, and that is a separate step which can carry its own requirements later. Category data being mandatory was already wrong after MCO-204 made nearly every category field optional.

## Bugs found by driving it rather than reading it

- **"New Idea" led to a blank page.** `/ideas/create` answered `200` with an `HX-Redirect` header, which only an in-flight HTMX request can follow — but the hub links to it with a plain `<a>`. Anyone without drafts got an empty document. This was live before this branch; the old role gate just hid the button. Added `redirectClientOrBrowser`.
- **Submit did nothing — no request, no message.** The item-requirements fields contained their own `<form>` for litematica upload, and a nested `<form>` makes the HTML parser close the outer one early, orphaning every field and button after it. Replaced with a bare input that posts multipart itself.
- **Publishing 415'd on a bodyless POST** once the handler started reading parameters. That now means "publish what is stored" rather than clobbering the draft with empty values.
- **Unticked checkboxes were stored as explicit `false`**, putting three "No" rows the author never asserted onto every minimally-filled idea's detail page. Only ticked boxes are recorded; absence already means false. This one interacts with the relaxations above — together they would have made minimal ideas unsaveable, caught by reading the publish path before testing it.

## Field-level pass

Typed maps (specs, production rate) repeated their key/value labels on every row — headed once now, per-row labels visually hidden but still in the accessibility tree (added a `.visually-hidden` utility; `display: none` would drop them). Number fields used their label as placeholder, so size read "X Dimension" twice per axis. "Add Entry" was a bare icon, now "+ Add row". Size renders X / Y / Z on one line. Rate fields no longer print their unit twice. Blank drafts are reused rather than stacking up identical "Untitled Draft" rows.

Label styling was scoped to `.wizard-stage-form` / `.wizard-fields`, neither of which the new form uses — labels were falling back to Inter by accident and now take `--font-ui` as the design system intends. **This is the most visible change in the diff's texture**, so worth a deliberate look.

## Testing

745 unit + 432 database. Six `DraftLifecycleIT` tests asserted the old wizard contract and now assert the new one, including a guard that the page contains exactly one `<form>` — the nested-form failure was completely invisible, so it deserves a test.

Verified in the running app with screenshots at each step, including every optional section **expanded**. That last part matters: an earlier revision shipped a broken Materials layout because I only checked the collapsed page.

## Known follow-ups

- The old wizard's `POST /stage` handler and stage-rendering functions are unreachable from the UI but still covered by tests. Deliberately not deleted here — a large removal does not belong in a UX change.
- The three booleans (Tileable / Directional / AFK-able) each render as a full-width bordered box and eat vertical space. Compacting them is a taste call about checkboxes app-wide, since the same class styles the filter sidebar.
- `specs` ergonomics beyond the column headings are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
