### PR TITLE
Synthetic sources for circular acquisitions + phantom catalog items

### DIFF
--- a/documentation/work-documents/gathering-planner/block-transformer-analysis.md
+++ b/documentation/work-documents/gathering-planner/block-transformer-analysis.md
@@ -1,0 +1,263 @@
+# `minecraft:block_transformer` — extraction analysis
+
+Status: **analysis (2026-07-03)** — snapshot only. Decision: **do it after 26.3 releases**
+(autumn), not off snapshots. This document captures findings so the work can start the
+day the full release lands.
+
+> **Update 2026-08-11.** Re-checked against 26.3 snapshot 7 while shipping the hardcoded
+> synthetic sources. The decision to wait still stands: **26.3 has not released** (planned
+> "Q3 2026"), and **honeycomb/waxing is still hardcoded**, so the no-cycle finding in §3
+> holds. The component gained an `update_from_neighbors` field; carriers are still only
+> axes, hoes and shovels.
+>
+> Two corrections from measuring against the real ingested graph rather than the component
+> JSON — see [§5](#5-what-changed-once-we-measured-the-graph-2026-08).
+
+Origin: 26.3 Snapshot 2 (2026-06-30) added the `minecraft:block_transformer` data
+component. It looked directly relevant to the synthetic in-world-transform sources we
+just shipped ([synthetic-sources-design.md](synthetic-sources-design.md)), so we
+investigated whether — and how — it can feed the graph.
+
+## TL;DR
+
+- `block_transformer` **is** the data-driven form of our `IN_WORLD_TRANSFORM`
+  (`mcorg:in_world_transform`) MechanicType: item-on-block interaction turns one block
+  into another, optionally dropping loot.
+- It is **not present in any datapack JSON inside the server JAR** — it exists only as a
+  code-defined default item component. The only way to extract it is to run Mojang's
+  **data generator** (`--reports`) and parse the per-item component reports.
+- The high-value payload is **log/wood stripping** (`oak_log → stripped_oak_log`, ×25 in the
+  component — but only **×12 are actually gaps in our graph**, see §5.1), which today
+  resolves *incorrectly* (circular self-break). It plugs into the existing
+  `isConstructive()` / self-block-penalty machinery with **zero scorer change**.
+- Cost is an **ingestion-architecture change**: `GetServerFilesPipeline` currently only
+  unzips JSON from the JAR; consuming this component means it must also run the data
+  generator (JDK-version-locked, ~1 min per JAR) and parse a new report tree. **Agreed
+  worth it post-26.3** — the component will almost certainly be expanded across the
+  remaining snapshots before the autumn release.
+
+---
+
+## 1. What we were looking for
+
+The question was narrow and decisive: **is `block_transformer` reachable by our
+extraction pipeline, and if so in what shape?** Concretely:
+
+- Does the component appear in files we already pull out of the server JAR
+  (`data/minecraft/**` — recipes, loot tables, tags), or only somewhere we don't read?
+- If we can get it, is the input-block → output-block mapping parseable into
+  `ResourceSource` rows (requiredItems / producedItems), the way recipes and loot are?
+- Which items/blocks does it cover, and how much of it is genuinely useful for planning
+  vs. noise?
+
+That determines whether this is "a new parser on the existing extraction" or "a new
+capability in the ingestion pipeline."
+
+## 2. How we went about finding it
+
+Server JAR analysed: `26.3-snapshot-2`
+(`https://piston-data.mojang.com/v1/objects/a6e2ae24c95dc838456927661a82434d26936d2f/server.jar`).
+
+1. **Downloaded and unzipped the JAR.** Modern server JARs are a *bootstrap*: the real
+   server lives at `META-INF/versions/26.3-snapshot-2/server-26.3-snapshot-2.jar`
+   (found via `META-INF/versions.list`). Extracted that bundled jar.
+2. **Grepped every `data/**.json` in the bundled jar for `block_transformer`.**
+   Zero hits. Grepped the raw bytecode: **exactly one hit** — the component-id string
+   constant in a class file. Conclusion: it is a *code-defined default component*, not a
+   datapack resource. Also confirmed the jar ships **no** `reports/` or `items.json`.
+3. **Ran the data generator** to see whether the component surfaces in generated reports:
+   `java -DbundlerMainClass=net.minecraft.data.Main -jar server.jar --reports`.
+   - First attempt failed: `UnsupportedClassVersionError` — class file version **69.0**,
+     i.e. the jar requires **JDK 25**. (Local default was 21.) Pulled a Temurin 25 build
+     and re-ran.
+   - Output landed under `generated/reports/minecraft/components/item/<item>.json` — one
+     file per item, each a `{ "components": { … } }` object. (Note: the old single
+     `reports/items.json` is gone; components are now split per item.)
+4. **Parsed the reports** for every item carrying the component and extracted the
+   input→output pairs, `loot`, `sound`, and `consume_on_use` fields to gauge shape and
+   value.
+
+## 3. What we found
+
+### Carriers
+
+**21 items, all tools** — axes, hoes, shovels across all six material tiers
+(`wooden`/`stone`/`copper`/`iron`/`golden`/`diamond`/`netherite`). **Honeycomb does
+*not* carry it yet** — copper *waxing* (`wax_on`) is still handled by legacy interaction
+code, not migrated to the component. (This matters for cycles — see below.)
+
+### JSON shape (parseable)
+
+Each component is a **list of rule objects**. The mapping we need is:
+
+- **input block** = `block_state_provider.rules[].if_true.blocks` (a block id or list,
+  predicate type `minecraft:matching_blocks`)
+- **output block** = the `then` provider's `…state.Name`
+
+Real example (`iron_axe`, first rule):
+
+```json
+{
+  "block_state_provider": {
+    "type": "minecraft:rule_based_state_provider",
+    "rules": [{
+      "if_true": { "type": "minecraft:matching_blocks", "blocks": "minecraft:oak_log" },
+      "then": {
+        "type": "minecraft:copy_properties_provider",
+        "source_block_state_provider": {
+          "type": "minecraft:simple_state_provider",
+          "state": { "Name": "minecraft:stripped_oak_log", "Properties": { "axis": "y" } }
+        }
+      }
+    }]
+  },
+  "item_damage_per_use": 1,
+  "sound": "minecraft:item.axe.strip"
+}
+```
+
+Other relevant fields on an entry: `loot` (a loot table id — extra drops on success),
+`consume_on_use` (bool), `drop_strategy`, `transform_type` (`single_block` /
+`copper_chest`), `particle`, `disallowed_faces`.
+
+### What each tool does (verified extraction)
+
+| Tool  | Rules | Breakdown |
+|-------|------:|-----------|
+| Axe   | 130 (identical across all tiers) | 25× **strip** (`item.axe.strip`: `oak_log→stripped_oak_log`, `oak_wood→stripped_oak_wood`, …), 45× **scrape** (`item.axe.scrape`: de-oxidise copper one step), 60× **wax_off** (`item.axe.wax_off`: `waxed_x → x`) |
+| Hoe   | 3   | `coarse_dirt→dirt`, `rooted_dirt→dirt` (**+ `loot: minecraft:till/rooted_dirt`** → hanging_roots), and `→farmland` (no clean single input — uses a non-`matching_blocks` predicate) |
+| Shovel| 1   | `→dirt_path` (no clean single input) |
+
+`consume_on_use` reads as default (true) on every entry, but all 21 carriers are
+**non-stackable tools**, so nothing is consumed — the spec note says `consume_on_use`
+"only applies to stackable items." The tool is not a material; only the input block is.
+So every source here has **one input block → one output block**, no consumed item.
+
+### Value, in tiers
+
+1. **Log/wood stripping (25 pairs) — the gold.** `stripped_*_log`/`stripped_*_wood` are
+   extremely common build blocks and today resolve *wrong*: their only source in our
+   graph is self-break loot (drops itself → circular). A `stripped_oak_log ← oak_log`
+   `IN_WORLD_TRANSFORM` source makes the plan chain correctly to logging.
+2. **Hoe tilling with loot (`rooted_dirt→dirt` + hanging_roots) — minor but free** once
+   the parser exists.
+3. **Copper scrape / wax_off (105 of 130 axe rules) — noise, recommend excluding.**
+   Marginal planning value (weathered/waxed copper is time-gated in reality; scrape is a
+   half-circular path), high node count, and it introduces reverse-weathering edges the
+   graph doesn't otherwise model. Defer or gate behind a flag.
+
+### Two convenient facts
+
+- **The reception machinery already exists.** `block_transformer` *is*
+  `IN_WORLD_TRANSFORM`. `SourceType.isConstructive()` already includes it, and the
+  self-block-loot penalty was just broadened from "has a recipe sibling" to "has a
+  constructive sibling" (synthetic-sources PR #334). So a stripped log's circular
+  self-break is penalised **automatically** the moment the transform source exists —
+  **no scorer change required.** `GatheringPlan` already maps `IN_WORLD_TRANSFORM →
+  ActivityGroup.CRAFT`.
+- **No cycle risk right now.** Because *waxing* (`wax_on`) is not yet on the component,
+  `wax_off` has no data-driven inverse — so no `copper ↔ waxed_copper` 2-cycle. This can
+  change if honeycomb gains the component in a later snapshot; revisit then (the graph's
+  structural cycle rejection should cover it, but add a test).
+
+## 4. What this means for the ingestion algorithm, post-26.3
+
+Today `GetServerFilesPipeline` downloads a server JAR and extracts JSON straight out of
+it (`data/minecraft/**`). `block_transformer` is **not** in that JSON, so consuming it
+requires a genuinely new step:
+
+1. **Run the data generator** on the downloaded JAR:
+   `java -DbundlerMainClass=net.minecraft.data.Main -jar server.jar --reports`, then read
+   `generated/reports/minecraft/components/item/*.json`. This is new capability, not a
+   new parser — the ingest machine must now *execute* the JAR, not just unzip it.
+   - **JDK version lock:** the generator refuses to run on an older JDK than the JAR was
+     built with (26.3-snapshot-2 = class file 69.0 = JDK 25). The ingest environment's
+     JDK must be ≥ the target version's. As Minecraft advances this is a moving
+     requirement — worth pinning the ingest image to the newest JDK, or selecting a JDK
+     per target version.
+   - Runtime cost ~1 min per JAR to generate reports; acceptable for the daily
+     ledger-driven ingest (only new/changed versions run).
+   - **Version gating is free:** pre-26.3 JARs simply emit no `block_transformer` in
+     their reports, so the extractor yields nothing for them. No special-casing.
+2. **Parse the component reports into `ResourceSource`s** (a new `mc-data` extractor,
+   mirroring `SyntheticSources` / the recipe parsers):
+   - For each entry, read `if_true.blocks` (input) and `then…state.Name` (output).
+     Emit a source: `producedItems = [output ×1]`, `requiredItems = [input ×1]`,
+     `type = IN_WORLD_TRANSFORM`. If `loot` is present, resolve that loot table and add
+     its averaged drops to `producedItems` (reuse `LootYield`).
+   - **Dedupe across tool tiers** — the same (input, output) pair appears on every axe
+     material. Emit one source per pair, keyed on the pair, not per tool. Filename
+     convention e.g. `block_transform/<output>.json` (parallels `synthetic/<name>.json`).
+   - **Skip entries with no `matching_blocks` input** (farmland, dirt_path) — no clean
+     single input, and low planning value. Optionally hardcode those few as synthetic if
+     ever wanted.
+   - **Scope decision:** ship **strip (+ hoe-loot)** first; exclude copper scrape/wax_off
+     unless we later decide the weathered-copper chains are worth the noise.
+3. **Bump `ExtractionVersion.CURRENT`** (+ a `History:` line) so existing versions
+   re-ingest once and pick up the new sources.
+
+Everything downstream is already in place: graph builder treats these like any
+`ResourceSource`; `IN_WORLD_TRANSFORM` already scores, groups, and triggers the
+self-block penalty.
+
+### Why wait for the full release
+
+This is a snapshot. The component is brand-new and clearly mid-migration (only tools
+carry it; waxing isn't on it yet; the farmland/dirt_path rules use predicates we don't
+parse). It will very likely gain carriers and rules across the remaining snapshots
+(honeycomb waxing, possibly more block interactions) before the autumn release. Building
+the extractor now would target a moving format. Capture the approach (this doc), and
+implement against the stable release — at which point the ingest-runs-the-generator step
+is the one real piece of new architecture, and the strip payload is low-hanging fruit
+that drops straight into the existing `IN_WORLD_TRANSFORM` machinery.
+
+## 5. What changed once we measured the graph (2026-08)
+
+The §3 analysis read the *component JSON*. Running the `circular` score diagnostic against
+the real ingested graph (26.2.0) changed two conclusions.
+
+### 5.1 Stripping is 12 pairs for us, not 25
+
+The component carries 25 strip rules, but only **12** are circular in our graph:
+
+```
+stripped_{oak,birch,spruce,jungle,acacia,dark_oak,mangrove,cherry,pale_oak}_log
+stripped_{crimson,warped}_stem
+stripped_bamboo_block
+```
+
+The six-sided `stripped_*_wood` / `*_hyphae` variants are **craftable from their stripped
+log**, so the recipe extractor already covers them and they were never broken. An extractor
+that emits all 25 is not wrong, just redundant for half of them — worth deduping against
+existing recipe sources rather than assuming every rule is a gap.
+
+### 5.2 These entries are permanent, not scaffolding
+
+The original framing implied the extractor would *replace* the hardcoded sources. It cannot:
+**`block_transformer` only exists in 26.3+, and we support back to 1.18** (possibly 1.12
+later). Everything below 26.3 stays on `SyntheticSources` forever.
+
+So the extractor's job is **per-version supersession, not replacement** — for 26.3+ emit from
+the generator reports and suppress the hardcoded equivalents; for older versions keep the
+hardcoded ones. `SyntheticSources.all(itemIds)` is now filtered against the version's item
+registry, which gives the natural seam: entries are written for the newest version and prune
+themselves backwards.
+
+### 5.3 Shipped ahead of this work
+
+The hardcoded pass (ExtractionVersion 3) covered the 12 strips, `mud`, `dirt_path`,
+`farmland`, and the filled bucket *items* (`water_bucket`/`lava_bucket`/`powder_snow_bucket`
+— the latter two had no source at all). Copper scrape/wax_off remains excluded, but the
+1.21.9 copper expansion made that a bigger call than §3 assumed — tracked as MCO-314.
+
+## Open decisions for implementation time
+
+1. **Scope:** strip + hoe-loot only, or also copper scrape/wax_off? (Recommend the
+   former — but see MCO-314; the copper family is now ~24 circular ids, not a handful.)
+2. **JDK selection** for the ingest generator step — pin newest, or per-version.
+3. **Cycle test** if a later snapshot puts waxing on the component. (Still not on it as of
+   26.3 snapshot 7.)
+4. **Supersession rule** (§5.2): how a 26.3+ generated source suppresses its hardcoded twin
+   without double-producing. Keying on (input, output) pair rather than filename is the
+   obvious approach, since the filenames deliberately differ (`synthetic/` vs
+   `block_transform/`).

--- a/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/ExtractionVersion.kt
+++ b/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/ExtractionVersion.kt
@@ -25,7 +25,12 @@ package app.mcorg.data.minecraft
  *       two of which had no source at all). Synthetic sources are now filtered against the
  *       version's item registry, so older versions no longer receive entries for items they
  *       don't have (2026-08).
+ *  - 4: prune the lang-derived item registry of legacy ids whose replacement is present
+ *       (chain/iron_chain, grass/short_grass, scute/turtle_scute, sign/oak_sign) and of
+ *       family-label keys that were never items (smithing_template, harness, set_spawn).
+ *       Mojang keeps the old lang key after a rename, so both spellings looked like registry
+ *       entries while only the new one is ever produced — MCO-313 (2026-08).
  */
 object ExtractionVersion {
-    const val CURRENT = 3
+    const val CURRENT = 4
 }

--- a/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/ExtractionVersion.kt
+++ b/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/ExtractionVersion.kt
@@ -19,7 +19,13 @@ package app.mcorg.data.minecraft
  *       infested_deepslate) — their base-block Silk Touch drop is a phantom overridden by
  *       InfestedBlock's code-level destroy handling and was winning over crafting as a fake
  *       raw-gather source (MCO-248, 2026-07).
+ *  - 3: synthetic sources for the circular and missing acquisitions found by the
+ *       `circular`/`unobtainable` score diagnostics — axe-stripping (12 logs/stems), mud,
+ *       dirt_path, farmland, and the filled bucket *items* (water/lava/powder snow, the last
+ *       two of which had no source at all). Synthetic sources are now filtered against the
+ *       version's item registry, so older versions no longer receive entries for items they
+ *       don't have (2026-08).
  */
 object ExtractionVersion {
-    const val CURRENT = 2
+    const val CURRENT = 3
 }

--- a/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/extract/ExtractResourceSources.kt
+++ b/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/extract/ExtractResourceSources.kt
@@ -16,7 +16,7 @@ data object ExtractResourceSources : Step<ExtractionContext, ExtractionFailure, 
         return lootTablesResult.flatMap { lootTables ->
             recipesResult.flatMap { recipes ->
                 tradesResult.map { trades ->
-                    lootTables + recipes + trades + SyntheticSources.all()
+                    lootTables + recipes + trades + SyntheticSources.all(input.itemIds)
                 }
             }
         }

--- a/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/extract/ExtractionContext.kt
+++ b/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/extract/ExtractionContext.kt
@@ -137,19 +137,59 @@ object ExtractionContextFactory {
      * The version's item registry, read off the lang file: every dot-free
      * `item.minecraft.X` / `block.minecraft.X` key is an id. Dotted suffixes
      * (`item.minecraft.splash_potion.effect.luck`) are auxiliary strings, not items.
+     *
+     * Then pruned of the two ways that heuristic over-reads — see [RENAMED_ITEMS] and
+     * [NON_ITEM_KEYS] (MCO-313).
      */
-    private fun registryIds(raw: Map<String, String>): Set<String> = buildSet {
-        raw.keys.forEach { key ->
-            for (prefix in listOf("item.minecraft.", "block.minecraft.")) {
-                if (key.startsWith(prefix)) {
-                    val id = key.removePrefix(prefix)
-                    if (!id.contains('.')) {
-                        add("minecraft:$id")
+    internal fun registryIds(raw: Map<String, String>): Set<String> {
+        val ids = buildSet {
+            raw.keys.forEach { key ->
+                for (prefix in listOf("item.minecraft.", "block.minecraft.")) {
+                    if (key.startsWith(prefix)) {
+                        val id = key.removePrefix(prefix)
+                        if (!id.contains('.')) {
+                            add("minecraft:$id")
+                        }
                     }
                 }
             }
         }
+
+        // Drop a legacy id only when its replacement is present. That makes the rule
+        // self-versioning with no version ranges to maintain: 1.18 has no short_grass, so it
+        // keeps `grass`; 26.2 has both, so `grass` goes.
+        val supersededLegacyIds = RENAMED_ITEMS
+            .filter { (_, current) -> current in ids }
+            .keys
+
+        return ids - supersededLegacyIds - NON_ITEM_KEYS
     }
+
+    /**
+     * Legacy id -> the id that replaced it. Mojang's lang file keeps the old key around long
+     * after a rename, so both spellings look like registry entries while only the new one is
+     * produced by any recipe or loot table — leaving the old one permanently BLOCKED.
+     *
+     * Only ever prunes the legacy id when the replacement exists in the same version, so
+     * versions predating a rename are untouched.
+     */
+    private val RENAMED_ITEMS = mapOf(
+        "minecraft:chain" to "minecraft:iron_chain",       // 1.21.9, when copper chains arrived
+        "minecraft:grass" to "minecraft:short_grass",      // 1.20.3
+        "minecraft:scute" to "minecraft:turtle_scute",     // 1.20.5
+        "minecraft:sign" to "minecraft:oak_sign",          // 1.14
+    )
+
+    /**
+     * Dot-free `item.`/`block.` lang keys that were never items — generic labels shared by a
+     * family (`item.minecraft.smithing_template` is the "Smithing Template" heading used by
+     * every template) or UI messages that happen to sit under the block namespace.
+     */
+    private val NON_ITEM_KEYS = setOf(
+        "minecraft:smithing_template",
+        "minecraft:harness",
+        "minecraft:set_spawn",
+    )
 
     private fun loadNames(version: MinecraftVersion.Release, root: Path): Result<ExtractionFailure, Map<String, String>> {
         try {

--- a/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/extract/SyntheticSources.kt
+++ b/webapp/mc-data/src/main/kotlin/app/mcorg/data/minecraft/extract/SyntheticSources.kt
@@ -6,9 +6,9 @@ import app.mcorg.domain.model.resources.ResourceSource
 import app.mcorg.domain.model.resources.ResourceSource.SourceType
 
 /**
- * Hardcoded acquisition sources for items Mojang's data files don't describe — game
- * mechanics (place concrete powder next to water), tool-based world collection (fill a
- * bucket, break ice), bee harvesting, and the wither's nether star.
+ * Hardcoded acquisition sources for items Mojang's data files don't describe — in-world
+ * transforms (place concrete powder next to water, strip a log, make mud), tool-based world
+ * collection (fill a bucket, break ice), bee harvesting, and the wither's nether star.
  *
  * These are plain [ResourceSource]s appended to the extracted recipe/loot/trade sources in
  * [ExtractResourceSources]; they are stored and graph-built exactly like real ones, so the
@@ -17,6 +17,18 @@ import app.mcorg.domain.model.resources.ResourceSource.SourceType
  *
  * Item display names are left blank; they resolve from the version's item catalog on load
  * (`LoadResourceSourcesForVersionStep`), the same as recipe-parser output.
+ *
+ * **Version-filtered.** [all] takes the version's item registry and drops any entry naming an
+ * id that version doesn't have, so 1.18 never gains a phantom `stripped_cherry_log`. Entries
+ * are therefore written for the newest version and prune themselves backwards — the further
+ * back the supported range goes, the more this carries.
+ *
+ * **Relationship to `minecraft:block_transformer` (26.3+).** That component is the data-driven
+ * form of [SourceType.MechanicTypes.IN_WORLD_TRANSFORM] and will eventually let us extract log
+ * stripping, tilling and path-making instead of hardcoding them — but *only for 26.3 and up*.
+ * Everything below stays on this registry permanently, so a future extractor supersedes these
+ * entries per-version rather than replacing them. See
+ * `documentation/work-documents/gathering-planner/block-transformer-analysis.md`.
  */
 object SyntheticSources {
 
@@ -26,7 +38,29 @@ object SyntheticSources {
         "light_gray", "cyan", "purple", "blue", "brown", "green", "red", "black",
     )
 
-    fun all(): List<ResourceSource> = buildList {
+    /**
+     * Blocks an axe strips into a `stripped_` counterpart. Only these are listed: the six-sided
+     * `*_wood` / `*_hyphae` variants are craftable from their stripped log, so the recipe
+     * extractor already covers them and they are not circular in the graph.
+     */
+    private val STRIPPABLE = listOf(
+        "oak_log", "birch_log", "spruce_log", "jungle_log", "acacia_log", "dark_oak_log",
+        "mangrove_log", "cherry_log", "pale_oak_log",
+        "crimson_stem", "warped_stem",
+        "bamboo_block",
+    )
+
+    /**
+     * @param itemIds the version's item registry ([ExtractionContext.itemIds]). Entries naming
+     *   an id outside it are dropped, so each version only gets sources it can actually use.
+     */
+    fun all(itemIds: Set<String>): List<ResourceSource> =
+        allUnfiltered().filter { source ->
+            (source.producedItems + source.requiredItems).all { (id, _) -> id.id in itemIds }
+        }
+
+    /** Every entry, before version filtering. Visible for tests. */
+    internal fun allUnfiltered(): List<ResourceSource> = buildList {
         // The wither drops a nether star — no normal loot table.
         add(
             source(
@@ -50,6 +84,57 @@ object SyntheticSources {
         add(source("synthetic/water.json", SourceType.MechanicTypes.COLLECT, produces = produce("minecraft:water")))
         add(source("synthetic/ice.json", SourceType.LootTypes.BLOCK, produces = produce("minecraft:water")))
         add(source("synthetic/lava.json", SourceType.MechanicTypes.COLLECT, produces = produce("minecraft:lava")))
+
+        // The *filled bucket items*, which is what a schematic's material list actually names —
+        // distinct from the fluid ids above. Without these, `lava_bucket` had no source at all
+        // and `water_bucket`'s best path was chest loot from a trial chamber.
+        //
+        // No `bucket` requirement, deliberately: placing the fluid returns the empty bucket, so
+        // one bucket serves an arbitrary number of placements. Requiring one per filled bucket
+        // would over-count iron enormously on any build with water. Same "tools are not
+        // materials" rule the design doc applies to shears and axes.
+        add(source("synthetic/water_bucket.json", SourceType.MechanicTypes.COLLECT, produces = produce("minecraft:water_bucket")))
+        add(source("synthetic/lava_bucket.json", SourceType.MechanicTypes.COLLECT, produces = produce("minecraft:lava_bucket")))
+        add(source("synthetic/powder_snow_bucket.json", SourceType.MechanicTypes.COLLECT, produces = produce("minecraft:powder_snow_bucket")))
+
+        // Strip a log with an axe. Until now the only source for every `stripped_*` was breaking
+        // one — perfectly circular advice. The axe is a tool, so the log is the only input.
+        STRIPPABLE.forEach { base ->
+            add(
+                source(
+                    "synthetic/stripped_$base.json", SourceType.MechanicTypes.IN_WORLD_TRANSFORM,
+                    produces = produce("minecraft:stripped_$base"),
+                    requires = listOf(require("minecraft:$base")),
+                )
+            )
+        }
+
+        // Use a water bottle on dirt. The bottle empties rather than being consumed, so — like
+        // the bucket above — it is a tool, and dirt is the only material.
+        add(
+            source(
+                "synthetic/mud.json", SourceType.MechanicTypes.IN_WORLD_TRANSFORM,
+                produces = produce("minecraft:mud"),
+                requires = listOf(require("minecraft:dirt")),
+            )
+        )
+
+        // Shovel on dirt/grass, hoe on dirt. Both are ordinary build blocks that had no source
+        // at all — they are code-defined interactions, absent from recipe and loot JSON alike.
+        add(
+            source(
+                "synthetic/dirt_path.json", SourceType.MechanicTypes.IN_WORLD_TRANSFORM,
+                produces = produce("minecraft:dirt_path"),
+                requires = listOf(require("minecraft:dirt")),
+            )
+        )
+        add(
+            source(
+                "synthetic/farmland.json", SourceType.MechanicTypes.IN_WORLD_TRANSFORM,
+                produces = produce("minecraft:farmland"),
+                requires = listOf(require("minecraft:dirt")),
+            )
+        )
 
         // Concrete: place the matching powder next to water to harden it.
         DYE_COLORS.forEach { color ->

--- a/webapp/mc-data/src/test/kotlin/app/mcorg/data/minecraft/extract/ExtractionContextTest.kt
+++ b/webapp/mc-data/src/test/kotlin/app/mcorg/data/minecraft/extract/ExtractionContextTest.kt
@@ -75,4 +75,57 @@ class ExtractionContextTest {
     fun `tagDisplayName formats a tag id as title case words`() {
         assertEquals("Wooden Slabs", ExtractionContext.tagDisplayName("#minecraft:wooden_slabs"))
     }
+
+    // --- registryIds (MCO-313) ---
+
+    private fun langKeys(vararg keys: String) = keys.associateWith { "irrelevant" }
+
+    @Test
+    fun `registryIds reads dot-free item and block keys as ids`() {
+        val ids = ExtractionContextFactory.registryIds(
+            langKeys("item.minecraft.diamond", "block.minecraft.stone")
+        )
+        assertEquals(setOf("minecraft:diamond", "minecraft:stone"), ids)
+    }
+
+    @Test
+    fun `registryIds ignores dotted auxiliary keys`() {
+        val ids = ExtractionContextFactory.registryIds(
+            langKeys("item.minecraft.splash_potion.effect.luck")
+        )
+        assertEquals(emptySet(), ids)
+    }
+
+    @Test
+    fun `registryIds drops a legacy id when its replacement is present`() {
+        val ids = ExtractionContextFactory.registryIds(
+            langKeys("block.minecraft.chain", "block.minecraft.iron_chain")
+        )
+        assertEquals(setOf("minecraft:iron_chain"), ids)
+    }
+
+    /**
+     * The rule has to be self-versioning: `chain` is the real item before 1.21.9, `grass`
+     * before 1.20.3. Without the replacement present, the legacy id must survive.
+     */
+    @Test
+    fun `registryIds keeps a legacy id on versions predating the rename`() {
+        val ids = ExtractionContextFactory.registryIds(
+            langKeys("block.minecraft.chain", "block.minecraft.grass", "item.minecraft.scute")
+        )
+        assertEquals(setOf("minecraft:chain", "minecraft:grass", "minecraft:scute"), ids)
+    }
+
+    @Test
+    fun `registryIds drops family-label keys that were never items`() {
+        val ids = ExtractionContextFactory.registryIds(
+            langKeys(
+                "item.minecraft.smithing_template",
+                "item.minecraft.harness",
+                "block.minecraft.set_spawn",
+                "item.minecraft.white_harness",
+            )
+        )
+        assertEquals(setOf("minecraft:white_harness"), ids)
+    }
 }

--- a/webapp/mc-data/src/test/kotlin/app/mcorg/data/minecraft/extract/SyntheticSourcesTest.kt
+++ b/webapp/mc-data/src/test/kotlin/app/mcorg/data/minecraft/extract/SyntheticSourcesTest.kt
@@ -9,7 +9,16 @@ import kotlin.test.assertTrue
 
 class SyntheticSourcesTest {
 
-    private val sources = SyntheticSources.all()
+    /**
+     * An item registry containing every id the entries mention — i.e. "the newest version",
+     * where nothing is filtered out. Version filtering is exercised separately below.
+     */
+    private val allIds: Set<String> =
+        SyntheticSources.allUnfiltered().flatMap { s ->
+            (s.producedItems + s.requiredItems).map { it.first.id }
+        }.toSet()
+
+    private val sources = SyntheticSources.all(allIds)
 
     private fun producing(itemId: String) =
         sources.filter { s -> s.producedItems.any { it.first.id == itemId } }
@@ -63,5 +72,73 @@ class SyntheticSourcesTest {
             assertEquals(SourceType.MechanicTypes.IN_WORLD_TRANSFORM, concrete.type, "$color concrete type")
             assertEquals("minecraft:${color}_concrete_powder", concrete.requiredItems.single().first.id)
         }
+    }
+
+    @Test
+    fun `every strippable log has an in-world transform from its unstripped form`() {
+        val bases = listOf(
+            "oak_log", "birch_log", "spruce_log", "jungle_log", "acacia_log", "dark_oak_log",
+            "mangrove_log", "cherry_log", "pale_oak_log", "crimson_stem", "warped_stem",
+            "bamboo_block",
+        )
+        bases.forEach { base ->
+            val stripped = producing("minecraft:stripped_$base").single()
+            assertEquals(SourceType.MechanicTypes.IN_WORLD_TRANSFORM, stripped.type, "$base strip type")
+            assertEquals("minecraft:$base", stripped.requiredItems.single().first.id, "$base strip input")
+        }
+    }
+
+    @Test
+    fun `mud, dirt path and farmland transform dirt`() {
+        listOf("minecraft:mud", "minecraft:dirt_path", "minecraft:farmland").forEach { id ->
+            val transform = producing(id).single()
+            assertEquals(SourceType.MechanicTypes.IN_WORLD_TRANSFORM, transform.type, "$id type")
+            assertEquals("minecraft:dirt", transform.requiredItems.single().first.id, "$id input")
+        }
+    }
+
+    /**
+     * The bucket is returned empty on placement, so it is a reusable tool rather than a
+     * consumed material — requiring one per filled bucket would badly over-count iron on any
+     * build containing water. See the note in [SyntheticSources].
+     */
+    @Test
+    fun `filled buckets are collected and consume nothing`() {
+        listOf("water_bucket", "lava_bucket", "powder_snow_bucket").forEach { id ->
+            val bucket = producing("minecraft:$id").single()
+            assertEquals(SourceType.MechanicTypes.COLLECT, bucket.type, "$id type")
+            assertTrue(bucket.requiredItems.isEmpty(), "$id must not consume a bucket")
+        }
+    }
+
+    @Test
+    fun `entries naming an item the version lacks are dropped`() {
+        val withoutCherry = allIds - "minecraft:stripped_cherry_log"
+        val sources = SyntheticSources.all(withoutCherry)
+
+        assertTrue(
+            sources.none { s -> s.producedItems.any { it.first.id == "minecraft:stripped_cherry_log" } },
+            "a version without stripped cherry logs must not gain one"
+        )
+        assertTrue(
+            sources.any { s -> s.producedItems.any { it.first.id == "minecraft:stripped_oak_log" } },
+            "unrelated entries must survive the filter"
+        )
+    }
+
+    @Test
+    fun `an entry is dropped when its required input is missing, not just its output`() {
+        val withoutDirt = allIds - "minecraft:dirt"
+        val sources = SyntheticSources.all(withoutDirt)
+
+        assertTrue(
+            sources.none { s -> s.producedItems.any { it.first.id == "minecraft:mud" } },
+            "mud must not be producible from an ingredient the version lacks"
+        )
+    }
+
+    @Test
+    fun `an empty registry yields no sources`() {
+        assertTrue(SyntheticSources.all(emptySet()).isEmpty())
     }
 }

--- a/webapp/mc-engine/src/main/kotlin/app/mcorg/engine/plan/ScoreDiagnostics.kt
+++ b/webapp/mc-engine/src/main/kotlin/app/mcorg/engine/plan/ScoreDiagnostics.kt
@@ -112,6 +112,23 @@ object ScoreDiagnostics {
         )
     }
 
+    /**
+     * True when the item's *only* producing source is breaking its own placed block —
+     * "to get a stripped oak log, break a stripped oak log."
+     *
+     * Such items are not BLOCKED (they have a source), so they are invisible to a
+     * no-sources scan, yet the acquisition the planner suggests for them is circular.
+     * That makes this the working list for new synthetic sources in mc-data: each hit
+     * either needs a real acquisition Mojang's JSON doesn't describe (an in-world
+     * transform, a collect, an interaction), or is a legitimate self-break-only block
+     * (natural stone, dirt). Exposed here rather than on the scorer so the restricted
+     * scoring surface stays internal.
+     */
+    fun hasOnlySelfBlockLoot(graph: ItemSourceGraph, item: MinecraftId): Boolean {
+        val sources = graph.getSourcesForItem(item)
+        return sources.isNotEmpty() && sources.all { SelectionScorer.isSelfBlockLoot(item, it) }
+    }
+
     /** Prefers the concrete item node over a same-id tag node (mirrors PlanSelector.graphItemFor). */
     private fun pickItemNode(graph: ItemSourceGraph, itemId: String) =
         graph.getItemNodesByStringId(itemId).let { nodes ->

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/cli/ScoreDiagnostics.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/cli/ScoreDiagnostics.kt
@@ -32,6 +32,12 @@ import kotlin.system.exitProcess
  * - `world=<id>` — resolve the version from a world row.
  * - `demand=<n>` — the requested amount fed to the scorer (default 64). Raise it
  *   above the recipe threshold (100) to see the bulk-crafting bonus kick in.
+ * - `unobtainable` — instead of scoring items, list every catalog item with no
+ *   producing source at all (the ids that show BLOCKED in a build).
+ * - `circular` — list every catalog item whose only producing source is breaking
+ *   its own placed block. These are *not* BLOCKED, so `unobtainable` misses them,
+ *   but the planner's advice for them is circular. The working list for new
+ *   synthetic sources.
  * - everything else — item ids; a bare `sand` becomes `minecraft:sand`. With no
  *   item ids, a default set covering the flagged notes is used.
  */
@@ -61,6 +67,7 @@ private suspend fun run(args: List<String>): Int {
     var demand = 64L
     val items = mutableListOf<String>()
     var unobtainable = false
+    var circular = false
 
     for (arg in args) {
         when {
@@ -68,6 +75,7 @@ private suspend fun run(args: List<String>): Int {
             arg.startsWith("world=") -> worldId = arg.substringAfter('=').toIntOrNull()
             arg.startsWith("demand=") -> demand = arg.substringAfter('=').toLongOrNull() ?: demand
             arg == "unobtainable" -> unobtainable = true
+            arg == "circular" -> circular = true
             else -> items.add(normalizeId(arg))
         }
     }
@@ -87,6 +95,11 @@ private suspend fun run(args: List<String>): Int {
 
     if (unobtainable) {
         printUnobtainable(graph, resolvedVersion)
+        return 0
+    }
+
+    if (circular) {
+        printCircular(graph, resolvedVersion)
         return 0
     }
 
@@ -164,6 +177,45 @@ private val distinctVersionsQuery = DatabaseSteps.query<Unit, List<String>>(
     parameterSetter = { _, _ -> },
     resultMapper = { rs -> buildList { while (rs.next()) add(rs.getString("version")) } }
 )
+
+/**
+ * Lists every catalog item whose *only* producing source is breaking its own placed block —
+ * "to get a stripped oak log, break a stripped oak log." These items are not BLOCKED, so
+ * [printUnobtainable] misses them entirely, but the advice the planner gives for them is
+ * circular and useless. They are the working list for new synthetic sources: each one needs
+ * a real acquisition (an in-world transform, a collect, an interaction) that Mojang's JSON
+ * doesn't describe.
+ *
+ * Items whose self-break is genuinely the only acquisition (natural stone, dirt, ores that
+ * drop themselves) are legitimate and appear here too — this is a review list, not a defect
+ * list. The signal is an item that *should* have a constructive path and doesn't.
+ */
+private suspend fun printCircular(graph: ItemSourceGraph, version: String) {
+    val catalog = (catalogQuery.process(version) as? Result.Success)?.value.orEmpty()
+    val circular = catalog
+        .map { (id, name) -> Item(id, name) }
+        .filter { item -> ScoreDiagnostics.hasOnlySelfBlockLoot(graph, item) }
+        .map { it.id }
+        .sorted()
+
+    fun bucket(id: String): String {
+        val stem = id.substringAfter(':')
+        return when {
+            stem.startsWith("stripped_") -> "stripped log/wood (axe strip)"
+            stem in IN_WORLD_TRANSFORM_CANDIDATES -> "in-world transform"
+            else -> "self-break only (review)"
+        }
+    }
+
+    println("\n=== ${circular.size} catalog items whose ONLY source is breaking themselves (version $version) ===")
+    circular.groupBy { bucket(it) }.toSortedMap().forEach { (b, ids) ->
+        println("\n-- $b (${ids.size}) --")
+        ids.forEach { println("   $it") }
+    }
+}
+
+/** Known in-world transforms Mojang's JSON doesn't describe — see mc-data's SyntheticSources. */
+private val IN_WORLD_TRANSFORM_CANDIDATES = setOf("mud", "dirt_path", "farmland")
 
 private val catalogQuery = DatabaseSteps.query<String, List<Pair<String, String>>>(
     sql = SafeSQL.select("SELECT item_id, item_name FROM minecraft_items WHERE version = ? ORDER BY item_id"),

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/minecraftfiles/StoreServerDataSteps.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/minecraftfiles/StoreServerDataSteps.kt
@@ -69,17 +69,31 @@ private data class StoreMinecraftItemDataStep(val connection: TransactionConnect
             // minecraft_tag_item and resource_source_* are ON DELETE CASCADE, so a blanket delete
             // would churn every source row on every ingest. Only genuinely-absent ids are removed,
             // and those have no sources to cascade to by construction.
-            DatabaseSteps.update<List<Item>>(
-                sql = SafeSQL.delete("DELETE FROM minecraft_items WHERE version = ? AND item_id <> ALL (?)"),
-                parameterSetter = { statement, items ->
-                    statement.setString(1, version.toString())
-                    statement.setArray(2, statement.connection.createArrayOf("text", items.map { it.id }.toTypedArray()))
-                },
-                transactionConnection = connection
-            ).process(allItems).map { removed ->
-                if (removed > 0) {
-                    logger.info("Retired $removed stale item(s) for minecraft version $version no longer in the registry.")
-                }
+            //
+            // Skipped entirely when extraction produced nothing: `item_id <> ALL ('{}')` is TRUE for
+            // every row, so an empty list would delete the version's whole catalog — and cascade its
+            // tags and sources with it — silently, inside this transaction. A version with no items
+            // is always an extraction fault, never a real registry, so refuse rather than obey.
+            if (allItems.isEmpty()) {
+                logger.warn("Extraction produced no items for minecraft version $version; skipping retirement to avoid wiping the catalog.")
+            } else {
+                DatabaseSteps.update<List<Item>>(
+                    sql = SafeSQL.delete("DELETE FROM minecraft_items WHERE version = ? AND item_id <> ALL (?)"),
+                    parameterSetter = { statement, items ->
+                        statement.setString(1, version.toString())
+                        statement.setArray(2, statement.connection.createArrayOf("text", items.map { it.id }.toTypedArray()))
+                    },
+                    transactionConnection = connection
+                ).process(allItems)
+                    // Propagate rather than swallow: a failed retirement followed by a successful
+                    // ON CONFLICT DO NOTHING insert would report a clean ingest while leaving the
+                    // stale ids in place. Mirrors StoreResourceSourcesStep's delete.
+                    .also { if (it is Result.Failure) return it }
+                    .map { removed ->
+                        if (removed > 0) {
+                            logger.info("Retired $removed stale item(s) for minecraft version $version no longer in the registry.")
+                        }
+                    }
             }
 
             DatabaseSteps.batchUpdate<Item>(

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/minecraftfiles/StoreServerDataSteps.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/minecraftfiles/StoreServerDataSteps.kt
@@ -60,6 +60,28 @@ private data class StoreMinecraftItemDataStep(val connection: TransactionConnect
             val tagItems = tags.flatMap { it.content }
             val allItems = (itemsAndTags.filterIsInstance<Item>() + tagItems).distinctBy { it.id }
 
+            // Retire ids this version no longer has. The insert below is ON CONFLICT DO NOTHING,
+            // so without this the catalog is append-only and *no* extraction change that removes
+            // an item can ever take effect — a pruned id would sit in minecraft_items forever,
+            // permanently BLOCKED (MCO-313).
+            //
+            // Deliberately surgical rather than delete-all-then-reinsert: the FKs from
+            // minecraft_tag_item and resource_source_* are ON DELETE CASCADE, so a blanket delete
+            // would churn every source row on every ingest. Only genuinely-absent ids are removed,
+            // and those have no sources to cascade to by construction.
+            DatabaseSteps.update<List<Item>>(
+                sql = SafeSQL.delete("DELETE FROM minecraft_items WHERE version = ? AND item_id <> ALL (?)"),
+                parameterSetter = { statement, items ->
+                    statement.setString(1, version.toString())
+                    statement.setArray(2, statement.connection.createArrayOf("text", items.map { it.id }.toTypedArray()))
+                },
+                transactionConnection = connection
+            ).process(allItems).map { removed ->
+                if (removed > 0) {
+                    logger.info("Retired $removed stale item(s) for minecraft version $version no longer in the registry.")
+                }
+            }
+
             DatabaseSteps.batchUpdate<Item>(
                 sql = SafeSQL.insert("""
                     INSERT INTO minecraft_items (version, item_id, item_name)

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/minecraftfiles/StoreServerDataIdempotencyTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/minecraftfiles/StoreServerDataIdempotencyTest.kt
@@ -99,6 +99,23 @@ class StoreServerDataIdempotencyTest {
         assertEquals(1, count("resource_source"), "retirement must not cascade live sources away")
     }
 
+    /**
+     * `item_id <> ALL ('{}')` is TRUE for every row, so an extraction that yields nothing would
+     * delete the version's entire catalog — and cascade its tags and sources away with it —
+     * silently, inside the ingest transaction. A version with no items is always an extraction
+     * fault, never a real registry, so the retirement is skipped rather than obeyed.
+     */
+    @Test
+    fun `an empty extraction does not wipe the catalog`() {
+        runBlocking { assertIs<Result.Success<*>>(StoreMinecraftDataStep.process(data)) }
+        assertEquals(listOf("minecraft:stone"), itemIds())
+
+        runBlocking { assertIs<Result.Success<*>>(StoreMinecraftDataStep.process(data.copy(items = emptyList()))) }
+
+        assertEquals(listOf("minecraft:stone"), itemIds(), "an empty extraction wiped the catalog")
+        assertEquals(1, count("resource_source"), "the wipe cascaded the version's sources away")
+    }
+
     private fun itemIds(): List<String> = runBlocking {
         DatabaseSteps.query<Unit, List<String>>(
             sql = SafeSQL.select("SELECT item_id FROM minecraft_items WHERE version = ? ORDER BY item_id"),

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/minecraftfiles/StoreServerDataIdempotencyTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/minecraftfiles/StoreServerDataIdempotencyTest.kt
@@ -65,6 +65,48 @@ class StoreServerDataIdempotencyTest {
         assertEquals(1, count("resource_source_produced_item"), "produced rows duplicated on re-ingest")
     }
 
+    /**
+     * The item insert is `ON CONFLICT DO NOTHING`, so without an explicit delete the catalog is
+     * append-only and no extraction change that *removes* an item can ever take effect — the
+     * pruned id sits in minecraft_items forever, permanently BLOCKED. This is what made the
+     * MCO-313 lang-key fix inert until storage was corrected.
+     */
+    @Test
+    fun `re-ingesting retires items the version no longer has`() {
+        val withLegacyId = data.copy(
+            items = data.items + Item("minecraft:chain", "Chain"),
+        )
+        runBlocking { assertIs<Result.Success<*>>(StoreMinecraftDataStep.process(withLegacyId)) }
+        assertEquals(2, count("minecraft_items"))
+
+        // Extraction now prunes the legacy id; the stored catalog must follow.
+        runBlocking { assertIs<Result.Success<*>>(StoreMinecraftDataStep.process(data)) }
+
+        assertEquals(1, count("minecraft_items"), "stale item survived re-ingest")
+        assertEquals(
+            listOf("minecraft:stone"),
+            itemIds(),
+            "the retired id must be the one extraction dropped"
+        )
+    }
+
+    @Test
+    fun `re-ingesting keeps items the version still has`() {
+        runBlocking { assertIs<Result.Success<*>>(StoreMinecraftDataStep.process(data)) }
+        runBlocking { assertIs<Result.Success<*>>(StoreMinecraftDataStep.process(data)) }
+
+        assertEquals(listOf("minecraft:stone"), itemIds())
+        assertEquals(1, count("resource_source"), "retirement must not cascade live sources away")
+    }
+
+    private fun itemIds(): List<String> = runBlocking {
+        DatabaseSteps.query<Unit, List<String>>(
+            sql = SafeSQL.select("SELECT item_id FROM minecraft_items WHERE version = ? ORDER BY item_id"),
+            parameterSetter = { stmt, _ -> stmt.setString(1, version.toString()) },
+            resultMapper = { rs -> buildList { while (rs.next()) add(rs.getString("item_id")) } }
+        ).process(Unit).getOrThrow()
+    }
+
     private fun count(table: String): Int = runBlocking {
         DatabaseSteps.query<Unit, Int>(
             sql = SafeSQL.select("SELECT count(*) AS c FROM $table WHERE version = ?"),

--- a/webapp/scripts/ingest-locally.sh
+++ b/webapp/scripts/ingest-locally.sh
@@ -27,7 +27,11 @@ set +a
 
 echo "Compiling..."
 cd "$WEBAPP_DIR"
-mvn compile -q
+# `install`, not `compile`: the run below is `-pl mc-web`, which resolves sibling modules
+# (mc-data, mc-engine, ...) from ~/.m2 rather than the reactor. With a bare `compile` an
+# extraction change lands in mc-data/target/classes, is never installed, and the ingest
+# silently runs the *previous* extraction code — looking like the change had no effect.
+mvn install -q -DskipTests
 
 echo "Ingesting Minecraft server data into $DB_URL ..."
 exec mvn -pl mc-web exec:java@ingest-server-files


### PR DESCRIPTION
Two independent fixes to what the item graph says about acquisitions, found together while sourcing content for farm ideas. Reviewable as two commits.

## 1. Synthetic sources for circular and missing acquisitions

The graph could only tell you to get a stripped oak log by **breaking a stripped oak log**.

The existing `unobtainable` diagnostic structurally cannot see this class — those items *do* have a source, just a circular one. So this adds a `circular` mode that finds items whose only producing source is their own block loot. Against 26.2.0 it returned 134, of which 13 were real gaps; the other 121 are legitimate self-break blocks (ores, leaves, coral).

18 new synthetic entries:

| Item(s) | Was | Now |
|---|---|---|
| 12 stripped logs/stems | Break Block (100), only option | In-world transform (75), self-break drops to −100 |
| `mud` | Break Block (100), only option | In-world transform (75) |
| `lava_bucket` | **BLOCKED — 0 sources** | Collect (100) |
| `water_bucket` | Chest loot, trial chamber (60) | Collect (100) |
| `dirt_path`, `farmland` | not in graph at all | In-world transform (75) |
| `powder_snow_bucket` | no source | Collect (100) |

Notes on the judgement calls:

- **12 strips, not 25.** The `block_transformer` analysis estimated 25 from the component JSON, but the six-sided `*_wood` variants are craftable from their stripped log and were never broken. Doc corrected.
- **Filled buckets require nothing.** Placing the fluid returns the empty bucket, so one bucket serves any number of placements; requiring one each would badly over-count iron on any build with water. Same "tools are not materials" rule the design doc applies to shears and axes.
- **No scoring change.** The self-block penalty fires on its own once a constructive sibling exists — exactly as the analysis doc predicted. The self-block check is exposed via mc-engine's `ScoreDiagnostics` rather than by widening `SelectionScorer`, so the restricted scoring surface stays `internal`.
- **Version-filtered.** Entries are pruned against the version's item registry, so 1.18 does not gain a phantom `stripped_cherry_log`. Matters more the further back the range goes.

Also lands `block-transformer-analysis.md`, which was stranded on `evegul/block-transformer-analysis`, with a re-check against 26.3 snapshot 7 (still unreleased, honeycomb still hardcoded, so the "wait for release" decision stands) and the correction that since the component only exists in 26.3+ while we support back to 1.18, these entries are **permanent** — a future extractor supersedes them per-version rather than replacing them.

## 2. Phantom catalog items (MCO-313)

`minecraft:chain` had no source despite chain having an ordinary shaped recipe. The recipe parses fine — the registry is derived from **lang-file keys**, and Mojang keeps the old key after a rename:

`chain`→`iron_chain` (1.21.9), `grass`→`short_grass` (1.20.3), `scute`→`turtle_scute` (1.20.5), `sign`→`oak_sign` (1.14), plus `smithing_template` / `harness` / `set_spawn`, which were never items.

A legacy id is dropped **only when its replacement is present in the same version** — self-versioning, no version ranges to maintain.

**That fix alone was inert.** `minecraft_items` is inserted `ON CONFLICT DO NOTHING` and never deleted, so no extraction change that removes an item could ever take effect, on any version. Sources have been delete-before-insert since MCO-168; items were not. The delete is surgical rather than delete-all-then-reinsert, because the FKs from `minecraft_tag_item` and `resource_source_*` are `ON DELETE CASCADE`.

## Verification

- `mvn clean compile` clean; unit tier + **433 database tests** pass (was 431).
- Full re-ingest of all 31 versions, then both diagnostics re-run: `circular` 134 → 121, `unobtainable` 310 → 303, `Retired 7 stale item(s)`.
- `ingest-locally.sh` now installs rather than compiles — the run is `-pl mc-web`, which resolves siblings from `~/.m2`, so a bare compile made the ingest silently use the *previous* extraction code. This cost a full verification cycle before it was spotted.

## Deliberately not in scope

- **MCO-314** — the weathered copper family (~24 ids) is circular too, but modelling passive time-gated oxidation in a quantity DAG needs a decision, not a guess.
- No `preview` label: this is data/extraction work with nothing to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)