### PR TITLE
MCO-319: stop calling lava cauldrons and powder snow creative-only

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
@@ -272,8 +272,9 @@ data class MapSchematicToMaterialsStep(
      *    silverfish-infested blocks).
      * 2. [REDIRECTS] — explicit block -> item for placed forms whose gathered item has a
      *    different id: crops to their seed/produce (carrots -> carrot, cocoa ->
-     *    cocoa_beans), and tool/effect placements to their material (dirt_path/farmland
-     *    -> dirt, redstone_wire -> redstone, wall_torch -> torch).
+     *    cocoa_beans), tool/effect placements to their material (dirt_path/farmland
+     *    -> dirt, redstone_wire -> redstone, wall_torch -> torch), and filled block states
+     *    to the block you place (lava_cauldron -> cauldron).
      * 3. *wall* variants — drop the "_wall_" infix when that yields a real item
      *    (birch_wall_sign -> birch_sign, dead_horn_coral_wall_fan -> dead_horn_coral_fan).
      * 4. Otherwise resolve by the id itself, or drop when the version has no such item.
@@ -352,6 +353,12 @@ data class MapSchematicToMaterialsStep(
             "minecraft:suspicious_sand" to "minecraft:sand",
             "minecraft:suspicious_gravel" to "minecraft:gravel",
             "minecraft:wall_torch" to "minecraft:torch",
+            // A filled cauldron is a block *state* of the cauldron, not an item of its own
+            // (there is no lava_cauldron item). What you gather is the cauldron; the bucket
+            // that fills it is a reusable tool, like the flint & steel behind a fire cell.
+            "minecraft:lava_cauldron" to "minecraft:cauldron",
+            "minecraft:water_cauldron" to "minecraft:cauldron",
+            "minecraft:powder_snow_cauldron" to "minecraft:cauldron",
         )
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportWarnings.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportWarnings.kt
@@ -125,12 +125,17 @@ val NON_MATERIAL_FILL = setOf(
  * placed effects (fire, portals) are created in-world from blocks counted elsewhere, and the
  * technical piston states belong to the piston. All warned rather than filtered — a build
  * really does contain them, and striking a row is the user's call.
+ *
+ * `powder_snow` belongs with the fluids (MCO-319): it is a block-only id placed from a
+ * powder snow bucket, so nothing produces it and the graph would otherwise call it
+ * creative-only. It is the same shape as water, and gets the same answer.
  */
 private val NON_MATERIAL_ITEM_IDS = NON_MATERIAL_FILL + setOf(
     "minecraft:water",
     "minecraft:flowing_water",
     "minecraft:lava",
     "minecraft:flowing_lava",
+    "minecraft:powder_snow",
     "minecraft:bubble_column",
     "minecraft:fire",
     "minecraft:soul_fire",

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/ImportWarningsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/ImportWarningsTest.kt
@@ -77,6 +77,30 @@ class ImportWarningsTest {
     }
 
     @Test
+    fun `powder snow reads as a non-material, not as creative-only`() {
+        // MCO-319: powder_snow is a block-only id placed from a bucket, so no source produces
+        // it and the graph rule alone would call it creative-only — the wrong story for a
+        // block any player can place. It is the same shape as water and gets water's answer.
+        // The graph here produces nothing, which is exactly the real-world condition.
+        val powderSnow = item("powder_snow")
+
+        val warnings = classifyImportWarnings(mapOf(powderSnow to 2), graphProducing(item("stone")))
+
+        assertEquals(ImportWarningKind.NON_MATERIAL, warnings.forItem(powderSnow.id)?.kind)
+    }
+
+    @Test
+    fun `an empty cauldron is not warned about at all`() {
+        // The other half of MCO-319: filled cauldron states are redirected to minecraft:cauldron
+        // by the importers, and a cauldron has a recipe, so nothing should be said about it.
+        val cauldron = item("cauldron")
+
+        val warnings = classifyImportWarnings(mapOf(cauldron to 6), graphProducing(cauldron))
+
+        assertTrue(warnings.isEmpty)
+    }
+
+    @Test
     fun `a name mismatch between catalog and graph does not fake an unobtainable row`() {
         // The graph node carries one display name and the world catalog another. Matching on
         // Item equality (id *and* name) would report a perfectly craftable item as blocked.

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/MapSchematicToMaterialsStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/MapSchematicToMaterialsStepTest.kt
@@ -27,6 +27,13 @@ class MapSchematicToMaterialsStepTest {
         "minecraft:soul_fire",
         "minecraft:bubble_column",
         "minecraft:soul_sand",
+        "minecraft:cauldron",
+        // Extraction names the catalog from the lang file, so every *block* id is in it too —
+        // including the filled cauldron states and powder snow, which have no item form.
+        "minecraft:lava_cauldron",
+        "minecraft:water_cauldron",
+        "minecraft:powder_snow_cauldron",
+        "minecraft:powder_snow",
     ).map { Item(it, it.substringAfterLast(':')) }
 
     private fun litematica(items: Map<String, Int>) =
@@ -139,6 +146,40 @@ class MapSchematicToMaterialsStepTest {
         assertNull(byId["minecraft:soul_fire"])
         assertNull(byId["minecraft:bubble_column"])
         assertEquals(10, byId["minecraft:soul_sand"], "the underlying block is still counted, not inflated")
+    }
+
+    @Test
+    fun `filled cauldrons resolve to the cauldron item`() {
+        // MCO-319: a lava cauldron is a block *state* of cauldron plus a bucket of lava, and
+        // there is no lava_cauldron item. Without the redirect it resolves to its own catalog
+        // entry, which nothing produces, and the plan blocks it forever.
+        val byId = map(
+            mapOf(
+                "minecraft:lava_cauldron" to 2,
+                "minecraft:water_cauldron" to 3,
+                "minecraft:powder_snow_cauldron" to 1,
+            )
+        )
+        assertEquals(6, byId["minecraft:cauldron"], "all three states are one cauldron each and sum")
+        assertNull(byId["minecraft:lava_cauldron"], "the filled block-state id must not survive")
+        assertNull(byId["minecraft:water_cauldron"])
+        assertNull(byId["minecraft:powder_snow_cauldron"])
+    }
+
+    @Test
+    fun `filled cauldron amounts merge with empty cauldrons already present`() {
+        val byId = map(mapOf("minecraft:cauldron" to 4, "minecraft:lava_cauldron" to 2))
+        assertEquals(6, byId["minecraft:cauldron"])
+    }
+
+    @Test
+    fun `powder snow stays on the list as a material to review`() {
+        // MCO-319: unlike fire, powder snow is not dropped by the mapper — it survives as a row
+        // so the review screen can warn about it, exactly as water does. The reclassification
+        // from "creative only" to "not a material" happens in ImportWarnings, not here.
+        val byId = map(mapOf("minecraft:powder_snow" to 2, "minecraft:oak_planks" to 5))
+        assertEquals(2, byId["minecraft:powder_snow"])
+        assertEquals(5, byId["minecraft:oak_planks"])
     }
 
     @Test


### PR DESCRIPTION
Fixes [MCO-319](https://linear.app/evegul/issue/MCO-319).

Importing a schematic with a lava cauldron or powder snow warned **"Not obtainable in survival … they need creative mode or an operator command"**, and the gathering plan then filed both as `Blocked: … — no feasible source found`. Both are survival-placeable.

## Why they leaked through

Both are **block-only ids** — there is no `lava_cauldron` item and no `powder_snow` item (verified against the vanilla registries: the item forms are `cauldron` and `powder_snow_bucket`). Extraction names the catalog from the lang file (`block.minecraft.*` → `" (Block)"`, `ExtractionContext`), so every block id still gets a catalog entry. The mapper therefore resolves them to a row of their own, and the graph has no source producing them → `UNOBTAINABLE`.

## Changes

- **`REDIRECTS`** (`MapSchematicToMaterialsStep`): `lava_cauldron`, `water_cauldron` and `powder_snow_cauldron` → `minecraft:cauldron`. A filled cauldron is a block *state* of the cauldron; the bucket that fills it is a reusable tool, not counted — the same treatment `fire` and `bubble_column` already get.
- **`NON_MATERIAL_ITEM_IDS`** (`ImportWarnings`): added `minecraft:powder_snow`, so it reads as *"Not really materials"* instead of *"Not obtainable in survival"*.

## One correction to the issue

The issue asked which of `NON_MATERIAL_FILL` / `NON_MATERIAL_BLOCKS` should host `powder_snow`. Traced it: **neither**. Both of those *drop* a cell before it reaches the material list, so powder snow would vanish silently rather than be reported. The warning strip's headings come from `classify()` reading `NON_MATERIAL_ITEM_IDS` — the group `minecraft:water` is actually in. That set is also the one both import doors read through `computeImportWarnings`, so the schematic and idea paths agree with no change to the idea path.

## Tests

- `MapSchematicToMaterialsStepTest` (12 → 15): all three cauldron states collapse to `cauldron` and sum; they merge with empty cauldrons already in the list; powder snow survives the mapper as a reviewable row.
- `ImportWarningsTest` (8 → 10): powder snow classifies `NON_MATERIAL` even when the graph produces nothing for it; a redirected cauldron draws no warning at all.

`mvn clean compile` clean. Unit tier BUILD SUCCESS; database tier 431 tests, 0 failures.

No preview label — backend classification change, nothing to eyeball beyond the strip copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)