### PR TITLE
MCO-318: make the roadmap's two edge columns agree

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/world/Roadmap.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/world/Roadmap.kt
@@ -132,7 +132,7 @@ data class RoadmapEdge(
     val isBlocking: Boolean,
     /**
      * The resource this edge is about, when it is a resource edge. Null for a manual
-     * project→project sequencing edge. The roadmap's "Blocked by" cell names the project
+     * project→project sequencing edge. The roadmap's "Depends on" cell names the project
      * *and* the resource, so the reader knows what to go and get.
      */
     val itemName: String? = null,

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/RoadmapPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/RoadmapPage.kt
@@ -103,8 +103,12 @@ private fun FlowContent.roadmapEmptyState(worldId: Int) {
 }
 
 private fun FlowContent.roadmapTable(roadmap: Roadmap) {
-    val blockingByConsumer = roadmap.edges.filter { it.isBlocking }.groupBy { it.fromNodeId }
-    val consumersByProducer = roadmap.edges.groupBy { it.toNodeId }
+    // Both directions read the *same* edge set (MCO-318). Filtering one side to blocking edges
+    // and not the other made the table contradict itself: a DONE farm claimed to block a project
+    // whose own row said nothing blocked it. Every edge shows on both rows; whether it is still
+    // blocking or already supplying is said in the cell, not by omitting it from one column.
+    val upstreamByConsumer = roadmap.edges.groupBy { it.fromNodeId }
+    val downstreamByProducer = roadmap.edges.groupBy { it.toNodeId }
 
     // Depth first — that is the sequence. Blocked projects sink within their layer, and
     // names break the remaining ties so the order is stable between renders.
@@ -123,8 +127,8 @@ private fun FlowContent.roadmapTable(roadmap: Roadmap) {
                     th { +"Project" }
                     th { +"State" }
                     th { +"Tasks" }
-                    th { +"Blocked by" }
-                    th { +"Blocks" }
+                    th { +"Depends on" }
+                    th { +"Supplies" }
                 }
             }
             tbody {
@@ -153,13 +157,13 @@ private fun FlowContent.roadmapTable(roadmap: Roadmap) {
                                 +"${node.tasksCompleted} / ${node.tasksTotal}"
                             }
                         }
-                        td("roadmap-cell--blocked") {
-                            attributes["data-label"] = "Blocked by"
-                            blockedByCell(roadmap.worldId, blockingByConsumer[node.projectId].orEmpty())
+                        td {
+                            attributes["data-label"] = "Depends on"
+                            dependsOnCell(roadmap.worldId, upstreamByConsumer[node.projectId].orEmpty())
                         }
                         td {
-                            attributes["data-label"] = "Blocks"
-                            blocksCell(roadmap.worldId, consumersByProducer[node.projectId].orEmpty())
+                            attributes["data-label"] = "Supplies"
+                            suppliesCell(roadmap.worldId, downstreamByProducer[node.projectId].orEmpty())
                         }
                     }
                 }
@@ -169,49 +173,107 @@ private fun FlowContent.roadmapTable(roadmap: Roadmap) {
 }
 
 /**
- * Names the project *and* the resource, per the IA: "Iron Farm — Iron Ingot". Knowing which
- * project blocks you is only half an answer; the other half is what you are waiting for.
- * A manual sequencing edge has no resource, so it names the project alone.
+ * One line of an edge cell, in whichever direction it is read: the project at the other end,
+ * the resource when the cell names it, and what the relationship currently *is*.
+ *
+ * [itemName] is what the cell prints and is null wherever the cell doesn't name the resource.
+ * [isResourceEdge] is about the edge itself — false only for a manual project→project
+ * sequencing edge, which is about no resource at all. MCO-316 hangs demand quantities off this
+ * type, so keep it the single shape both directions are mapped into.
  */
-private fun FlowContent.blockedByCell(worldId: Int, edges: List<RoadmapEdge>) {
-    if (edges.isEmpty()) {
+private data class RoadmapEdgeEntry(
+    val projectId: Int,
+    val projectName: String,
+    val itemName: String?,
+    val isResourceEdge: Boolean,
+    val isBlocking: Boolean,
+)
+
+/**
+ * Upstream: what this project is waiting on, or already being fed by. Names the project *and*
+ * the resource, per the IA: "Iron Farm — Iron Ingot". Knowing which project you depend on is
+ * only half an answer; the other half is what you are getting from it. A manual sequencing edge
+ * has no resource, so it names the project alone.
+ */
+private fun FlowContent.dependsOnCell(worldId: Int, edges: List<RoadmapEdge>) {
+    roadmapEdgeCell(
+        worldId,
+        edges.map { edge ->
+            RoadmapEdgeEntry(
+                projectId = edge.toNodeId,
+                projectName = edge.toNodeName,
+                itemName = edge.itemName,
+                isResourceEdge = edge.itemName != null,
+                isBlocking = edge.isBlocking,
+            )
+        }
+    )
+}
+
+/**
+ * Downstream: who this project feeds. The same edges the consumers' own rows show, so the two
+ * columns cannot disagree — a DONE farm supplies its consumers here rather than claiming to
+ * block them. Names only; the resource detail lives on the consumer's row.
+ */
+private fun FlowContent.suppliesCell(worldId: Int, edges: List<RoadmapEdge>) {
+    roadmapEdgeCell(
+        worldId,
+        edges
+            .groupBy { it.fromNodeId }
+            .map { (consumerId, consumerEdges) ->
+                RoadmapEdgeEntry(
+                    projectId = consumerId,
+                    projectName = consumerEdges.first().fromNodeName,
+                    itemName = null,
+                    isResourceEdge = consumerEdges.any { it.itemName != null },
+                    // Several resources can run along the same pair of projects; the pair is
+                    // blocking if any one of them still is.
+                    isBlocking = consumerEdges.any { it.isBlocking },
+                )
+            }
+    )
+}
+
+/**
+ * Blocking is called out in words, not just colour — the primary user is red-green colour-blind,
+ * and "this is still holding you up" is the one thing in the cell that must not be missed.
+ */
+private fun FlowContent.roadmapEdgeCell(worldId: Int, entries: List<RoadmapEdgeEntry>) {
+    if (entries.isEmpty()) {
         span("roadmap-muted") { +"—" }
         return
     }
     div("roadmap-edge-list") {
-        edges
-            .sortedWith(compareBy({ it.toNodeName }, { it.itemName ?: "" }))
-            .forEach { edge ->
-                div("roadmap-edge") {
+        entries
+            // Blockers first — they are the actionable ones — then a stable alphabetical order.
+            .sortedWith(
+                compareByDescending<RoadmapEdgeEntry> { it.isBlocking }
+                    .thenBy { it.projectName }
+                    .thenBy { it.itemName ?: "" }
+            )
+            .forEach { entry ->
+                val modifier = if (entry.isBlocking) "roadmap-edge--blocking" else "roadmap-edge--supplying"
+                div("roadmap-edge $modifier") {
                     a(classes = "roadmap-project-link") {
-                        href = "/worlds/$worldId/projects/${edge.toNodeId}"
-                        +edge.toNodeName
+                        href = "/worlds/$worldId/projects/${entry.projectId}"
+                        +entry.projectName
                     }
-                    edge.itemName?.let { item ->
+                    entry.itemName?.let { item ->
                         span("roadmap-edge__item") { +" — $item" }
                     }
+                    span("roadmap-edge__status") { +entry.statusLabel() }
                 }
             }
     }
 }
 
-/** The other direction: who is waiting on this project. Names only — the detail is on their row. */
-private fun FlowContent.blocksCell(worldId: Int, edges: List<RoadmapEdge>) {
-    val consumers = edges
-        .distinctBy { it.fromNodeId }
-        .sortedBy { it.fromNodeName }
-    if (consumers.isEmpty()) {
-        span("roadmap-muted") { +"—" }
-        return
-    }
-    div("roadmap-edge-list") {
-        consumers.forEach { edge ->
-            div("roadmap-edge") {
-                a(classes = "roadmap-project-link") {
-                    href = "/worlds/$worldId/projects/${edge.fromNodeId}"
-                    +edge.fromNodeName
-                }
-            }
-        }
-    }
+/**
+ * "blocking" for a producer that is not DONE yet; otherwise the relationship is live —
+ * "supplying" when there is a resource flowing, and a plain "done" for a manual sequencing
+ * edge, where nothing is being supplied and the only news is that the prerequisite is met.
+ */
+private fun RoadmapEdgeEntry.statusLabel(): String = when {
+    isBlocking -> "blocking"
+    isResourceEdge -> "supplying"
+    else -> "done"
 }

--- a/webapp/mc-web/src/main/resources/static/styles/pages/roadmap.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/roadmap.css
@@ -72,15 +72,35 @@
     font-size: var(--text-sm);
 }
 
-/* The resource is the actionable half of "blocked by" — present, but subordinate
+/* The resource is the actionable half of "depends on" — present, but subordinate
    to the project name it hangs off. */
 .roadmap-edge__item {
     color: var(--text-muted);
     font-size: var(--text-xs);
 }
 
-.roadmap-cell--blocked .roadmap-project-link {
+/* MCO-318: both columns list the same edges, so the state of each relationship is said
+   per edge. The word is the signal — colour only reinforces it (the primary user is
+   red-green colour-blind), so never drop the label and keep the state on colour alone. */
+.roadmap-edge__status {
+    margin-left: var(--space-2);
+    font-family: var(--font-ui);
+    font-size: var(--text-label);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+/* Still holding someone up: redstone, the danger role. */
+.roadmap-edge--blocking .roadmap-project-link,
+.roadmap-edge--blocking .roadmap-edge__status {
     color: var(--red);
+}
+
+/* Already flowing: grass, the done role. The project name stays ink — it is a link,
+   not a status — and only the label carries the colour. */
+.roadmap-edge--supplying .roadmap-edge__status {
+    color: var(--green);
 }
 
 .roadmap-muted {

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/WorldRoadmapIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/WorldRoadmapIT.kt
@@ -40,8 +40,14 @@ import kotlin.test.assertFalse
 @ExtendWith(DatabaseTestExtension::class)
 class WorldRoadmapIT : WithUser() {
 
+    companion object {
+        /** The per-edge status labels the cells print (MCO-318), matched as element text. */
+        private const val STATUS_BLOCKING = ">blocking<"
+        private const val STATUS_SUPPLYING = ">supplying<"
+    }
+
     @Test
-    fun `the roadmap names the blocking project and the resource it owes`() = testApplication {
+    fun `an unfinished farm blocks, and both columns say so`() = testApplication {
         setupRoutes()
         val worldId = createWorld("Roadmap IT World")
         val consumer = createProject(worldId, "Beacon Build")
@@ -54,17 +60,26 @@ class WorldRoadmapIT : WithUser() {
         assertEquals(HttpStatusCode.OK, response.status)
         val body = response.bodyAsText()
         assertContains(body, "roadmap-table")
-        assertContains(body, "Beacon Build")
-        assertContains(body, "Iron Farm")
-        // The IA asks the blocked-by cell to name both halves.
-        assertContains(body, "Iron Ingot")
-        assertContains(body, "/worlds/$worldId/projects/$farm")
+
+        // The IA asks the upstream cell to name both halves: the project and the resource.
+        val consumerRow = roadmapRow(body, "Beacon Build")
+        assertContains(consumerRow.dependsOn, "Iron Farm")
+        assertContains(consumerRow.dependsOn, "Iron Ingot")
+        assertContains(consumerRow.dependsOn, "/worlds/$worldId/projects/$farm")
+        assertContains(consumerRow.dependsOn, STATUS_BLOCKING)
+
+        // MCO-318: the same edge, read from the other end, must make the same claim.
+        val farmRow = roadmapRow(body, "Iron Farm")
+        assertContains(farmRow.supplies, "Beacon Build")
+        assertContains(farmRow.supplies, "/worlds/$worldId/projects/$consumer")
+        assertContains(farmRow.supplies, STATUS_BLOCKING)
+        assertFalse(farmRow.dependsOn.contains("roadmap-edge"), "the farm depends on nothing")
 
         deleteWorld(worldId)
     }
 
     @Test
-    fun `an operational farm still appears, no longer blocking`() = testApplication {
+    fun `an operational farm supplies its consumer instead of blocking it`() = testApplication {
         setupRoutes()
         val worldId = createWorld("Operational Roadmap World")
         val consumer = createProject(worldId, "Beacon Build")
@@ -77,9 +92,21 @@ class WorldRoadmapIT : WithUser() {
 
         // The relationship is still on the roadmap — it just stopped being a blocker, which
         // the summary line reports (it only counts blocked projects when there are any).
-        assertContains(body, "Iron Farm")
         assertContains(body, "2 projects")
         assertFalse(body.contains("1 blocked"), "an operational farm blocks nobody")
+
+        // MCO-318: the consumer's own row used to show "—" here while the farm's row claimed
+        // to block it. Both cells now show the relationship, marked as supply, not blocking.
+        val consumerRow = roadmapRow(body, "Beacon Build")
+        assertContains(consumerRow.dependsOn, "Iron Farm")
+        assertContains(consumerRow.dependsOn, "Iron Ingot")
+        assertContains(consumerRow.dependsOn, STATUS_SUPPLYING)
+        assertFalse(consumerRow.dependsOn.contains(STATUS_BLOCKING), "a DONE farm blocks nothing")
+
+        val farmRow = roadmapRow(body, "Iron Farm")
+        assertContains(farmRow.supplies, "Beacon Build")
+        assertContains(farmRow.supplies, STATUS_SUPPLYING)
+        assertFalse(farmRow.supplies.contains(STATUS_BLOCKING), "a DONE farm blocks nothing")
 
         deleteWorld(worldId)
     }
@@ -124,6 +151,27 @@ class WorldRoadmapIT : WithUser() {
         assertEquals(HttpStatusCode.Found, response.status)
 
         deleteWorld(worldId)
+    }
+
+    // ---- reading the rendered table -------------------------------------------------
+
+    /** The two edge cells of one project's row, so an assertion can name which column it means. */
+    private data class RoadmapRowCells(val dependsOn: String, val supplies: String)
+
+    /**
+     * Slices the row belonging to [projectName] out of the rendered table. Cells are found by
+     * their `data-label` (which the mobile stacked-card layout needs anyway), so the assertions
+     * read one column at a time instead of searching the whole page and hoping.
+     */
+    private fun roadmapRow(body: String, projectName: String): RoadmapRowCells {
+        val row = body.split("data-label=\"Layer\"")
+            .drop(1)
+            .firstOrNull { it.substringBefore("data-label=\"State\"").contains(">$projectName<") }
+            ?: error("no roadmap row for $projectName")
+        return RoadmapRowCells(
+            dependsOn = row.substringAfter("data-label=\"Depends on\"").substringBefore("data-label=\"Supplies\""),
+            supplies = row.substringAfter("data-label=\"Supplies\"").substringBefore("</tr>"),
+        )
     }
 
     // ---- routing — mirrors WorldHandler ------------------------------------------


### PR DESCRIPTION
Fixes MCO-318.

## The bug

The two edge columns applied different filters to the same edge set, so the table
contradicted itself:

```kotlin
val blockingByConsumer = roadmap.edges.filter { it.isBlocking }.groupBy { it.fromNodeId }  // filtered
val consumersByProducer = roadmap.edges.groupBy { it.toNodeId }                            // NOT filtered
```

Four DONE farms supplying one active project: each farm's row claimed to block the
project, the project's own row said nothing blocked it. Same four edges.

## The fix

Filtering "Blocks" to blocking edges too would leave six rows and zero relationships
(every producer there is DONE). Instead both columns read the *whole* edge set, and each
line says what the relationship currently is:

| Status label | When | Colour |
|---|---|---|
| `blocking` | producer not DONE yet | `--red` (danger), also tints the project link |
| `supplying` | resource edge, producer DONE | `--green` (done) |
| `done` | manual sequencing edge, prerequisite met | inherits ink |

The word is the signal, colour only reinforces it — no state is conveyed by colour alone.

Headers move with the semantics: **Depends on** / **Supplies**. A DONE farm now sits in
the downstream column without a header asserting it blocks anything.

Resulting shape for the reported case:

| Layer | Project | State | Depends on | Supplies |
|---|---|---|---|---|
| 0 | Cobblestone Generator | Done | — | YAMS V2.33 FB · SUPPLYING |
| 0 | Ice Farm | Done | — | YAMS V2.33 FB · SUPPLYING |
| 0 | Sand Duper | Done | — | YAMS V2.33 FB · SUPPLYING |
| 0 | Witch Farm | Done | — | YAMS V2.33 FB · SUPPLYING |
| 1 | YAMS V2.33 FB | Active | Cobblestone Generator — Cobblestone · SUPPLYING<br>Ice Farm — Ice · SUPPLYING<br>Sand Duper — Sand · SUPPLYING<br>Witch Farm — Redstone Dust · SUPPLYING | — |

A producer that is not DONE keeps the old red treatment and reads `BLOCKING` on both rows.
Blockers sort first within a cell.

## Notes

- Both cells map into one `RoadmapEdgeEntry` shape — that is where MCO-316 can hang demand
  quantities without touching the direction/blocking logic.
- No new engine or scoring code; presentation + CSS + tests only.

## Tests

`WorldRoadmapIT` now slices a row by its `data-label` cells and asserts the two columns
agree, for both a blocking producer and a DONE one.

- `mvn clean compile` — zero errors
- `./webapp/scripts/test.sh` — 752 unit tests, 0 failures
- `./webapp/scripts/test.sh --database` — 431 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
