### PR TITLE
MCO-315: the import review list is one field, not two per row

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
@@ -92,9 +92,9 @@ suspend fun ApplicationCall.handleReviewSchematic() {
 /**
  * Step two: create the project from the **reviewed** list.
  *
- * Takes the review page's fields rather than the file — excluded rows never arrive (an
- * unchecked checkbox is not submitted), so exclusion needs no server-side concept beyond
- * "build what you were sent".
+ * Takes the review page's fields rather than the file. The list arrives as one
+ * [ReviewedMaterialsCodec] payload carrying every row and whether the user struck it, so
+ * exclusion is still just "build the rows you were told to keep".
  */
 suspend fun ApplicationCall.handleCreateProjectFromSchematic() {
     val user = this.getUser()
@@ -128,14 +128,13 @@ suspend fun ApplicationCall.handleCreateProjectFromSchematic() {
 /**
  * Reads the review page's submission back into a [SchematicProject].
  *
- * Rows arrive as `qty[<itemId>]=<amount>`; excluded rows are simply absent. Every id is
- * re-checked against the world's catalog — the review page is a form like any other, and
- * what it sends is not trusted just because the server rendered it a moment ago.
+ * The whole list arrives in one `materials` field (MCO-315); rows the user struck are carried
+ * too and dropped here. Every id is re-checked against the world's catalog — the review page
+ * is a form like any other, and what it sends is not trusted just because the server rendered
+ * it a moment ago.
  */
 internal data class ValidateReviewedMaterialsStep(val availableItems: List<Item>) :
     Step<Parameters, AppFailure, SchematicProject> {
-
-    private val quantityParameter = Regex("""^qty\[(.+)]$""")
 
     override suspend fun process(input: Parameters): Result<AppFailure, SchematicProject> {
         val name = input["name"]?.trim()?.takeIf { it.isNotBlank() }
@@ -143,25 +142,23 @@ internal data class ValidateReviewedMaterialsStep(val availableItems: List<Item>
                 AppFailure.customValidationError("name", "Give the project a name")
             )
 
+        val rows = when (val decoded = ReviewedMaterialsCodec.decode(input[ReviewedMaterialsCodec.FIELD])) {
+            is Result.Failure -> return Result.Failure(decoded.error)
+            is Result.Success -> decoded.value
+        }
+
         val byId = availableItems.associateBy { it.id }
         val errors = mutableListOf<ValidationFailure>()
         val requirements = mutableMapOf<Item, Int>()
 
-        input.entries().forEach { entry ->
-            val itemId = quantityParameter.find(entry.key)?.groupValues?.get(1) ?: return@forEach
-            val item = byId[itemId]
+        rows.forEach { row ->
+            if (!row.included) return@forEach
+            val item = byId[row.itemId]
             if (item == null) {
-                errors.add(ValidationFailure.CustomValidation("materials", "Unknown item: $itemId"))
+                errors.add(ValidationFailure.CustomValidation("materials", "Unknown item: ${row.itemId}"))
                 return@forEach
             }
-            val amount = entry.value.firstOrNull()?.toIntOrNull()
-            if (amount == null || amount <= 0) {
-                errors.add(
-                    ValidationFailure.CustomValidation("materials", "${item.name} needs a positive amount")
-                )
-                return@forEach
-            }
-            requirements[item] = amount
+            requirements[item] = row.amount
         }
 
         if (errors.isNotEmpty()) return Result.failure(AppFailure.ValidationError(errors))

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -145,51 +145,44 @@ suspend fun ApplicationCall.handleImportIdea() {
 /**
  * Replaces an idea's requirements with the ones the review page sent back.
  *
- * Rows arrive as `qty[<itemId>]=<amount>`; excluded rows are simply absent. Ids are checked
- * against the world's catalog rather than against the idea, so a submission cannot smuggle
- * in an item the idea never listed.
+ * The whole list arrives in one `materials` field (MCO-315); rows the user struck are carried
+ * too and dropped here. Ids are checked against the world's catalog rather than against the
+ * idea, so a submission cannot smuggle in an item the idea never listed.
  *
  * There is deliberately no "not reviewed, use the idea's list" fallback. A form with every
- * row unchecked and a bare direct post are byte-identical, so a fallback would silently
+ * row unchecked and a bare direct post are near-identical, so a fallback would silently
  * import everything at exactly the moment the user asked for nothing. Import goes through
- * the review screen; a submission with no rows is refused like any other empty one.
+ * the review screen; a submission with no rows — or with no list at all — is refused.
  */
 internal data class ApplyReviewedRequirementsStep(
     val submitted: Parameters,
     val availableItems: List<Item>,
 ) : Step<IdeaForImport, AppFailure, IdeaForImport> {
 
-    private val quantityParameter = Regex("""^qty\[(.+)]$""")
-
     override suspend fun process(input: IdeaForImport): Result<AppFailure, IdeaForImport> {
-        val submittedRows = submitted.entries()
-            .mapNotNull { entry ->
-                val itemId = quantityParameter.find(entry.key)?.groupValues?.get(1) ?: return@mapNotNull null
-                itemId to entry.value.firstOrNull()
-            }
+        val submittedRows = when (
+            val decoded = ReviewedMaterialsCodec.decode(submitted[ReviewedMaterialsCodec.FIELD])
+        ) {
+            is Result.Failure -> return Result.Failure(decoded.error)
+            is Result.Success -> decoded.value
+        }
 
         val byId = availableItems.associateBy { it.id }
         val errors = mutableListOf<ValidationFailure>()
         val requirements = mutableMapOf<Item, Int>()
 
-        submittedRows.forEach { (itemId, rawAmount) ->
+        submittedRows.forEach { row ->
+            if (!row.included) return@forEach
             // The review screen never offers air, so this only catches a hand-rolled post —
             // but "air is never a material" is worth enforcing where the list becomes final.
-            if (itemId in NON_MATERIAL_FILL) return@forEach
+            if (row.itemId in NON_MATERIAL_FILL) return@forEach
 
-            val item = byId[itemId]
+            val item = byId[row.itemId]
             if (item == null) {
-                errors.add(ValidationFailure.CustomValidation("materials", "Unknown item: $itemId"))
+                errors.add(ValidationFailure.CustomValidation("materials", "Unknown item: ${row.itemId}"))
                 return@forEach
             }
-            val amount = rawAmount?.toIntOrNull()
-            if (amount == null || amount <= 0) {
-                errors.add(
-                    ValidationFailure.CustomValidation("materials", "${item.name} needs a positive amount")
-                )
-                return@forEach
-            }
-            requirements[item] = amount
+            requirements[item] = row.amount
         }
 
         if (errors.isNotEmpty()) return Result.failure(AppFailure.ValidationError(errors))

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ReviewedMaterials.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ReviewedMaterials.kt
@@ -1,0 +1,142 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.failure.AppFailure
+
+/**
+ * One row of the import review list, as it travels between the browser and the server.
+ *
+ * [included] is the checkbox: an excluded row is still carried, because a family swap has to
+ * rewrite the rows the user struck without resurrecting them (MCO-304).
+ */
+data class ReviewedMaterial(
+    val itemId: String,
+    val amount: Int,
+    val included: Boolean,
+)
+
+/**
+ * MCO-315: the review screen's material list travels as **one** form field.
+ *
+ * It used to be two fields per row — `qty[<id>]` for the checkbox and `row[<id>]` for the
+ * always-submitted mirror. Ktor decodes an urlencoded body with `parseQueryString`, whose
+ * `limit` defaults to **1000 pairs** and which simply *stops* at the limit rather than
+ * failing, so a 560-material schematic lost everything past row ~466 without a word: 93 of
+ * 558 materials silently missing from the created project.
+ *
+ * Raising the limit was rejected. The review screen deliberately holds the whole list in the
+ * form rather than in a draft table (the MCO-303 decision), so the form *is* the storage and
+ * it will keep growing; a bigger ceiling only moves the cliff. One field per list is flat in
+ * the number of rows, which takes the cliff away instead.
+ *
+ * The payload is self-describing so that truncation can never be silent again: it declares
+ * how many rows it carries, and [decode] refuses a payload whose rows do not add up. Any
+ * transport that cuts the list short — a future parameter cap, a body limit, a proxy — now
+ * produces a validation error the user can see instead of a project missing a fifth of its
+ * materials.
+ *
+ * ```
+ * materials := "v1" ";" count *( ";" row )
+ * row       := [ "!" ] item-id "=" amount        ; "!" marks an excluded (unchecked) row
+ * ```
+ *
+ * Minecraft resource locations are `[a-z0-9_.-]` plus `:` and `/`, so `;`, `=` and `!` can
+ * never occur inside an id and need no escaping. The whole value is form-urlencoded by the
+ * browser like any other field.
+ */
+object ReviewedMaterialsCodec {
+
+    /** The single form field the whole list rides in. */
+    const val FIELD = "materials"
+
+    /**
+     * A sanity bound, not a product limit — a vanilla catalog holds ~1500 distinct items, so
+     * nothing a real import can produce comes close. It exists so a hand-rolled post cannot
+     * ask the server to build an arbitrarily large list before validation gets a look in.
+     */
+    const val MAX_ROWS = 10_000
+
+    private const val VERSION = "v1"
+    private const val ROW_SEPARATOR = ";"
+    private const val AMOUNT_SEPARATOR = '='
+    private const val EXCLUDED_MARK = '!'
+
+    fun encode(rows: List<ReviewedMaterial>): String = buildString {
+        append(VERSION)
+        append(ROW_SEPARATOR)
+        append(rows.size)
+        rows.forEach { row ->
+            append(ROW_SEPARATOR)
+            if (!row.included) append(EXCLUDED_MARK)
+            append(row.itemId)
+            append(AMOUNT_SEPARATOR)
+            append(row.amount)
+        }
+    }
+
+    /**
+     * Reads the field back, refusing anything that is not exactly what was sent.
+     *
+     * Every failure here is loud on purpose. A missing field is the shape a *stale* review
+     * page (one rendered before this change) submits, and answering it with "import what
+     * happened to arrive" is how the original bug looked to the user.
+     */
+    fun decode(raw: String?): Result<AppFailure, List<ReviewedMaterial>> {
+        val payload = raw?.trim()
+        if (payload.isNullOrEmpty()) {
+            return failure(
+                "The material list did not arrive with the form. Reload the review page and try again."
+            )
+        }
+
+        val parts = payload.split(ROW_SEPARATOR)
+        if (parts.first() != VERSION) {
+            return failure(
+                "The material list is in a format Seam does not recognise. Reload the review page and try again."
+            )
+        }
+
+        val declared = parts.getOrNull(1)?.toIntOrNull()
+        if (declared == null || declared < 0) {
+            return failure(
+                "The material list did not say how many materials it carries. Reload the review page and try again."
+            )
+        }
+        if (declared > MAX_ROWS) {
+            return failure(
+                "This import lists $declared distinct materials, more than the $MAX_ROWS Seam can take in one go."
+            )
+        }
+
+        val encodedRows = parts.drop(2)
+        if (encodedRows.size != declared) {
+            return failure(
+                "The material list arrived incomplete — ${encodedRows.size} of $declared materials reached the " +
+                    "server. Nothing was imported. Reload the review page and try again."
+            )
+        }
+
+        val rows = ArrayList<ReviewedMaterial>(encodedRows.size)
+        for (encoded in encodedRows) {
+            val included = !encoded.startsWith(EXCLUDED_MARK)
+            val body = if (included) encoded else encoded.substring(1)
+            val separator = body.lastIndexOf(AMOUNT_SEPARATOR)
+            if (separator <= 0) {
+                return failure(
+                    "The material list contains a row Seam could not read. Reload the review page and try again."
+                )
+            }
+            val itemId = body.substring(0, separator)
+            val amount = body.substring(separator + 1).toIntOrNull()
+            if (amount == null || amount <= 0) {
+                return failure("$itemId needs a positive amount")
+            }
+            rows.add(ReviewedMaterial(itemId, amount, included))
+        }
+
+        return Result.success(rows)
+    }
+
+    private fun failure(message: String): Result<AppFailure, List<ReviewedMaterial>> =
+        Result.failure(AppFailure.customValidationError(FIELD, message))
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/SubstituteInImportReviewPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/SubstituteInImportReviewPipeline.kt
@@ -70,9 +70,11 @@ data class ReviewedList(
 /**
  * Reads the review form, applies one family swap, and hands back the rewritten list.
  *
- * The form sends each row twice: `row[<id>]` always, and `qty[<id>]` only while the row is
- * checked. Reading the list from `row[...]` is what lets an excluded row survive a swap —
- * from `qty[...]` alone, striking a row and then swapping would delete it for good.
+ * The form sends the whole list — struck rows included — in one `materials` field (MCO-315).
+ * Carrying the struck rows is what lets an excluded row survive a swap; from the kept rows
+ * alone, striking a row and then swapping would delete it for good. Before MCO-315 that
+ * guarantee was a second field per row, which is exactly what overflowed the request's
+ * parameter cap and made the tail of a large list vanish across a swap.
  *
  * Ids are re-checked against the world catalog. The review page is a form like any other and
  * what it sends is not trusted just because the server rendered it a moment ago.
@@ -80,31 +82,28 @@ data class ReviewedList(
 internal data class SubstituteReviewedListStep(val availableItems: List<Item>) :
     Step<Parameters, AppFailure, ReviewedList> {
 
-    private val rowParameter = Regex("""^row\[(.+)]$""")
-    private val quantityParameter = Regex("""^qty\[(.+)]$""")
-
     override suspend fun process(input: Parameters): Result<AppFailure, ReviewedList> {
         val fromToken = input["from"]?.takeIf { it.isNotBlank() }
             ?: return Result.failure(AppFailure.customValidationError("from", "Nothing to swap"))
-        val toToken = input["to[$fromToken]"]?.takeIf { it.isNotBlank() }
+        val toToken = input["to"]?.takeIf { it.isNotBlank() }
             ?: return Result.failure(AppFailure.customValidationError("to", "Pick what to swap to"))
+
+        val rows = when (val decoded = ReviewedMaterialsCodec.decode(input[ReviewedMaterialsCodec.FIELD])) {
+            is Result.Failure -> return Result.Failure(decoded.error)
+            is Result.Success -> decoded.value
+        }
 
         val byId = availableItems.associateBy { it.id }
         val requirements = LinkedHashMap<Item, Int>()
+        val checked = mutableSetOf<String>()
 
-        input.entries().forEach { entry ->
-            val itemId = rowParameter.find(entry.key)?.groupValues?.get(1) ?: return@forEach
-            val item = byId[itemId]
+        rows.forEach { row ->
+            val item = byId[row.itemId]
                 ?: return Result.failure(
-                    AppFailure.customValidationError("materials", "Unknown item: $itemId")
+                    AppFailure.customValidationError("materials", "Unknown item: ${row.itemId}")
                 )
-            val amount = entry.value.firstOrNull()?.toIntOrNull()
-            if (amount == null || amount <= 0) {
-                return Result.failure(
-                    AppFailure.customValidationError("materials", "${item.name} needs a positive amount")
-                )
-            }
-            requirements[item] = amount
+            requirements[item] = row.amount
+            if (row.included) checked.add(row.itemId)
         }
 
         if (requirements.isEmpty()) {
@@ -112,9 +111,6 @@ internal data class SubstituteReviewedListStep(val availableItems: List<Item>) :
                 AppFailure.customValidationError("materials", "There is nothing here to swap")
             )
         }
-
-        val checked = input.entries()
-            .mapNotNullTo(mutableSetOf()) { quantityParameter.find(it.key)?.groupValues?.get(1) }
 
         val tokens = variantTokens(availableItems)
         val catalogIds = availableItems.mapTo(HashSet()) { it.id }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -5,6 +5,8 @@ import app.mcorg.domain.model.user.TokenProfile
 import app.mcorg.pipeline.project.ImportWarning
 import app.mcorg.pipeline.project.ImportWarningKind
 import app.mcorg.pipeline.project.ImportWarnings
+import app.mcorg.pipeline.project.ReviewedMaterial
+import app.mcorg.pipeline.project.ReviewedMaterialsCodec
 import app.mcorg.pipeline.resources.SubstitutionFamily
 import app.mcorg.presentation.hxInclude
 import app.mcorg.presentation.hxPost
@@ -45,9 +47,12 @@ import kotlinx.html.tr
  * creates it. "Not building the decorative shell" is a decision worth making while the
  * list is still a form, not after it is a hundred resource rows in a project.
  *
- * The whole material list is in this page's form: a checkbox per row (checked = keep) and
- * a hidden quantity beside it. An unchecked box is simply not submitted, so excluding is
- * exclusion with no server-side concept behind it. Nothing is persisted until Create.
+ * The whole material list is in this page's form — as a *single* field (MCO-315). It used to
+ * be two fields per row, which walked straight into Ktor's 1000-parameter body cap and lost
+ * everything past row ~466 of a 560-material schematic without saying so. One field per list
+ * is flat in the number of rows; see [ReviewedMaterialsCodec] for the payload and for why
+ * raising the cap was the wrong fix. The checkboxes are now pure UI — `import-review.js`
+ * folds their state back into the field.
  *
  * Shared by both import doors (MCO-306): the schematic upload posts its parsed list here,
  * and an idea import arrives with the idea's requirements. [action] and [hiddenFields] are
@@ -80,6 +85,7 @@ fun importReviewPage(
         "/static/styles/components/form.css",
         "/static/styles/pages/import-review.css",
     ),
+    scripts = listOf("/static/scripts/import-review.js"),
 ) {
     appHeader(
         worldName = worldName,
@@ -188,22 +194,51 @@ private fun DIV.materialsSectionBody(
 ) {
     id = MATERIALS_ID
     classes = setOf("import-review__materials")
+
+    // One order for the whole section: the hidden field and the table must describe the same
+    // list in the same sequence, or a swap would reorder the rows under the user.
+    val rows = requirements.entries.sortedWith(
+        compareByDescending<Map.Entry<Item, Int>> { it.value }.thenBy { it.key.name }
+    )
+
+    materialsField(rows, excluded)
     warningStrip(warnings)
     substitutionControls(worldId, families)
-    materialsTable(requirements, excluded, warnings)
+    materialsTable(rows, excluded, warnings)
 }
 
 private const val MATERIALS_ID = "import-review-materials"
+private const val MATERIALS_FIELD_ID = "import-review-materials-field"
+
+/**
+ * The list itself — every row, its quantity and whether it is struck — in one field
+ * (MCO-315). Rendered first inside the swappable section so it is among the very first
+ * parameters in the body, and rewritten by `import-review.js` whenever a checkbox moves.
+ *
+ * Without JavaScript this still submits the list exactly as the server rendered it; only the
+ * exclusions would be missed, and the payload's declared row count means nothing can be lost
+ * without the server saying so.
+ */
+private fun FlowContent.materialsField(rows: List<Map.Entry<Item, Int>>, excluded: Set<String>) {
+    hiddenInput {
+        id = MATERIALS_FIELD_ID
+        name = ReviewedMaterialsCodec.FIELD
+        value = ReviewedMaterialsCodec.encode(
+            rows.map { (item, amount) -> ReviewedMaterial(item.id, amount, item.id !in excluded) }
+        )
+    }
+}
 
 /**
  * One control per family found in the list: "all Oak -> [ Spruce ]".
  *
- * The swap posts the *whole* form and swaps this section for the rewritten one, which is why
- * the rows carry a hidden `row[...]` mirror of their quantity — an unchecked checkbox submits
- * nothing, and a swap must not silently resurrect or delete the rows you struck.
+ * The swap posts the form back and replaces this section with the rewritten one, which is why
+ * the single materials field carries the struck rows too — a swap must not silently resurrect
+ * or delete the rows you struck.
  *
- * The target select is named per family (`to[<token>]`) so several controls can coexist in
- * one form; the button says which family it is via `hx-vals`.
+ * The selects are deliberately *not* form controls: they carry no `name`, so a create submit
+ * never drags a parameter per family along with it, and the swap button reads the one it needs
+ * by id through `hx-vals`. `hx-vals` also says which family is being swapped.
  */
 private fun FlowContent.substitutionControls(worldId: Int, families: List<SubstitutionFamily>) {
     if (families.isEmpty()) return
@@ -224,7 +259,6 @@ private fun FlowContent.substitutionControls(worldId: Int, families: List<Substi
                 }
                 select("form-control import-review__swap-to") {
                     id = "swap-to-${family.token}"
-                    name = "to[${family.token}]"
                     attributes["aria-label"] = "Swap all ${family.label} to"
                     family.targets.forEach { target ->
                         option {
@@ -240,7 +274,8 @@ private fun FlowContent.substitutionControls(worldId: Int, families: List<Substi
                     hxInclude("#import-review-form")
                     hxTarget("#$MATERIALS_ID")
                     hxSwap("outerHTML")
-                    attributes["hx-vals"] = """{"from": "${family.token}"}"""
+                    attributes["hx-vals"] =
+                        """js:{"from": "${family.token}", "to": document.getElementById("swap-to-${family.token}").value}"""
                     +"Swap"
                 }
             }
@@ -283,14 +318,10 @@ private fun namesOf(flagged: List<ImportWarning>): String {
 }
 
 private fun FlowContent.materialsTable(
-    requirements: Map<Item, Int>,
+    rows: List<Map.Entry<Item, Int>>,
     excluded: Set<String>,
     warnings: ImportWarnings,
 ) {
-    val rows = requirements.entries.sortedWith(
-        compareByDescending<Map.Entry<Item, Int>> { it.value }.thenBy { it.key.name }
-    )
-
     div("import-review__summary") {
         span("section-label") { +"Materials" }
         span("import-review__count") {
@@ -314,20 +345,16 @@ private fun FlowContent.materialsTable(
                     tr("import-review__row") {
                         td {
                             attributes["data-label"] = "Include"
+                            // Deliberately nameless: the box submits nothing of its own. It
+                            // describes one row of the single materials field, which
+                            // `import-review.js` rebuilds from these boxes (MCO-315). Two
+                            // fields per row is what overflowed the body's parameter cap.
                             input(type = InputType.checkBox, classes = "import-review__include") {
                                 id = "include-$rowId"
-                                // Unchecked boxes are not submitted — that *is* the exclusion.
-                                name = "qty[${item.id}]"
-                                value = amount.toString()
                                 checked = item.id !in excluded
+                                attributes["data-item-id"] = item.id
+                                attributes["data-amount"] = amount.toString()
                                 attributes["aria-label"] = "Include ${item.name}"
-                            }
-                            // The row's quantity again, always submitted. Create ignores it;
-                            // a substitution needs it, because the rows you struck are absent
-                            // from `qty[...]` and would otherwise vanish across the swap.
-                            hiddenInput {
-                                name = "row[${item.id}]"
-                                value = amount.toString()
                             }
                         }
                         td {
@@ -353,10 +380,9 @@ private fun FlowContent.materialsTable(
         }
     }
 
-    // Nothing to submit when every row is unchecked; the server says so too, but a form
-    // with no rows at all should not have reached this page in the first place.
+    // The server refuses an empty list too, but a form with no rows at all should not have
+    // reached this page in the first place.
     if (rows.isEmpty()) {
-        hiddenInput { name = "empty"; value = "true" }
         p("form-error") { +"This schematic contains no recognisable materials." }
     }
 }

--- a/webapp/mc-web/src/main/resources/static/scripts/import-review.js
+++ b/webapp/mc-web/src/main/resources/static/scripts/import-review.js
@@ -1,0 +1,75 @@
+/**
+ * MCO-315 — the import review list travels as one form field, not two per row.
+ *
+ * Two fields per row walked into Ktor's 1000-parameter body cap, which stops decoding at the
+ * limit instead of failing: a 560-material schematic silently lost everything past row ~466.
+ * The list now rides in a single hidden field (see ReviewedMaterialsCodec), which means the
+ * include checkboxes carry no name of their own — this file is what folds their state back
+ * into that field.
+ *
+ * The DOM is the source of truth; the field is only transport. It is rebuilt on every change,
+ * again on submit, and again when HTMX is about to send (the swap round-trip), so a missed
+ * event can never turn into a wrong list on the wire.
+ */
+(function () {
+    var FORM_ID = 'import-review-form';
+    var FIELD_ID = 'import-review-materials-field';
+    var VERSION = 'v1';
+
+    var form = document.getElementById(FORM_ID);
+    if (!form) {
+        return;
+    }
+
+    /** Encodes the current checkbox state, or null when the review section is not on the page. */
+    function encode() {
+        var boxes = form.querySelectorAll('.import-review__include');
+        var rows = [];
+        for (var i = 0; i < boxes.length; i++) {
+            var box = boxes[i];
+            var itemId = box.getAttribute('data-item-id');
+            var amount = box.getAttribute('data-amount');
+            if (!itemId || !amount) {
+                continue;
+            }
+            rows.push((box.checked ? '' : '!') + itemId + '=' + amount);
+        }
+        var payload = VERSION + ';' + rows.length;
+        return rows.length === 0 ? payload : payload + ';' + rows.join(';');
+    }
+
+    /** Writes the encoded list into the hidden field and hands it back. */
+    function sync() {
+        var field = document.getElementById(FIELD_ID);
+        if (!field) {
+            return null;
+        }
+        field.value = encode();
+        return field.value;
+    }
+
+    form.addEventListener('change', function (event) {
+        var target = event.target;
+        if (target && target.classList && target.classList.contains('import-review__include')) {
+            sync();
+        }
+    });
+
+    form.addEventListener('submit', function () {
+        sync();
+    });
+
+    // HTMX has already collected the parameters by the time it fires this, so the fresh value
+    // goes into the request rather than into the DOM. Only ever overwrites a field the request
+    // was already carrying, so unrelated requests bubbling through the form are left alone.
+    form.addEventListener('htmx:configRequest', function (event) {
+        var parameters = event.detail && event.detail.parameters;
+        if (!parameters || typeof parameters.has !== 'function') {
+            return;
+        }
+        var value = sync();
+        if (value !== null && parameters.has('materials')) {
+            parameters.set('materials', value);
+        }
+    });
+})();

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/ReviewedMaterialsCodecTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/ReviewedMaterialsCodecTest.kt
@@ -1,0 +1,165 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.failure.ValidationFailure
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * MCO-315 — the review list as one field, and the promise that it can never arrive short
+ * without saying so.
+ */
+class ReviewedMaterialsCodecTest {
+
+    private fun decode(raw: String?) = ReviewedMaterialsCodec.decode(raw)
+
+    private fun succeed(raw: String?): List<ReviewedMaterial> {
+        val result = decode(raw)
+        assertIs<Result.Success<List<ReviewedMaterial>>>(result, "expected success, got $result")
+        return result.value
+    }
+
+    private fun failureMessage(raw: String?): String {
+        val result = decode(raw)
+        assertIs<Result.Failure<AppFailure>>(result, "expected failure, got $result")
+        val error = result.error
+        assertIs<AppFailure.ValidationError>(error)
+        return error.errors.filterIsInstance<ValidationFailure.CustomValidation>().joinToString(" ") { it.message }
+    }
+
+    @Test
+    fun `a list round-trips with its order, quantities and exclusions intact`() {
+        val rows = listOf(
+            ReviewedMaterial("minecraft:stone", 1024, included = true),
+            ReviewedMaterial("minecraft:shroomlight", 64, included = false),
+            ReviewedMaterial("minecraft:oak_planks", 12, included = true),
+        )
+
+        assertEquals(rows, succeed(ReviewedMaterialsCodec.encode(rows)))
+    }
+
+    @Test
+    fun `an empty list is a valid payload, not a missing one`() {
+        val encoded = ReviewedMaterialsCodec.encode(emptyList())
+
+        assertEquals("v1;0", encoded)
+        assertTrue(succeed(encoded).isEmpty())
+    }
+
+    @Test
+    fun `a list far larger than the old 1000-parameter cap survives whole`() {
+        // The bug: two fields per row meant ~466 rows fit in a request body. One field per
+        // list is flat in the number of rows, so 5000 costs the same one parameter as one.
+        val rows = (1..5000).map { ReviewedMaterial("minecraft:bulk_$it", it, included = it % 7 != 0) }
+
+        val decoded = succeed(ReviewedMaterialsCodec.encode(rows))
+
+        assertEquals(rows, decoded)
+        assertEquals(rows.count { it.included }, decoded.count { it.included })
+    }
+
+    @Test
+    fun `ids carrying every character a resource location allows survive`() {
+        val rows = listOf(
+            ReviewedMaterial("minecraft:block/oak_log-2.0", 3, included = true),
+            ReviewedMaterial("some_mod:deep.slate_thing", 7, included = false),
+        )
+
+        assertEquals(rows, succeed(ReviewedMaterialsCodec.encode(rows)))
+    }
+
+    @Test
+    fun `the exact shape the browser script writes is accepted`() {
+        // `import-review.js` rebuilds this field from the checkboxes, so the two encoders sit
+        // on opposite sides of a wire format with no schema between them. This literal is the
+        // format, spelled out independently of [ReviewedMaterialsCodec.encode].
+        val fromBrowser = "v1;3;minecraft:stone=1024;!minecraft:shroomlight=64;minecraft:oak_planks=12"
+
+        assertEquals(
+            listOf(
+                ReviewedMaterial("minecraft:stone", 1024, included = true),
+                ReviewedMaterial("minecraft:shroomlight", 64, included = false),
+                ReviewedMaterial("minecraft:oak_planks", 12, included = true),
+            ),
+            succeed(fromBrowser),
+        )
+        assertEquals(
+            fromBrowser,
+            ReviewedMaterialsCodec.encode(succeed(fromBrowser)),
+            "and the server writes exactly what the browser writes",
+        )
+    }
+
+    // ---- loud failures ---------------------------------------------------------------
+
+    @Test
+    fun `a payload cut short is refused rather than silently accepted`() {
+        // Exactly the shape truncation takes: the header still claims the full list, the
+        // rows behind it stop early. This is the check that makes MCO-315 unrepeatable.
+        val full = ReviewedMaterialsCodec.encode(
+            (1..600).map { ReviewedMaterial("minecraft:bulk_$it", it, included = true) }
+        )
+        val truncated = full.split(";").take(2 + 466).joinToString(";")
+
+        val message = failureMessage(truncated)
+
+        assertTrue(message.contains("incomplete"), "expected a truncation error, got: $message")
+        assertTrue(message.contains("466 of 600"), "the error should name what was lost, got: $message")
+    }
+
+    @Test
+    fun `a payload carrying more rows than it declares is refused`() {
+        val message = failureMessage("v1;1;minecraft:stone=1;minecraft:oak_planks=2")
+
+        assertTrue(message.contains("incomplete"), message)
+    }
+
+    @Test
+    fun `a missing field is refused rather than treated as an empty list`() {
+        val message = failureMessage(null)
+
+        assertTrue(message.contains("did not arrive"), message)
+    }
+
+    @Test
+    fun `a blank field is refused`() {
+        assertIs<Result.Failure<AppFailure>>(decode("   "))
+    }
+
+    @Test
+    fun `an unrecognised version marker is refused`() {
+        val message = failureMessage("v2;1;minecraft:stone=1")
+
+        assertTrue(message.contains("does not recognise"), message)
+    }
+
+    @Test
+    fun `a payload without a row count is refused`() {
+        assertIs<Result.Failure<AppFailure>>(decode("v1"))
+        assertIs<Result.Failure<AppFailure>>(decode("v1;many;minecraft:stone=1"))
+        assertIs<Result.Failure<AppFailure>>(decode("v1;-1"))
+    }
+
+    @Test
+    fun `a list beyond the sanity bound is refused before anything is built`() {
+        val message = failureMessage("v1;${ReviewedMaterialsCodec.MAX_ROWS + 1}")
+
+        assertTrue(message.contains("more than the"), message)
+    }
+
+    @Test
+    fun `a row with no quantity is refused`() {
+        assertIs<Result.Failure<AppFailure>>(decode("v1;1;minecraft:stone"))
+        assertIs<Result.Failure<AppFailure>>(decode("v1;1;=64"))
+    }
+
+    @Test
+    fun `a non-positive or unreadable quantity is refused`() {
+        assertIs<Result.Failure<AppFailure>>(decode("v1;1;minecraft:stone=0"))
+        assertIs<Result.Failure<AppFailure>>(decode("v1;1;minecraft:stone=-4"))
+        assertIs<Result.Failure<AppFailure>>(decode("v1;1;minecraft:stone=lots"))
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/SubstituteReviewedListStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/SubstituteReviewedListStepTest.kt
@@ -3,6 +3,7 @@ package app.mcorg.pipeline.project
 import app.mcorg.domain.model.minecraft.Item
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.failure.ValidationFailure
 import io.ktor.http.Parameters
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
@@ -12,6 +13,9 @@ import kotlin.test.assertTrue
 
 /**
  * MCO-304 — reading the review form back, one family swap at a time.
+ *
+ * Since MCO-315 the form sends the list as one `materials` field rather than two parameters
+ * per row; the struck rows ride along inside it, which is what keeps them struck across a swap.
  */
 class SubstituteReviewedListStepTest {
 
@@ -28,9 +32,20 @@ class SubstituteReviewedListStepTest {
 
     private val step = SubstituteReviewedListStep(catalog)
 
+    /** `id to amount` for a kept row, `"!" + id to amount` for a struck one. */
+    private fun materials(vararg rows: Pair<String, Int>): String =
+        ReviewedMaterialsCodec.encode(
+            rows.map { (id, amount) ->
+                ReviewedMaterial(id.removePrefix("!"), amount, included = !id.startsWith("!"))
+            }
+        )
+
     private fun form(vararg pairs: Pair<String, String>) = Parameters.build {
         pairs.forEach { (key, value) -> append(key, value) }
     }
+
+    private fun swap(from: String, to: String, materials: String) =
+        form("from" to from, "to" to to, ReviewedMaterialsCodec.FIELD to materials)
 
     private fun run(params: Parameters) = runBlocking { step.process(params) }
 
@@ -43,14 +58,7 @@ class SubstituteReviewedListStepTest {
     @Test
     fun `every row in the family moves and everything else stays`() {
         val reviewed = succeed(
-            form(
-                "from" to "oak",
-                "to[oak]" to "spruce",
-                "row[minecraft:oak_planks]" to "64",
-                "qty[minecraft:oak_planks]" to "64",
-                "row[minecraft:stone]" to "12",
-                "qty[minecraft:stone]" to "12",
-            )
+            swap("oak", "spruce", materials("minecraft:oak_planks" to 64, "minecraft:stone" to 12))
         )
 
         assertEquals(
@@ -62,15 +70,8 @@ class SubstituteReviewedListStepTest {
 
     @Test
     fun `a struck row survives the swap and is still struck`() {
-        // No qty[...] for the stairs — that is exactly what an unchecked box submits.
         val reviewed = succeed(
-            form(
-                "from" to "oak",
-                "to[oak]" to "spruce",
-                "row[minecraft:oak_planks]" to "64",
-                "qty[minecraft:oak_planks]" to "64",
-                "row[minecraft:oak_stairs]" to "8",
-            )
+            swap("oak", "spruce", materials("minecraft:oak_planks" to 64, "!minecraft:oak_stairs" to 8))
         )
 
         assertEquals(
@@ -85,13 +86,7 @@ class SubstituteReviewedListStepTest {
         // The struck oak planks land on the kept spruce planks. Striking a row the user had
         // checked would be the surprising outcome; the quantity is visible either way.
         val reviewed = succeed(
-            form(
-                "from" to "oak",
-                "to[oak]" to "spruce",
-                "row[minecraft:oak_planks]" to "64",
-                "row[minecraft:spruce_planks]" to "10",
-                "qty[minecraft:spruce_planks]" to "10",
-            )
+            swap("oak", "spruce", materials("!minecraft:oak_planks" to 64, "minecraft:spruce_planks" to 10))
         )
 
         assertEquals(mapOf("minecraft:spruce_planks" to 74), reviewed.requirements.mapKeys { it.key.id })
@@ -101,64 +96,102 @@ class SubstituteReviewedListStepTest {
     @Test
     fun `quantities merge rather than one row overwriting the other`() {
         val reviewed = succeed(
-            form(
-                "from" to "oak",
-                "to[oak]" to "spruce",
-                "row[minecraft:oak_slab]" to "5",
-                "qty[minecraft:oak_slab]" to "5",
-                "row[minecraft:spruce_slab]" to "3",
-                "qty[minecraft:spruce_slab]" to "3",
-            )
+            swap("oak", "spruce", materials("minecraft:oak_slab" to 5, "minecraft:spruce_slab" to 3))
         )
 
         assertEquals(8, reviewed.requirements.values.single())
     }
 
     @Test
+    fun `a list far past the old parameter cap swaps whole, struck rows included`() {
+        // MCO-315: at two parameters per row this list lost its tail on the way in, so a swap
+        // silently deleted everything past ~row 466 of the review screen.
+        val bulk = (1..300).map { Item("minecraft:bulk_$it", "Bulk $it") }
+        val wide = SubstituteReviewedListStep(catalog + bulk)
+        val rows = buildList {
+            add("minecraft:oak_planks" to 64)
+            add("!minecraft:oak_stairs" to 8)
+            bulk.forEachIndexed { index, item ->
+                add((if (index % 5 == 0) "!" else "") + item.id to index + 1)
+            }
+        }
+
+        val result = runBlocking {
+            wide.process(swap("oak", "spruce", materials(*rows.toTypedArray())))
+        }
+
+        assertIs<Result.Success<ReviewedList>>(result, "expected success, got $result")
+        val reviewed = result.value
+        assertEquals(302, reviewed.requirements.size, "every row survives the round-trip")
+        assertEquals(64, reviewed.requirements.entries.single { it.key.id == "minecraft:spruce_planks" }.value)
+        assertEquals(
+            bulk.filterIndexed { index, _ -> index % 5 == 0 }.map { it.id }.toSet() +
+                setOf("minecraft:spruce_stairs"),
+            reviewed.excluded,
+            "the struck rows are still struck, all the way to the end of the list",
+        )
+    }
+
+    @Test
+    fun `a truncated list is refused rather than swapped in part`() {
+        // Every id here is in the catalog, so truncation is the only thing that can fail.
+        val bulk = (1..600).map { Item("minecraft:bulk_$it", "Bulk $it") }
+        val wide = SubstituteReviewedListStep(catalog + bulk)
+        val full = materials(*bulk.mapIndexed { index, item -> item.id to index + 1 }.toTypedArray())
+        val truncated = full.split(";").take(2 + 466).joinToString(";")
+
+        val result = runBlocking { wide.process(swap("oak", "spruce", truncated)) }
+
+        assertIs<Result.Failure<AppFailure>>(result)
+        val error = result.error
+        assertIs<AppFailure.ValidationError>(error)
+        assertTrue(
+            error.errors.filterIsInstance<ValidationFailure.CustomValidation>()
+                .any { "466 of 600" in it.message },
+            "the user is told the list arrived short, not handed a partial swap: ${error.errors}",
+        )
+    }
+
+    @Test
     fun `a missing target is refused`() {
-        val result = run(form("from" to "oak", "row[minecraft:oak_planks]" to "1"))
+        val result = run(
+            form("from" to "oak", ReviewedMaterialsCodec.FIELD to materials("minecraft:oak_planks" to 1))
+        )
 
         assertIs<Result.Failure<AppFailure>>(result)
     }
 
     @Test
     fun `a missing family is refused`() {
-        val result = run(form("to[oak]" to "spruce", "row[minecraft:oak_planks]" to "1"))
+        val result = run(
+            form("to" to "spruce", ReviewedMaterialsCodec.FIELD to materials("minecraft:oak_planks" to 1))
+        )
 
         assertIs<Result.Failure<AppFailure>>(result)
     }
 
     @Test
     fun `an id outside the world catalog is refused rather than passed through`() {
-        val result = run(
-            form(
-                "from" to "oak",
-                "to[oak]" to "spruce",
-                "row[minecraft:not_a_real_item]" to "1",
-            )
-        )
+        val result = run(swap("oak", "spruce", materials("minecraft:not_a_real_item" to 1)))
 
         assertIs<Result.Failure<AppFailure>>(result)
     }
 
     @Test
     fun `a non-positive quantity is refused`() {
-        val result = run(
-            form(
-                "from" to "oak",
-                "to[oak]" to "spruce",
-                "row[minecraft:oak_planks]" to "0",
-            )
-        )
+        val result = run(swap("oak", "spruce", "v1;1;minecraft:oak_planks=0"))
 
         assertIs<Result.Failure<AppFailure>>(result)
     }
 
     @Test
     fun `a form with no rows at all is refused`() {
-        val result = run(form("from" to "oak", "to[oak]" to "spruce"))
+        assertIs<Result.Failure<AppFailure>>(run(swap("oak", "spruce", materials())))
+    }
 
-        assertIs<Result.Failure<AppFailure>>(result)
+    @Test
+    fun `a form with no material list at all is refused`() {
+        assertIs<Result.Failure<AppFailure>>(run(form("from" to "oak", "to" to "spruce")))
     }
 
     @Test
@@ -168,12 +201,7 @@ class SubstituteReviewedListStepTest {
         val narrowCatalog = catalog + Item("minecraft:oak_sapling", "Oak Sapling")
         val reviewed = runBlocking {
             SubstituteReviewedListStep(narrowCatalog).process(
-                form(
-                    "from" to "oak",
-                    "to[oak]" to "spruce",
-                    "row[minecraft:oak_sapling]" to "4",
-                    "qty[minecraft:oak_sapling]" to "4",
-                )
+                swap("oak", "spruce", materials("minecraft:oak_sapling" to 4))
             )
         }
 

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/CreateProjectFromSchematicIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/CreateProjectFromSchematicIT.kt
@@ -5,6 +5,8 @@ import app.mcorg.nbt.util.LitematicaReader
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.project.ReviewedMaterial
+import app.mcorg.pipeline.project.ReviewedMaterialsCodec
 import app.mcorg.pipeline.project.handleCreateProjectFromSchematic
 import app.mcorg.pipeline.project.handleReviewSchematic
 import app.mcorg.pipeline.world.CreateWorldInput
@@ -37,6 +39,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -64,19 +67,20 @@ class CreateProjectFromSchematicIT : WithUser() {
             ).process(Unit)
         }
         // The reviewed-create tests post their own rows, so the catalog needs these two
-        // regardless of what the fixture happens to contain.
-        (litematica.items.keys + setOf("minecraft:stone", "minecraft:oak_planks")).forEach { itemId ->
-            runBlocking {
-                DatabaseSteps.update<Unit>(
-                    sql = SafeSQL.insert(
-                        "INSERT INTO minecraft_items (version, item_id, item_name) VALUES ('1.21.4', ?, ?) ON CONFLICT DO NOTHING"
-                    ),
-                    parameterSetter = { stmt, _ ->
-                        stmt.setString(1, itemId)
-                        stmt.setString(2, itemId.removePrefix("minecraft:").replace('_', ' '))
-                    }
-                ).process(Unit)
-            }
+        // regardless of what the fixture happens to contain. The bulk ids back the MCO-315
+        // regression: a list far wider than the old ~466-row cutoff.
+        val bulkIds = (1..BULK_ROWS).map { "minecraft:bulk_item_$it" }
+        val catalog = (litematica.items.keys + setOf("minecraft:stone", "minecraft:oak_planks") + bulkIds).toList()
+        runBlocking {
+            DatabaseSteps.batchUpdate<String>(
+                sql = SafeSQL.insert(
+                    "INSERT INTO minecraft_items (version, item_id, item_name) VALUES ('1.21.4', ?, ?) ON CONFLICT DO NOTHING"
+                ),
+                parameterSetter = { stmt, itemId ->
+                    stmt.setString(1, itemId)
+                    stmt.setString(2, itemId.removePrefix("minecraft:").replace('_', ' '))
+                }
+            ).process(catalog)
         }
     }
 
@@ -253,7 +257,11 @@ class CreateProjectFromSchematicIT : WithUser() {
         assertTrue(body.contains("Review this import"), "expected the review page")
         assertTrue(body.contains("import-review-table"))
         assertTrue(body.contains("Shulker Loader"), "the provided name is carried into the form")
-        assertTrue(body.contains("qty["), "rows round-trip as form fields")
+        assertTrue(
+            body.contains("""name="materials" value="v1;"""),
+            "the whole list round-trips as one field (MCO-315)",
+        )
+        assertFalse(body.contains("qty["), "and never as one parameter per row again")
         assertEquals(before, countProjects(worldId), "review must not create anything")
     }
 
@@ -265,7 +273,7 @@ class CreateProjectFromSchematicIT : WithUser() {
         val response = client.post("/worlds/$worldId/projects/from-schematic") {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("name=Reviewed Build&qty[minecraft:stone]=64&qty[minecraft:oak_planks]=12")
+            setBody("name=Reviewed Build&" + materials("minecraft:stone" to 64, "minecraft:oak_planks" to 12))
         }
 
         // A plain form submit gets a real redirect, not an HX-Redirect header.
@@ -283,13 +291,18 @@ class CreateProjectFromSchematicIT : WithUser() {
     fun `excluded rows never reach the project`() = testApplication {
         setupRoutes()
 
-        // The review page submits only the checked rows; oak_planks was unchecked, so it
-        // is simply absent from the body.
+        // The list carries every row; oak_planks rides along marked struck and is dropped
+        // server-side rather than simply being absent from the body.
         val client = createClient { followRedirects = false }
         val response = client.post("/worlds/$worldId/projects/from-schematic") {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("name=Partial Build&qty[minecraft:stone]=64")
+            setBody(
+                "name=Partial Build&" + materials(
+                    "minecraft:stone" to 64,
+                    "!minecraft:oak_planks" to 12,
+                )
+            )
         }
 
         assertEquals(HttpStatusCode.SeeOther, response.status)
@@ -305,7 +318,7 @@ class CreateProjectFromSchematicIT : WithUser() {
         val response = client.post("/worlds/$worldId/projects/from-schematic") {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("name=Nothing At All")
+            setBody("name=Nothing At All&" + materials("!minecraft:stone" to 64))
         }
 
         assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
@@ -320,7 +333,7 @@ class CreateProjectFromSchematicIT : WithUser() {
         val response = client.post("/worlds/$worldId/projects/from-schematic") {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("name=Smuggled&qty[minecraft:not_a_real_item]=1")
+            setBody("name=Smuggled&" + materials("minecraft:not_a_real_item" to 1))
         }
 
         assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
@@ -336,10 +349,91 @@ class CreateProjectFromSchematicIT : WithUser() {
         val response = client.post("/worlds/$worldId/projects/from-schematic") {
             addAuthCookie(this, outsider)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("name=Outsider Build&qty[minecraft:stone]=1")
+            setBody("name=Outsider Build&" + materials("minecraft:stone" to 1))
         }
 
         assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertEquals(before, countProjects(worldId))
+    }
+
+    // -------------------------------------------------------------------------
+    // MCO-315 — a list wider than the old request-parameter cap
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `a list far past the old 466-row cutoff persists every included row`() = testApplication {
+        setupRoutes()
+
+        // The bug in one assertion: 600 rows at two parameters each overflowed Ktor's
+        // 1000-pair body cap, which stops decoding instead of failing, so the project came
+        // out ~135 materials short with nothing said about it.
+        val rows = (1..BULK_ROWS).map { "minecraft:bulk_item_$it" to it }
+        val struck = rows.filterIndexed { index, _ -> index % 7 == 0 }.map { it.first }.toSet()
+
+        val client = createClient { followRedirects = false }
+        val response = client.post("/worlds/$worldId/projects/from-schematic") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "name=Wide Build&" + materials(
+                    *rows.map { (id, amount) ->
+                        (if (id in struck) "!$id" else id) to amount
+                    }.toTypedArray()
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val projectId = response.headers["Location"]!!.substringAfterLast("/").toInt()
+
+        val persisted = readRequirements(projectId).toMap()
+        assertEquals(BULK_ROWS - struck.size, persisted.size, "every included row is persisted")
+        rows.forEach { (id, amount) ->
+            if (id in struck) {
+                assertFalse(id in persisted, "$id was struck and must not be persisted")
+            } else {
+                assertEquals(amount, persisted[id], "$id must survive the import")
+            }
+        }
+    }
+
+    @Test
+    fun `a material list that arrives short is refused rather than partly imported`() = testApplication {
+        setupRoutes()
+        val before = countProjects(worldId)
+
+        // Exactly the shape a truncating transport produces: the payload still declares 600
+        // rows, only 466 of them arrive. Loud failure, no project.
+        val full = ReviewedMaterialsCodec.encode(
+            (1..BULK_ROWS).map { ReviewedMaterial("minecraft:bulk_item_$it", it, included = true) }
+        )
+        val truncated = full.split(";").take(2 + 466).joinToString(";")
+
+        val response = client.post("/worlds/$worldId/projects/from-schematic") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("name=Cut Short&${ReviewedMaterialsCodec.FIELD}=$truncated")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertTrue(response.bodyAsText().contains("466 of $BULK_ROWS"), response.bodyAsText())
+        assertEquals(before, countProjects(worldId))
+    }
+
+    @Test
+    fun `a submission with no material list at all is refused`() = testApplication {
+        setupRoutes()
+        val before = countProjects(worldId)
+
+        // What a review page rendered before MCO-315 would send. Importing "whatever arrived"
+        // is the failure mode this whole change exists to remove.
+        val response = client.post("/worlds/$worldId/projects/from-schematic") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("name=Stale Page&qty[minecraft:stone]=64")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
         assertEquals(before, countProjects(worldId))
     }
 
@@ -358,12 +452,28 @@ class CreateProjectFromSchematicIT : WithUser() {
         (result as Result.Success).value
     }
 
-    /** Rebuilds a create-request body from the review page's rendered checkboxes. */
+    /** Rebuilds a create-request body from the review page's single rendered materials field. */
     private fun formBodyFrom(reviewHtml: String, name: String): String {
-        val rows = Regex("""name="qty\[([^"]+)]" value="(\d+)"""")
-            .findAll(reviewHtml)
-            .map { "qty[${it.groupValues[1]}]=${it.groupValues[2]}" }
-            .toList()
-        return (listOf("name=$name") + rows).joinToString("&")
+        val field = Regex("""name="materials" value="([^"]+)"""").find(reviewHtml)
+        assertNotNull(field, "the review page must render the materials field")
+        return "name=$name&${ReviewedMaterialsCodec.FIELD}=${field.groupValues[1]}"
+    }
+
+    /**
+     * A request body carrying the whole list in one field, as the review page now sends it.
+     * Prefix an id with `!` to mark the row struck.
+     */
+    private fun materials(vararg rows: Pair<String, Int>): String {
+        val encoded = ReviewedMaterialsCodec.encode(
+            rows.map { (id, amount) ->
+                ReviewedMaterial(id.removePrefix("!"), amount, included = !id.startsWith("!"))
+            }
+        )
+        return "${ReviewedMaterialsCodec.FIELD}=$encoded"
+    }
+
+    private companion object {
+        /** Comfortably past the ~466 rows that used to fit in a request body. */
+        const val BULK_ROWS = 600
     }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
@@ -7,6 +7,8 @@ import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.project.ImportWarningKind
+import app.mcorg.pipeline.project.ReviewedMaterial
+import app.mcorg.pipeline.project.ReviewedMaterialsCodec
 import app.mcorg.pipeline.project.handleImportIdea
 import app.mcorg.pipeline.project.handleReviewIdeaImport
 import app.mcorg.pipeline.world.CreateWorldInput
@@ -52,6 +54,7 @@ class ImportIdeaReviewIT : WithUser() {
     private var worldId: Int = 0
     private var ideaId: Int = 0
     private var airyIdeaId: Int = 0
+    private var wideIdeaId: Int = 0
 
     @BeforeAll
     fun setup() {
@@ -72,6 +75,12 @@ class ImportIdeaReviewIT : WithUser() {
         addRequirement(airyIdeaId, "minecraft:air", 9_389_854)
         addRequirement(airyIdeaId, "minecraft:water", 12)
         addRequirement(airyIdeaId, "minecraft:oak_planks", 64)
+
+        // MCO-315: an idea whose list is far wider than the ~466 rows that used to fit in a
+        // request body. The idea door shares the review screen, so it shared the data loss.
+        wideIdeaId = createIdea("Very Wide Idea")
+        seedItems((1..BULK_ROWS).map { "minecraft:bulk_item_$it" to "Bulk Item $it" })
+        addRequirements(wideIdeaId, (1..BULK_ROWS).map { "minecraft:bulk_item_$it" to it })
     }
 
     // ---- review ------------------------------------------------------------------
@@ -87,8 +96,11 @@ class ImportIdeaReviewIT : WithUser() {
         val body = response.bodyAsText()
         assertContains(body, "Review this import")
         assertContains(body, "Iron Farm Idea")
-        assertContains(body, "qty[minecraft:iron_ingot]")
-        assertContains(body, "qty[minecraft:oak_planks]")
+        // One field for the whole list since MCO-315, not one parameter per row.
+        assertContains(body, """name="materials" value="v1;3;""")
+        assertContains(body, "minecraft:iron_ingot=64")
+        assertContains(body, "minecraft:oak_planks=32")
+        assertFalse(body.contains("qty["), "the per-row parameters are gone")
         // The form has to carry the world through — the action URL has no room for it.
         assertContains(body, "name=\"worldId\"")
         assertEquals(before, countProjects(), "review must not create anything")
@@ -125,9 +137,9 @@ class ImportIdeaReviewIT : WithUser() {
 
         assertEquals(HttpStatusCode.OK, response.status)
         val body = response.bodyAsText()
-        assertFalse(body.contains("qty[minecraft:air]"), "air is filtered, not offered as a row")
+        assertFalse(body.contains("minecraft:air"), "air is filtered, not offered as a row")
         assertFalse(body.contains("9389854"), "and its quantity goes with it")
-        assertContains(body, "qty[minecraft:oak_planks]", message = "the real materials still arrive")
+        assertContains(body, "minecraft:oak_planks=64", message = "the real materials still arrive")
     }
 
     @Test
@@ -137,7 +149,7 @@ class ImportIdeaReviewIT : WithUser() {
         val response = client.get("/ideas/$airyIdeaId/import/review?worldId=$worldId") { addAuthCookie(this) }
 
         val body = response.bodyAsText()
-        assertContains(body, "qty[minecraft:water]", message = "water stays on the list — striking it is the user's call")
+        assertContains(body, "minecraft:water=12", message = "water stays on the list — striking it is the user's call")
         assertContains(body, "Not really materials", message = "but the strip says what it is")
         assertContains(body, ImportWarningKind.NON_MATERIAL.chip, message = "and so does the row")
     }
@@ -152,7 +164,12 @@ class ImportIdeaReviewIT : WithUser() {
         val response = client.post("/ideas/$airyIdeaId/import") {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("worldId=$worldId&name=Roof&qty[minecraft:air]=9389854&qty[minecraft:oak_planks]=64")
+            setBody(
+                "worldId=$worldId&name=Roof&" + materials(
+                    "minecraft:air" to 9389854,
+                    "minecraft:oak_planks" to 64,
+                )
+            )
         }
 
         assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
@@ -171,7 +188,13 @@ class ImportIdeaReviewIT : WithUser() {
         val response = client.post("/ideas/$ideaId/import") {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("worldId=$worldId&name=Reviewed Iron Farm&qty[minecraft:iron_ingot]=64&qty[minecraft:redstone]=8")
+            setBody(
+                "worldId=$worldId&name=Reviewed Iron Farm&" + materials(
+                    "minecraft:iron_ingot" to 64,
+                    "!minecraft:oak_planks" to 32,
+                    "minecraft:redstone" to 8,
+                )
+            )
         }
 
         assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
@@ -191,13 +214,29 @@ class ImportIdeaReviewIT : WithUser() {
         setupRoutes()
         val before = countProjects()
 
-        // Unchecking every row submits no qty[...] fields at all, which is byte-identical to
-        // a bare direct post. Importing the idea's full list here would do the opposite of
-        // what the user just asked for.
+        // Unchecking every row sends a list where every row is struck. Importing the idea's
+        // full list here would do the opposite of what the user just asked for.
         val response = client.post("/ideas/$ideaId/import") {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("worldId=$worldId")
+            setBody("worldId=$worldId&" + materials("!minecraft:iron_ingot" to 64))
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertEquals(before, countProjects())
+    }
+
+    @Test
+    fun `a submission with no material list at all is refused`() = testApplication {
+        setupRoutes()
+        val before = countProjects()
+
+        // Also the shape a review page rendered before MCO-315 would send. There is no
+        // "import the whole idea instead" fallback, by design.
+        val response = client.post("/ideas/$ideaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("worldId=$worldId&qty[minecraft:iron_ingot]=64")
         }
 
         assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
@@ -212,7 +251,7 @@ class ImportIdeaReviewIT : WithUser() {
         val response = client.post("/ideas/$ideaId/import") {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("worldId=$worldId&qty[minecraft:not_a_real_item]=1")
+            setBody("worldId=$worldId&" + materials("minecraft:not_a_real_item" to 1))
         }
 
         assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
@@ -228,10 +267,65 @@ class ImportIdeaReviewIT : WithUser() {
         val response = client.post("/ideas/$ideaId/import") {
             addAuthCookie(this, outsider)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("worldId=$worldId&qty[minecraft:iron_ingot]=1")
+            setBody("worldId=$worldId&" + materials("minecraft:iron_ingot" to 1))
         }
 
         assertEquals(HttpStatusCode.Forbidden, response.status)
+        assertEquals(before, countProjects())
+    }
+
+    // ---- MCO-315 — a list wider than the old request-parameter cap -------------------
+
+    @Test
+    fun `an idea list far past the old 466-row cutoff imports every included row`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        val struck = (1..BULK_ROWS).filter { it % 7 == 0 }.map { "minecraft:bulk_item_$it" }.toSet()
+        val rows = (1..BULK_ROWS).map { "minecraft:bulk_item_$it" to it }
+
+        val response = client.post("/ideas/$wideIdeaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "worldId=$worldId&name=Wide Import&" + materials(
+                    *rows.map { (id, amount) -> (if (id in struck) "!$id" else id) to amount }.toTypedArray()
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val projectId = response.headers["Location"]!!.substringAfterLast("/").toInt()
+
+        val persisted = readRequirements(projectId).toMap()
+        assertEquals(BULK_ROWS - struck.size, persisted.size, "every included row is persisted")
+        rows.forEach { (id, amount) ->
+            if (id in struck) {
+                assertFalse(id in persisted, "$id was struck and must not be persisted")
+            } else {
+                assertEquals(amount, persisted[id], "$id must survive the import")
+            }
+        }
+    }
+
+    @Test
+    fun `an idea list that arrives short is refused rather than partly imported`() = testApplication {
+        setupRoutes()
+        val before = countProjects()
+
+        val full = ReviewedMaterialsCodec.encode(
+            (1..BULK_ROWS).map { ReviewedMaterial("minecraft:bulk_item_$it", it, included = true) }
+        )
+        val truncated = full.split(";").take(2 + 466).joinToString(";")
+
+        val response = client.post("/ideas/$wideIdeaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("worldId=$worldId&name=Cut Short&${ReviewedMaterialsCodec.FIELD}=$truncated")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertContains(response.bodyAsText(), "466 of $BULK_ROWS")
         assertEquals(before, countProjects())
     }
 
@@ -303,6 +397,33 @@ class ImportIdeaReviewIT : WithUser() {
         (result as Result.Success).value
     }
 
+    private fun seedItems(items: List<Pair<String, String>>) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert("INSERT INTO minecraft_version (version) VALUES ('1.21.4') ON CONFLICT DO NOTHING"),
+            parameterSetter = { _, _ -> }
+        ).process(Unit)
+        DatabaseSteps.batchUpdate<Pair<String, String>>(
+            SafeSQL.insert(
+                "INSERT INTO minecraft_items (version, item_id, item_name) VALUES ('1.21.4', ?, ?) ON CONFLICT DO NOTHING"
+            ),
+            parameterSetter = { stmt, (itemId, itemName) ->
+                stmt.setString(1, itemId)
+                stmt.setString(2, itemName)
+            }
+        ).process(items)
+    }
+
+    private fun addRequirements(ideaId: Int, requirements: List<Pair<String, Int>>) = runBlocking {
+        DatabaseSteps.batchUpdate<Pair<String, Int>>(
+            SafeSQL.insert("INSERT INTO idea_item_requirements (idea_id, item_id, quantity) VALUES (?, ?, ?)"),
+            parameterSetter = { stmt, (itemId, quantity) ->
+                stmt.setInt(1, ideaId)
+                stmt.setString(2, itemId)
+                stmt.setInt(3, quantity)
+            }
+        ).process(requirements)
+    }
+
     private fun addRequirement(ideaId: Int, itemId: String, quantity: Int) = runBlocking {
         DatabaseSteps.update<Unit>(
             SafeSQL.insert(
@@ -356,5 +477,23 @@ class ImportIdeaReviewIT : WithUser() {
             }
         ).process(projectId)
         (result as Result.Success).value
+    }
+
+    /**
+     * A request body carrying the whole list in one field, as the review page now sends it.
+     * Prefix an id with `!` to mark the row struck.
+     */
+    private fun materials(vararg rows: Pair<String, Int>): String {
+        val encoded = ReviewedMaterialsCodec.encode(
+            rows.map { (id, amount) ->
+                ReviewedMaterial(id.removePrefix("!"), amount, included = !id.startsWith("!"))
+            }
+        )
+        return "${ReviewedMaterialsCodec.FIELD}=$encoded"
+    }
+
+    private companion object {
+        /** Comfortably past the ~466 rows that used to fit in a request body. */
+        const val BULK_ROWS = 600
     }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportReviewSubstitutionIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportReviewSubstitutionIT.kt
@@ -4,6 +4,8 @@ import app.mcorg.domain.model.minecraft.MinecraftVersion
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.project.ReviewedMaterial
+import app.mcorg.pipeline.project.ReviewedMaterialsCodec
 import app.mcorg.pipeline.project.handleSubstituteInImportReview
 import app.mcorg.pipeline.world.CreateWorldInput
 import app.mcorg.pipeline.world.CreateWorldStep
@@ -60,6 +62,8 @@ class ImportReviewSubstitutionIT : WithUser() {
             seedItem("minecraft:${wood}_stairs", "${wood.replaceFirstChar { it.uppercase() }} Stairs")
         }
         seedItem("minecraft:stone", "Stone")
+        // MCO-315: enough rows to be past the ~466 that used to fit in a request body.
+        seedItems((1..BULK_ROWS).map { "minecraft:bulk_item_$it" to "Bulk Item $it" })
     }
 
     @Test
@@ -70,18 +74,20 @@ class ImportReviewSubstitutionIT : WithUser() {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
             setBody(
-                "from=oak&to[oak]=spruce" +
-                    "&row[minecraft:oak_planks]=64&qty[minecraft:oak_planks]=64" +
-                    "&row[minecraft:oak_stairs]=12&qty[minecraft:oak_stairs]=12" +
-                    "&row[minecraft:stone]=100&qty[minecraft:stone]=100"
+                swap(
+                    "oak", "spruce",
+                    "minecraft:oak_planks" to 64,
+                    "minecraft:oak_stairs" to 12,
+                    "minecraft:stone" to 100,
+                )
             )
         }
 
         assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
         val body = response.bodyAsText()
-        assertContains(body, "row[minecraft:spruce_planks]")
-        assertContains(body, "row[minecraft:spruce_stairs]")
-        assertContains(body, "row[minecraft:stone]", message = "an unrelated row is untouched")
+        assertContains(body, "minecraft:spruce_planks=64")
+        assertContains(body, "minecraft:spruce_stairs=12")
+        assertContains(body, "minecraft:stone=100", message = "an unrelated row is untouched")
         assertFalse(body.contains("minecraft:oak_planks"), "no oak survives the swap")
         assertFalse(body.contains("minecraft:oak_stairs"), "no oak survives the swap")
     }
@@ -90,20 +96,18 @@ class ImportReviewSubstitutionIT : WithUser() {
     fun `an excluded row survives the swap and stays excluded`() = testApplication {
         setupRoutes()
 
-        // oak_stairs is struck — it has a `row[...]` but no `qty[...]`, exactly as the form
-        // sends an unchecked box. It must come back as spruce stairs, still unchecked.
+        // oak_stairs is struck — it rides along in the list marked excluded, exactly as the
+        // form sends an unchecked box. It must come back as spruce stairs, still unchecked.
         val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
             setBody(
-                "from=oak&to[oak]=spruce" +
-                    "&row[minecraft:oak_planks]=64&qty[minecraft:oak_planks]=64" +
-                    "&row[minecraft:oak_stairs]=12"
+                swap("oak", "spruce", "minecraft:oak_planks" to 64, "!minecraft:oak_stairs" to 12)
             )
         }
 
         val body = response.bodyAsText()
-        assertContains(body, "row[minecraft:spruce_stairs]", message = "the struck row is not lost")
+        assertContains(body, "!minecraft:spruce_stairs=12", message = "the struck row is not lost")
         assertTrue(isChecked(body, "minecraft:spruce_planks"), "the kept row is still kept")
         assertFalse(isChecked(body, "minecraft:spruce_stairs"), "the struck row is still struck")
     }
@@ -115,17 +119,16 @@ class ImportReviewSubstitutionIT : WithUser() {
         val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody(
-                "from=oak&to[oak]=spruce" +
-                    "&row[minecraft:oak_planks]=64&qty[minecraft:oak_planks]=64" +
-                    "&row[minecraft:oak_slab]=8&qty[minecraft:oak_slab]=8"
-            )
+            setBody(swap("oak", "spruce", "minecraft:oak_planks" to 64, "minecraft:oak_slab" to 8))
         }
 
         val body = response.bodyAsText()
         assertContains(body, "import-review-materials", message = "the fragment replaces itself")
         assertContains(body, "All Spruce (2 rows)", message = "the family is now spruce")
-        assertContains(body, """name="to[spruce]"""")
+        assertContains(body, """id="swap-to-spruce"""")
+        // The selects carry no name (MCO-315) — a create submit must not drag one parameter
+        // per family along with it.
+        assertFalse(body.contains("""name="to["""), "the swap selects are not form controls")
     }
 
     @Test
@@ -136,15 +139,16 @@ class ImportReviewSubstitutionIT : WithUser() {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
             setBody(
-                "from=oak&to[oak]=spruce" +
-                    "&row[minecraft:oak_planks]=64&qty[minecraft:oak_planks]=64" +
-                    "&row[minecraft:spruce_planks]=10&qty[minecraft:spruce_planks]=10" +
-                    "&row[minecraft:oak_slab]=1&qty[minecraft:oak_slab]=1"
+                swap(
+                    "oak", "spruce",
+                    "minecraft:oak_planks" to 64,
+                    "minecraft:spruce_planks" to 10,
+                    "minecraft:oak_slab" to 1,
+                )
             )
         }
 
-        val body = response.bodyAsText()
-        assertContains(body, """name="row[minecraft:spruce_planks]" value="74"""")
+        assertContains(response.bodyAsText(), "minecraft:spruce_planks=74")
     }
 
     @Test
@@ -154,7 +158,7 @@ class ImportReviewSubstitutionIT : WithUser() {
         val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("from=oak&to[oak]=spruce&row[minecraft:not_a_real_item]=1")
+            setBody(swap("oak", "spruce", "minecraft:not_a_real_item" to 1))
         }
 
         assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
@@ -167,7 +171,7 @@ class ImportReviewSubstitutionIT : WithUser() {
         val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
             addAuthCookie(this)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("from=oak&row[minecraft:oak_planks]=64&qty[minecraft:oak_planks]=64")
+            setBody("from=oak&" + materials("minecraft:oak_planks" to 64))
         }
 
         assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
@@ -181,11 +185,75 @@ class ImportReviewSubstitutionIT : WithUser() {
         val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
             addAuthCookie(this, outsider)
             contentType(ContentType.Application.FormUrlEncoded)
-            setBody("from=oak&to[oak]=spruce&row[minecraft:oak_planks]=64")
+            setBody(swap("oak", "spruce", "minecraft:oak_planks" to 64))
         }
 
         assertEquals(HttpStatusCode.Forbidden, response.status)
     }
+
+    // ---- MCO-315 — a swap on a list wider than the old parameter cap ------------------
+
+    @Test
+    fun `a swap on a list far past the old 466-row cutoff keeps every row`() = testApplication {
+        setupRoutes()
+
+        // Two parameters per row meant the substitute POST truncated too: a family swap on a
+        // large review silently deleted the tail of the list, exclusions and all.
+        val struck = (1..BULK_ROWS).filter { it % 5 == 0 }.map { "minecraft:bulk_item_$it" }.toSet()
+        val rows = listOf("minecraft:oak_planks" to 64, "!minecraft:oak_stairs" to 12) +
+            (1..BULK_ROWS).map { (if ("minecraft:bulk_item_$it" in struck) "!" else "") + "minecraft:bulk_item_$it" to it }
+
+        val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(swap("oak", "spruce", *rows.toTypedArray()))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        val body = response.bodyAsText()
+
+        assertContains(body, "${BULK_ROWS + 2} items", message = "not one row is dropped on the way in")
+        assertContains(body, "minecraft:spruce_planks=64")
+        assertContains(body, "!minecraft:spruce_stairs=12", message = "the struck row is still struck")
+        // The rows that used to fall off the end — the last one especially.
+        assertContains(body, "minecraft:bulk_item_$BULK_ROWS=$BULK_ROWS")
+        struck.forEach { assertContains(body, "!$it=", message = "$it must come back struck") }
+    }
+
+    @Test
+    fun `a swap on a list that arrives short is refused rather than applied in part`() = testApplication {
+        setupRoutes()
+
+        val full = ReviewedMaterialsCodec.encode(
+            (1..BULK_ROWS).map { ReviewedMaterial("minecraft:bulk_item_$it", it, included = true) }
+        )
+        val truncated = full.split(";").take(2 + 466).joinToString(";")
+
+        val response = client.post("/worlds/$worldId/projects/import-review/substitute") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("from=oak&to=spruce&${ReviewedMaterialsCodec.FIELD}=$truncated")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertContains(response.bodyAsText(), "466 of $BULK_ROWS")
+    }
+
+    /**
+     * The whole list in one field, as the review page now sends it (MCO-315). Prefix an id
+     * with `!` to mark the row struck.
+     */
+    private fun materials(vararg rows: Pair<String, Int>): String {
+        val encoded = ReviewedMaterialsCodec.encode(
+            rows.map { (id, amount) ->
+                ReviewedMaterial(id.removePrefix("!"), amount, included = !id.startsWith("!"))
+            }
+        )
+        return "${ReviewedMaterialsCodec.FIELD}=$encoded"
+    }
+
+    private fun swap(from: String, to: String, vararg rows: Pair<String, Int>): String =
+        "from=$from&to=$to&" + materials(*rows)
 
     /** Reads the rendered include-checkbox for one row back out of the fragment. */
     private fun isChecked(body: String, itemId: String): Boolean {
@@ -241,5 +309,26 @@ class ImportReviewSubstitutionIT : WithUser() {
                 stmt.setString(2, itemName)
             }
         ).process(Unit)
+    }
+
+    private fun seedItems(items: List<Pair<String, String>>) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert("INSERT INTO minecraft_version (version) VALUES ('1.21.4') ON CONFLICT DO NOTHING"),
+            parameterSetter = { _, _ -> }
+        ).process(Unit)
+        DatabaseSteps.batchUpdate<Pair<String, String>>(
+            SafeSQL.insert(
+                "INSERT INTO minecraft_items (version, item_id, item_name) VALUES ('1.21.4', ?, ?) ON CONFLICT DO NOTHING"
+            ),
+            parameterSetter = { stmt, (itemId, itemName) ->
+                stmt.setString(1, itemId)
+                stmt.setString(2, itemName)
+            }
+        ).process(items)
+    }
+
+    private companion object {
+        /** Comfortably past the ~466 rows that used to fit in a request body. */
+        const val BULK_ROWS = 600
     }
 }


### PR DESCRIPTION
Fixes **MCO-315** — silent data loss on large schematic imports.

## The bug

Importing a schematic with more than ~466 distinct materials silently lost everything past that point. Measured on `YAMS V2.33 FB.litematic` (107,917 blocks, 560 distinct materials): the review screen listed 560 rows, 2 were struck, and **465 of 558 persisted — 93 materials (17%) vanished**. No error; the project looked complete.

## Cause — confirmed, with one correction to the issue

The issue named `parseUrlEncodedParameters`. The server actually calls **`parseQueryString`** (`DefaultTransform.kt`, `Parameters::class` + `application/x-www-form-urlencoded`). Same story, and the arithmetic is exact rather than approximate: `parseQueryString`'s `limit` defaults to **1000** and its parser does `if (count == limit) return` — it stops, discarding the remainder, without failing.

The review form sent two fields per row (`qty[<id>]` when checked, `row[<id>]` always) behind the name field and 67 family selects:

```
1 (name) + 67 (selects) + 2*465 (kept rows) + 1*2 (struck rows) = 1000
```

Exactly the 465 observed. (Had it been `parseUrlEncodedParameters`, Kotlin's `split(limit=)` would have glued the remainder onto the 1000th parameter instead of dropping it — a different, noisier failure. It isn't that function.)

## The fix

Not a raised cap. The review screen deliberately holds the list in the form rather than a draft table (the MCO-303 decision), so the form *is* the storage and it will keep growing — a bigger ceiling only moves the cliff.

The list now travels as one self-describing field:

```
materials := "v1" ";" count *( ";" [ "!" ] item-id "=" amount )
```

- **Flat in the number of rows.** 5000 materials cost the same one parameter as one.
- **`!` marks a struck row**, so exclusions still survive a family swap — the property `row[]` existed to guarantee.
- **Truncation can never be silent again.** The payload declares its own row count; a body cut short by any transport (a parameter cap, a body limit, a proxy) produces a validation error naming what was lost — `"The material list arrived incomplete — 466 of 600 materials reached the server. Nothing was imported."` A submission with no list at all is refused too, which is exactly what a stale review page sends.
- **Server-side validation is unchanged in strictness.** `ValidateReviewedMaterialsStep` still re-checks every id against the world's catalog; the codec only replaces the transport.

Checkboxes become pure UI (no `name`, `data-item-id`/`data-amount` instead) and `import-review.js` folds their state back into the field on `change`, on `submit`, and on `htmx:configRequest`. The family selects lose their names as well: htmx includes the enclosing form on *every* non-GET (`getInputValues` → `getRelatedForm`), so keeping them named would have put one parameter per family on every create submit regardless of `hx-include`. The swap button reads the one it needs by id through `hx-vals` — an established pattern here (8 other `js:` call sites).

All three readers of the shared page move together: create-from-schematic, idea import, and the substitution round-trip.

## Tests

- `ReviewedMaterialsCodecTest` (14) — round-trip, a 5000-row list, the literal wire format the browser script writes, and every loud-failure path (cut short, over-declared, missing, unversioned, over the sanity bound, unreadable row, non-positive amount).
- Regression above the old ~466-row threshold on all three paths: `CreateProjectFromSchematicIT`, `ImportIdeaReviewIT` and `ImportReviewSubstitutionIT` each import/swap a 600-row list and assert every included row persists and every struck row stays struck — plus a truncated-payload test on each proving loud refusal with nothing written.
- `SubstituteReviewedListStepTest` (13) rewritten to the new shape, including a 302-row swap.
- `import-review.js` exercised against a stub DOM: 600 rows in, `v1;600;…` out, `configRequest` overwrites only a parameter the request already carried, unrelated requests untouched.

`mvn clean compile` clean. `./webapp/scripts/test.sh --database`: **769 unit / 439 database, 0 failures** (5 skipped are pre-existing `@Disabled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)