### PR TITLE
Docs: score diagnostic how-to + fixture-fidelity guidance; stop the bogus local config error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,14 @@ sudo service docker start           # Start Docker if not running (passwordless)
 ./webapp/scripts/ingest-locally.sh  # Ingest Minecraft data into the local/worktree DB
 ```
 
+Read-only diagnostic for "why did the planner pick *that* source?" — prints the scorer's factor
+breakdown per candidate against the real ingested graph. Required reading before any
+`SelectionScorer` change; see `mc-engine/CLAUDE.md` for args and the `mvn install` prerequisite:
+
+```bash
+cd webapp && mvn -q -pl mc-web exec:java@score-diagnostics -Dexec.args="world=<id> demand=64 <item ids>"
+```
+
 Module-scoped builds:
 
 ```bash
@@ -168,6 +176,11 @@ when the PR carries the **`preview`** label.
   Sourcing `local.env` and building that URL in one shell command can trip the
   worktree-isolation guard. If it does, put the two lines in a throwaway script and run
   that instead — same result, and it keeps the password out of the transcript.
+- **A local run logs `HikariCP connection pool for PRODUCTION environment` even when
+  `ENV=LOCAL`.** That string is the pool *profile* name, not the database — it does not mean
+  you are pointed at production. To check which DB you actually have, compare the host in
+  `local.env`'s `DB_URL` against `neonctl connection-string <branch> --project-id
+  sweet-dust-00910797`; a worktree's host differs from `master`'s.
 
   **Writes:** free in a worktree — the Neon branch is a disposable fork. Against the main
   checkout's DB, treat `INSERT`/`UPDATE`/`DELETE`/DDL as you would any shared dev data:

--- a/webapp/mc-engine/CLAUDE.md
+++ b/webapp/mc-engine/CLAUDE.md
@@ -58,9 +58,60 @@ cd webapp && mvn compile -pl mc-engine
 mvn test -pl mc-engine
 ```
 
+## Score diagnostics — read this before touching `SelectionScorer`
+
+The root CLAUDE.md's restricted-area rule says to verify scoring changes against real ingested
+data rather than reasoning. This is the tool. It is **read-only** and changes no ranking:
+
+```bash
+cd webapp && set -a && . ./local.env && set +a
+mvn -q -pl mc-web exec:java@score-diagnostics \
+  -Dexec.args="world=11 demand=64 iron_ingot iron_nugget cobblestone"
+```
+
+It prints, per item, every candidate source in the order `PlanSelector` would rank them, with
+the factor breakdown that produced each total (`base 95  thr +50  recip -13  req -10  depth -5`)
+and the selected one marked `▶`. Args: `world=<id>` or `version=<mc version>` to pick the graph,
+`demand=<n>` (default 64 — raise above the recipe threshold of 100 to see the bulk bonus), then
+item ids (`sand` expands to `minecraft:sand`).
+
+**`exec:java` resolves siblings from `~/.m2`, not the reactor**, so install first or you will
+measure stale jars and not notice:
+
+```bash
+mvn -q install -DskipTests -pl mc-domain,mc-pipeline,mc-engine
+```
+
+`-am` does **not** help here — that is the other half of the MCO-285 note and it applies to
+`-pl` test/compile runs, not to `exec:java`.
+
 ## Tests
 
 Located in `src/test/kotlin/app/mcorg/engine/`. Graph building/model tests plus the planner suites:
 `PlanSelectorTest` (selection mechanism), `PlanQuantifierTest` (quantity propagation),
 `ActivityOrderingTest` (roadmap ordering), and `CuratedSelectionTest` (pinned expectations for
 real Minecraft acquisition chains — see `documentation/work-documents/fable-mc-engine-scoring-audit.md`).
+
+### A curated expectation is only as good as the source set it models
+
+`CuratedSelectionTest` fixtures are hand-built lists of `ResourceSource`. If a fixture omits a
+source that exists in real data, the test can **pass for the wrong reason** — and keep passing
+while production is broken.
+
+This is not hypothetical. MCO-317: `iron_ingot - smelting raw iron beats unpacking blocks,
+packing nuggets, and chest loot` passed for a long time because `ironChain` gave `iron_nugget`
+only *circular* sources (unpack an ingot). The selector rejected `iron_ingot_from_nuggets`
+structurally, so smelting won by default and the scorer was never actually exercised. Real data
+has a non-circular nugget source — smelting iron equipment via a tag — and with it the planner
+routed an entire build's iron through 296,515 nuggets. Adding that one source to the fixture
+turned the test red immediately.
+
+So when adding or trusting a curated expectation:
+
+- Check the fixture against the **real** source set for that item (the diagnostic above lists
+  every candidate, which is the fastest way to see what you left out).
+- Ask whether the expectation holds because of the scorer, or because the alternative was
+  structurally impossible in your fixture. Only the first is a real test.
+- After a scoring change, sweep the constant across its plausible range and confirm which tests
+  fail at which values. A value that passes may still be sitting on a tie-break with zero margin
+  — that is how MCO-317's first attempt at 15 got caught.

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/config/AppConfig.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/config/AppConfig.kt
@@ -96,9 +96,12 @@ object AppConfig {
             }
         }
 
+        // LOCAL deliberately leaves these null: jwt.kt falls back to the generated PEM pair
+        // (`mc-web/create-keys.sh` -> resources/keys), which is the intended local path. Leaving
+        // them unset is correct there, not a misconfiguration.
         System.getenv("RSA_PRIVATE_KEY").let {
             if (env == Local) {
-                errors.add("RSA_PRIVATE_KEY must be set in LOCAL environment, should use generated key")
+                // no-op — generated key file is used
             } else if (it.isNullOrBlank()) {
                 errors.add("RSA_PRIVATE_KEY is not set")
             } else {
@@ -108,7 +111,7 @@ object AppConfig {
 
         System.getenv("RSA_PUBLIC_KEY").let {
             if (env == Local) {
-                errors.add("RSA_PUBLIC_KEY must be set in LOCAL environment, should use generated key")
+                // no-op — generated key file is used
             } else if (it.isNullOrBlank()) {
                 errors.add("RSA_PUBLIC_KEY is not set")
             } else {


### PR DESCRIPTION
Two independent commits from the 2026-08-13 dogfooding session. **The second is easy to drop** if you'd rather keep the log line.

---

### 1. `Docs: how to run the score diagnostic, and why curated fixtures lie`

**Closes a dangling reference I introduced in #388.** That PR added to the restricted-area rule: *verify scoring changes against "the `score-diagnostics` CLI against real ingested data"* — and then never said how to run it. Outside the CLI's own KDoc there was no mention of it anywhere in the repo, so the instruction was unfollowable by anyone who hadn't used it before.

Adds to `mc-engine/CLAUDE.md` (the file the restricted-area rule already makes mandatory reading):

- how to invoke it, what the factor breakdown means, and the args
- the prerequisite that bites silently: **`exec:java` resolves siblings from `~/.m2`**, so changed modules must be installed first or you measure stale jars with no warning. `-am` does *not* cover this — that's the other half of the MCO-285 note, which applies to `-pl` compile/test runs.

And a one-line pointer from root Build Commands, where someone actually looks for commands.

**Plus the sharper lesson from MCO-317.** `CuratedSelectionTest`'s iron expectations passed for a long time *for the wrong reason*: the fixture gave `iron_nugget` only circular sources, so the bad candidate was rejected structurally and smelting won by default — the scorer was never exercised. Real data has a non-circular nugget source, and with it the planner routed an entire build's iron through 296,515 nuggets smelted from armour. Adding that one source to the fixture turned the test red immediately.

The guidance that falls out: check a fixture against the real source set; ask whether an expectation holds because of the scorer or because the alternative was impossible in your fixture; and sweep a changed constant across its range rather than trusting that it passes — a passing value can still sit on a tie-break with zero margin, which is exactly how MCO-317's first attempt at 15 was caught.

Also notes that a local run logs `HikariCP connection pool for PRODUCTION environment` while `ENV=LOCAL`. That's the pool *profile* name, not the database — it cost a verification detour during the session, so the note says how to actually check which DB you're on.

### 2. `Stop logging a config error on every local run`

`AppConfig` reported the RSA keys as invalid configuration whenever `env == Local`, **unconditionally** — no null check on that branch, so it fired even with the generated keys present and working:

```
ERROR AppConfig - Invalid configuration:
RSA_PRIVATE_KEY must be set in LOCAL environment, should use generated key
RSA_PUBLIC_KEY must be set in LOCAL environment, should use generated key
```

Leaving them unset is the *correct* local setup. `jwt.kt:49` reads `AppConfig.rsaPrivateKey ?: readKey("private_key.pem")`, so the null is what selects the generated PEM pair from `create-keys.sh`. The message described the intended path as a failure.

Local now skips the check; non-local validation is unchanged. No test asserted the old strings.

---

### Tests

- `mvn clean compile` — zero errors
- `./webapp/scripts/test.sh` — 774, 0 failures
- `./webapp/scripts/test.sh --database --exclude-unit-tests` — 442, 0 failures (5 pre-existing `@Disabled`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
