### PR TITLE
Group the import review by litematic subregion

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/minecraft/Litematica.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/minecraft/Litematica.kt
@@ -1,9 +1,37 @@
 package app.mcorg.domain.model.minecraft
 
+/**
+ * A parsed `.litematic` file.
+ *
+ * [items] is the whole build's material list. [regions] is the same data before it was
+ * flattened — Litematica lets a schematic hold several named subregions, and a build commonly
+ * separates the functional part from a decorative shell (MCO-398). Keeping both means callers
+ * that only want "what does this cost" stay unchanged, while the import review can offer the
+ * regions as groups to include or exclude.
+ *
+ * **Invariant:** [items] is the per-id sum over [regions]. The reader builds them together.
+ * [regions] is empty only for a `Litematica` constructed directly without them (tests, and the
+ * idea path, which has no regions to speak of).
+ */
 data class Litematica(
     val name: String,
     val description: String,
     val author: String,
     val size: Triple<Int, Int, Int>,
-    val items: Map<String, Int>
+    val items: Map<String, Int>,
+    val regions: List<LitematicaRegion> = emptyList(),
+)
+
+/**
+ * One named subregion of a schematic, with the blocks it contains.
+ *
+ * The name is whatever the author typed in Litematica's schematic editor, so it is arbitrary
+ * user text — it may be empty, may be `"Unnamed"` (the default for a region nobody renamed),
+ * and may simply repeat the schematic's own name, which is what Litematica does for a
+ * single-region save. All three are common in real files; none of them are worth showing as a
+ * group header on their own, which is why a single-region schematic renders without one.
+ */
+data class LitematicaRegion(
+    val name: String,
+    val items: Map<String, Int>,
 )

--- a/webapp/mc-nbt/src/main/kotlin/app/mcorg/nbt/util/LitematicaReader.kt
+++ b/webapp/mc-nbt/src/main/kotlin/app/mcorg/nbt/util/LitematicaReader.kt
@@ -1,6 +1,7 @@
 package app.mcorg.nbt.util
 
 import app.mcorg.domain.model.minecraft.Litematica
+import app.mcorg.domain.model.minecraft.LitematicaRegion
 import app.mcorg.nbt.failure.NBTFailure
 import app.mcorg.pipeline.Result
 import app.mcorg.nbt.io.BinaryNbtDeserializer
@@ -73,7 +74,8 @@ object LitematicaReader {
             author = metadata.author,
             description = metadata.description ?: "",
             size = metadata.size,
-            items = regionData.items
+            items = regionData.items,
+            regions = regionData.regions,
         )
 
         return Result.success(litematica)
@@ -87,7 +89,8 @@ object LitematicaReader {
     )
 
     data class LitematicaRegionData(
-        val items: Map<String, Int>
+        val items: Map<String, Int>,
+        val regions: List<LitematicaRegion>,
     )
 
     private fun CompoundTag.extractMetadata(): LitematicaMetadata {
@@ -110,12 +113,27 @@ object LitematicaReader {
         )
     }
 
+    /**
+     * Reads every subregion, keeping each one's name alongside the flattened total.
+     *
+     * The name is the compound's own key — Litematica stores regions as a map of name to
+     * region — and it used to be discarded here (MCO-398). A build routinely separates its
+     * functional part from a decorative shell, and dropping the names left the import review
+     * with one flat list of hundreds of rows and no way to strike a whole section.
+     *
+     * Regions keep file order; a region contributing nothing (empty, or all air) is skipped so
+     * the review does not offer an empty group.
+     */
     private fun CompoundTag.extractRegionData(): LitematicaRegionData {
         val items = mutableMapOf<String, Int>()
+        val regions = mutableListOf<LitematicaRegion>()
 
-        this.value.forEach { (_, tag) ->
+        this.value.forEach { (regionName, tag) ->
             if (tag is CompoundTag) {
                 val regionItems = tag.extractSingleRegionData()
+                if (regionItems.isNotEmpty()) {
+                    regions.add(LitematicaRegion(regionName, regionItems))
+                }
                 regionItems.forEach { (itemName, itemCount) ->
                     items[itemName] = items.getOrDefault(itemName, 0) + itemCount
                 }
@@ -123,7 +141,8 @@ object LitematicaReader {
         }
 
         return LitematicaRegionData(
-            items = items
+            items = items,
+            regions = regions,
         )
     }
 

--- a/webapp/mc-nbt/src/test/kotlin/app/mcorg/nbt/util/LitematicaReaderTest.kt
+++ b/webapp/mc-nbt/src/test/kotlin/app/mcorg/nbt/util/LitematicaReaderTest.kt
@@ -201,6 +201,125 @@ class LitematicaReaderTest {
         assertEquals(Triple(0, 0, 0), lit.size)
     }
 
+    // ---- subregions (MCO-398) ---------------------------------------------------------
+
+    /** A `BlockStatePalette` entry list: `[{Name: air}, {Name: <block>}]`, so index 1 is the block. */
+    private fun DataOutputStream.writePaletteEntry(block: String) {
+        writeByte(9)                 // ListTag
+        writeUTF("BlockStatePalette")
+        writeByte(10)                // of CompoundTag
+        writeInt(2)
+        writeStringEntry("Name", "minecraft:air")
+        writeByte(0)
+        writeStringEntry("Name", block)
+        writeByte(0)
+    }
+
+    /**
+     * One 1x1x1 region holding a single [block].
+     *
+     * A two-entry palette packs at 2 bits per block, so one block state of value `1` selects
+     * palette index 1 — the block rather than the air that pads index 0.
+     */
+    private fun DataOutputStream.writeSingleBlockRegion(name: String, block: String) {
+        writeCompoundEntry(name) {
+            writeCompoundEntry("Size") {
+                writeIntEntry("x", 1)
+                writeIntEntry("y", 1)
+                writeIntEntry("z", 1)
+            }
+            writePaletteEntry(block)
+            writeByte(12)            // LongListTag
+            writeUTF("BlockStates")
+            writeInt(1)
+            writeLong(1L)
+        }
+    }
+
+    private fun twoRegionFile() = buildRootCompound {
+        writeCompoundEntry("Metadata") {
+            writeStringEntry("Name", "Two parter")
+            writeStringEntry("Author", "tester")
+            writeCompoundEntry("EnclosingSize") {
+                writeIntEntry("x", 1)
+                writeIntEntry("y", 1)
+                writeIntEntry("z", 1)
+            }
+        }
+        writeCompoundEntry("Regions") {
+            writeSingleBlockRegion("Functional frame", "minecraft:oak_planks")
+            writeSingleBlockRegion("Display glass", "minecraft:glass")
+        }
+    }
+
+    @Test
+    fun `subregions are kept with their names`() {
+        val lit = TestUtils.assertResultSuccess(LitematicaReader.readLitematica(twoRegionFile()))
+
+        assertEquals(listOf("Functional frame", "Display glass"), lit.regions.map { it.name })
+        assertEquals(mapOf("minecraft:oak_planks" to 1), lit.regions[0].items)
+        assertEquals(mapOf("minecraft:glass" to 1), lit.regions[1].items)
+    }
+
+    @Test
+    fun `items stays the flattening of the regions`() {
+        // The documented invariant on Litematica. Callers that only want "what does this cost"
+        // must keep working untouched, which is the whole reason both are carried.
+        val lit = TestUtils.assertResultSuccess(LitematicaReader.readLitematica(twoRegionFile()))
+
+        val flattened = lit.regions
+            .flatMap { it.items.entries }
+            .groupBy({ it.key }, { it.value })
+            .mapValues { (_, counts) -> counts.sum() }
+        assertEquals(flattened, lit.items)
+    }
+
+    @Test
+    fun `a real single-region file reports its one region`() {
+        // Litematica names a lone region after the schematic itself — which is exactly why the
+        // review screen renders no section header for it.
+        val lit = TestUtils.assertResultSuccess(
+            LitematicaReader.readLitematica(getFileAsStream("litematica/WiskeProSorter.litematic"))
+        )
+
+        assertEquals(listOf("WiskeProSorter"), lit.regions.map { it.name })
+        assertEquals(lit.items, lit.regions.single().items)
+    }
+
+    @Test
+    fun `a region named Unnamed is carried as-is`() {
+        // The other thing real files do. Naming it is the review screen's problem, not the
+        // reader's — it reports what the file says.
+        val lit = TestUtils.assertResultSuccess(
+            LitematicaReader.readLitematica(getFileAsStream("litematica/Dig_Sort_III.litematic"))
+        )
+
+        assertEquals(listOf("Unnamed"), lit.regions.map { it.name })
+    }
+
+    @Test
+    fun `a region with no materials is not reported`() {
+        val bytes = buildRootCompound {
+            writeCompoundEntry("Metadata") {
+                writeStringEntry("Name", "test")
+                writeStringEntry("Author", "tester")
+                writeCompoundEntry("EnclosingSize") {
+                    writeIntEntry("x", 1)
+                    writeIntEntry("y", 1)
+                    writeIntEntry("z", 1)
+                }
+            }
+            writeCompoundEntry("Regions") {
+                writeSingleBlockRegion("Real", "minecraft:oak_planks")
+                writeCompoundEntry("Empty") {}
+            }
+        }
+
+        val lit = TestUtils.assertResultSuccess(LitematicaReader.readLitematica(bytes))
+
+        assertEquals(listOf("Real"), lit.regions.map { it.name })
+    }
+
     private val defaultFile = "litematica/Compact_AB_Tilable_2x_Shulker_Loader.litematic"
 
     fun getFileAsStream(filePath: String = defaultFile) =

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
@@ -49,6 +49,7 @@ data class SchematicProject(
     val name: String,
     val requirements: Map<Item, Int>,
     val placedCounts: Map<String, Int> = emptyMap(),
+    val regions: List<ResolvedRegion> = emptyList(),
 )
 
 /**
@@ -60,6 +61,20 @@ data class SchematicProject(
  * It is review-time context only and is not persisted with the project.
  */
 data class SchematicMaterials(
+    val requirements: List<Pair<Item, Int>>,
+    val placedCounts: Map<String, Int> = emptyMap(),
+    val regions: List<ResolvedRegion> = emptyList(),
+)
+
+/**
+ * One subregion's resolved material list (MCO-398).
+ *
+ * Empty for a schematic with no regions in it. A **single** region is still reported — the
+ * review screen is what decides that one group is not worth any group chrome, since
+ * Litematica names a lone region after the schematic itself or leaves it "Unnamed".
+ */
+data class ResolvedRegion(
+    val name: String,
     val requirements: List<Pair<Item, Int>>,
     val placedCounts: Map<String, Int> = emptyMap(),
 )
@@ -90,6 +105,7 @@ suspend fun ApplicationCall.handleReviewSchematic() {
                     projectName = project.name,
                     requirements = project.requirements,
                     placedCounts = project.placedCounts,
+                    regions = project.regions,
                     warnings = computeImportWarnings(worldId, project.requirements),
                 )
             )
@@ -171,7 +187,10 @@ internal data class ValidateReviewedMaterialsStep(val availableItems: List<Item>
                 errors.add(ValidationFailure.CustomValidation("materials", "Unknown item: ${row.itemId}"))
                 return@forEach
             }
-            requirements[item] = row.amount
+            // Summed, not assigned: with region groups (MCO-398) the same item legitimately
+            // arrives once per region it appears in, and the last row would otherwise silently
+            // replace the earlier ones — 200 oak planks in the shell erasing 500 in the frame.
+            requirements[item] = (requirements[item] ?: 0) + row.amount
         }
 
         if (errors.isNotEmpty()) return Result.failure(AppFailure.ValidationError(errors))
@@ -248,33 +267,36 @@ data class MapSchematicToMaterialsStep(
 
         val byId = availableItems.associateBy { it.id }
 
-        // Fluids first, because they are the one case where the cell count is not the amount
-        // to gather: a bucket is reusable, so 4,013 water cells are one water bucket carried
-        // and refilled. The cell count is kept as [SchematicMaterials.placedCounts] so the
-        // review screen can still show it — see FLUID_PLACEMENTS.
-        val fluidCells = mutableMapOf<Item, Int>()
-        input.items.forEach { (blockId, amount) ->
-            val bucketId = FLUID_PLACEMENTS[blockId] ?: return@forEach
-            val bucket = byId[bucketId] ?: return@forEach
-            fluidCells[bucket] = (fluidCells[bucket] ?: 0) + amount
+        // Per subregion where the file has them (MCO-398), so the review screen can offer a
+        // decorative shell as one group to strike. A region contributing nothing after
+        // resolution is dropped rather than shown as an empty group.
+        val regions = input.regions.mapNotNull { region ->
+            val resolved = resolve(region.items, byId)
+            resolved.takeIf { it.requirements.isNotEmpty() }
+                ?.let { ResolvedRegion(region.name, it.requirements, it.placedCounts) }
         }
 
-        // A schematic stores placed block-state ids; some are gathered as a different
-        // item (birch_wall_sign -> birch_sign) and some are not a material at all
-        // (an extended piston's head). Normalize, then merge amounts for block ids that
-        // collapse onto the same item (e.g. a build with both a sign and a wall sign).
-        val resolved = input.items.entries
-            .filter { (blockId, _) -> blockId !in FLUID_PLACEMENTS }
-            .mapNotNull { (blockId, amount) -> resolveMaterial(blockId, byId)?.let { it to amount } }
-            .groupBy({ it.first }, { it.second })
-            .map { (item, amounts) -> item to amounts.sum() }
+        // The flat list is the sum over regions, not a second resolution of the flattened
+        // file — otherwise the two would disagree about fluids. Resolving per region caps
+        // each region's water at one bucket, so a build whose pond spans two regions asks
+        // for two: one per section you actually build. Resolving the flattened file would
+        // say one, and the review screen (which totals the region rows) would say two.
+        // One bucket per section is the honest reading, and both paths now give it.
+        //
+        // A `Litematica` with no regions at all — the idea path, and directly constructed
+        // test data — still resolves the flattened map, which is the pre-MCO-398 behaviour.
+        val flat = if (regions.isEmpty()) {
+            resolve(input.items, byId)
+        } else {
+            ResolvedMaterials(
+                requirements = sumRequirements(regions.map { it.requirements }),
+                placedCounts = regions.map { it.placedCounts }.reduce { acc, next ->
+                    (acc.keys + next.keys).associateWith { (acc[it] ?: 0) + (next[it] ?: 0) }
+                },
+            )
+        }
 
-        // One bucket per fluid, on top of any the build stores as real items.
-        val byItem = LinkedHashMap<Item, Int>()
-        resolved.forEach { (item, amount) -> byItem[item] = (byItem[item] ?: 0) + amount }
-        fluidCells.keys.forEach { bucket -> byItem[bucket] = (byItem[bucket] ?: 0) + 1 }
-
-        val requirements = byItem.map { (item, amount) -> item to amount }
+        val requirements = flat.requirements
 
         if (requirements.isEmpty()) {
             return Result.failure(
@@ -292,10 +314,54 @@ data class MapSchematicToMaterialsStep(
         return Result.success(
             SchematicMaterials(
                 requirements = requirements,
-                placedCounts = fluidCells.entries.associate { (bucket, cells) -> bucket.id to cells },
+                placedCounts = flat.placedCounts,
+                regions = regions,
             )
         )
     }
+
+    /** One region's — or the whole file's — block counts, resolved to gathered items. */
+    private fun resolve(counts: Map<String, Int>, byId: Map<String, Item>): ResolvedMaterials {
+        // Fluids first, because they are the one case where the cell count is not the amount
+        // to gather: a bucket is reusable, so 4,013 water cells are one water bucket carried
+        // and refilled. The cell count is kept as [SchematicMaterials.placedCounts] so the
+        // review screen can still show it — see FLUID_PLACEMENTS.
+        val fluidCells = LinkedHashMap<Item, Int>()
+        counts.forEach { (blockId, amount) ->
+            val bucketId = FLUID_PLACEMENTS[blockId] ?: return@forEach
+            val bucket = byId[bucketId] ?: return@forEach
+            fluidCells[bucket] = (fluidCells[bucket] ?: 0) + amount
+        }
+
+        // A schematic stores placed block-state ids; some are gathered as a different
+        // item (birch_wall_sign -> birch_sign) and some are not a material at all
+        // (an extended piston's head). Normalize, then merge amounts for block ids that
+        // collapse onto the same item (e.g. a build with both a sign and a wall sign).
+        val resolved = counts.entries
+            .filter { (blockId, _) -> blockId !in FLUID_PLACEMENTS }
+            .mapNotNull { (blockId, amount) -> resolveMaterial(blockId, byId)?.let { it to amount } }
+
+        // One bucket per fluid, on top of any the build stores as real items.
+        val byItem = LinkedHashMap<Item, Int>()
+        resolved.forEach { (item, amount) -> byItem[item] = (byItem[item] ?: 0) + amount }
+        fluidCells.keys.forEach { bucket -> byItem[bucket] = (byItem[bucket] ?: 0) + 1 }
+
+        return ResolvedMaterials(
+            requirements = byItem.map { (item, amount) -> item to amount },
+            placedCounts = fluidCells.entries.associate { (bucket, cells) -> bucket.id to cells },
+        )
+    }
+
+    private fun sumRequirements(lists: List<List<Pair<Item, Int>>>): List<Pair<Item, Int>> {
+        val byItem = LinkedHashMap<Item, Int>()
+        lists.forEach { list -> list.forEach { (item, amount) -> byItem[item] = (byItem[item] ?: 0) + amount } }
+        return byItem.map { (item, amount) -> item to amount }
+    }
+
+    private data class ResolvedMaterials(
+        val requirements: List<Pair<Item, Int>>,
+        val placedCounts: Map<String, Int>,
+    )
 
     /**
      * Resolves a schematic block-state id to the item a player actually gathers, or
@@ -399,7 +465,12 @@ private data class MapSchematicToProjectStep(
             ?: "Imported build"
 
         return Result.success(
-            SchematicProject(name.take(100), materials.requirements.toMap(), materials.placedCounts)
+            SchematicProject(
+                name.take(100),
+                materials.requirements.toMap(),
+                materials.placedCounts,
+                materials.regions,
+            )
         )
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -187,7 +187,10 @@ internal data class ApplyReviewedRequirementsStep(
                 errors.add(ValidationFailure.CustomValidation("materials", "Unknown item: ${row.itemId}"))
                 return@forEach
             }
-            requirements[item] = row.amount
+            // Summed, not assigned — see the same note in ValidateReviewedMaterialsStep. The
+            // idea door has no regions today, but it posts to the same codec and the two
+            // readers must not disagree about what a repeated id means.
+            requirements[item] = (requirements[item] ?: 0) + row.amount
         }
 
         if (errors.isNotEmpty()) return Result.failure(AppFailure.ValidationError(errors))

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -177,6 +177,7 @@ private fun FlowContent.materialsSection(
         materialsField(allRows, excluded)
         warningStrip(warnings)
         materialsSummary(groups, allRows)
+        sectionsLead(groups)
         groups.forEachIndexed { index, group ->
             if (group.name == null) {
                 materialsTable(index, group.rows, excluded, placedCounts, warnings)
@@ -190,6 +191,22 @@ private fun FlowContent.materialsSection(
         if (allRows.isEmpty()) {
             p("form-error") { +"This schematic contains no recognisable materials." }
         }
+    }
+}
+
+/**
+ * Says what the sections are before the user meets them.
+ *
+ * Subregions are a Litematica concept, not a Seam one, and a stack of collapsed bars explains
+ * neither what they are nor that they open. One line costs nothing and removes both questions;
+ * without it the sections read as an unexplained grouping the screen invented.
+ */
+private fun FlowContent.sectionsLead(groups: List<MaterialGroup>) {
+    if (groups.size < 2) return
+
+    p("import-review__sections-lead") {
+        +"This schematic is built from ${groups.size} sections. "
+        +"Untick one to leave it out of the import, or open it to choose materials one at a time."
     }
 }
 
@@ -310,6 +327,12 @@ private fun FlowContent.materialsSummary(groups: List<MaterialGroup>, allRows: L
  * The checkbox in the header includes or excludes everything inside. It is deliberately
  * nameless like every other box on this screen: `import-review.js` folds it into the single
  * materials field, and it submits nothing of its own.
+ *
+ * The disclosure is a **worded** control rather than a bare chevron. A small glyph reads as
+ * decoration next to a checkbox that is plainly interactive, so the section looks like
+ * something you tick rather than something you open — and the material list inside stays
+ * hidden from anyone who does not already know it is there. Both labels are rendered and CSS
+ * shows one, so the control announces itself rather than relying on generated content.
  */
 private fun FlowContent.regionGroup(
     index: Int,
@@ -330,6 +353,10 @@ private fun FlowContent.regionGroup(
             span("import-review__region-meta") {
                 +"${group.rows.size} ${if (group.rows.size == 1) "material" else "materials"}"
                 +" · ${"%,d".format(blocks)} blocks"
+            }
+            span("btn btn--ghost btn--sm import-review__region-toggle") {
+                span("import-review__region-toggle--closed") { +"Show materials ▾" }
+                span("import-review__region-toggle--open") { +"Hide materials ▴" }
             }
         }
         materialsTable(index, group.rows, excluded, placedCounts, warnings)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -5,6 +5,7 @@ import app.mcorg.domain.model.user.TokenProfile
 import app.mcorg.pipeline.project.ImportWarning
 import app.mcorg.pipeline.project.ImportWarningKind
 import app.mcorg.pipeline.project.ImportWarnings
+import app.mcorg.pipeline.project.ResolvedRegion
 import app.mcorg.pipeline.project.ReviewedMaterial
 import app.mcorg.pipeline.project.ReviewedMaterialsCodec
 import app.mcorg.presentation.templated.dsl.appHeader
@@ -15,6 +16,7 @@ import kotlinx.html.FlowContent
 import kotlinx.html.InputType
 import kotlinx.html.a
 import kotlinx.html.button
+import kotlinx.html.details
 import kotlinx.html.div
 import kotlinx.html.form
 import kotlinx.html.h1
@@ -25,6 +27,7 @@ import kotlinx.html.label
 import kotlinx.html.main
 import kotlinx.html.p
 import kotlinx.html.span
+import kotlinx.html.summary
 import kotlinx.html.table
 import kotlinx.html.tbody
 import kotlinx.html.td
@@ -55,6 +58,12 @@ import kotlinx.html.tr
  * Litematica's own material-swap edits the schematic itself and keeps them in sync by
  * construction. That is the right door; this screen deliberately no longer offers a worse one.
  *
+ * [regions] (MCO-398) split the list into collapsible sections, one per Litematica subregion,
+ * each with a header checkbox that includes or excludes the whole thing. A 555-row flat table
+ * is a screen people skip; sections are what make "I am not building the decorative shell" a
+ * single click. Fewer than two regions renders with no group chrome at all — a lone region is
+ * named after the schematic or left "Unnamed", so a header would wrap the list in noise.
+ *
  * [warnings] (MCO-305) name the painful rows without standing in their way. Advisory only —
  * every warned row arrives checked. Since MCO-397 the strip above the list carries only
  * creative-only rows, the one kind worth interrupting for; everything else is a row chip.
@@ -68,6 +77,7 @@ fun importReviewPage(
     action: String = "/worlds/$worldId/projects/from-schematic",
     hiddenFields: Map<String, String> = emptyMap(),
     placedCounts: Map<String, Int> = emptyMap(),
+    regions: List<ResolvedRegion> = emptyList(),
     warnings: ImportWarnings = ImportWarnings(),
 ): String = pageShell(
     pageTitle = "Seam — review import",
@@ -126,7 +136,7 @@ fun importReviewPage(
                     }
                 }
 
-                materialsSection(requirements, emptySet(), placedCounts, warnings)
+                materialsSection(requirements, emptySet(), placedCounts, regions, warnings)
 
                 div("import-review__actions") {
                     button(classes = "btn btn--primary") {
@@ -143,25 +153,70 @@ fun importReviewPage(
     }
 }
 
+/**
+ * One group of rows. [name] is null for a schematic that has nothing worth grouping by, which
+ * is the common case and renders exactly as the screen did before MCO-398 — no group chrome.
+ */
+private data class MaterialGroup(val name: String?, val rows: List<Pair<Item, Int>>)
+
 private fun FlowContent.materialsSection(
     requirements: Map<Item, Int>,
     excluded: Set<String>,
     placedCounts: Map<String, Int>,
+    regions: List<ResolvedRegion>,
     warnings: ImportWarnings,
 ) {
     div("import-review__materials") {
-        // One order for the whole section: the hidden field and the table must describe the
-        // same list in the same sequence, since `import-review.js` folds the table's checkbox
-        // state back into the field by position-independent id but the two must agree on which
-        // rows exist at all.
-        val rows = requirements.entries.sortedWith(
-            compareByDescending<Map.Entry<Item, Int>> { it.value }.thenBy { it.key.name }
-        )
+        val groups = groupsFor(requirements, regions)
 
-        materialsField(rows, excluded)
+        // One order for the whole section: the hidden field and the tables must describe the
+        // same rows in the same sequence. `import-review.js` rebuilds the field from the
+        // checkboxes in DOM order, so the two only agree if this order is the render order.
+        val allRows = groups.flatMap { it.rows }
+
+        materialsField(allRows, excluded)
         warningStrip(warnings)
-        materialsTable(rows, excluded, placedCounts, warnings)
+        materialsSummary(groups, allRows)
+        groups.forEachIndexed { index, group ->
+            if (group.name == null) {
+                materialsTable(index, group.rows, excluded, placedCounts, warnings)
+            } else {
+                regionGroup(index, group, excluded, placedCounts, warnings)
+            }
+        }
+
+        // The server refuses an empty list too, but a form with no rows at all should not have
+        // reached this page in the first place.
+        if (allRows.isEmpty()) {
+            p("form-error") { +"This schematic contains no recognisable materials." }
+        }
     }
+}
+
+/**
+ * Splits the list into the groups the screen offers.
+ *
+ * Grouping needs **more than one** region to be worth anything. Litematica names a lone region
+ * after the schematic itself, or leaves it `"Unnamed"` — every real single-region fixture in
+ * `mc-nbt/src/test/resources` does one or the other — so a header there would be noise wrapped
+ * around the entire list. Those files render exactly as they did before MCO-398.
+ */
+private fun groupsFor(requirements: Map<Item, Int>, regions: List<ResolvedRegion>): List<MaterialGroup> {
+    val byQuantity = compareByDescending<Pair<Item, Int>> { it.second }.thenBy { it.first.name }
+
+    // The mapper already drops regions that resolve to nothing; this keeps the screen honest
+    // if one ever arrives anyway, rather than rendering a section with an empty table.
+    val populated = regions.filter { it.requirements.isNotEmpty() }
+
+    if (populated.size < 2) {
+        return listOf(MaterialGroup(null, requirements.toList().sortedWith(byQuantity)))
+    }
+
+    // Largest section first: on a build whose decorative shell is the thing you want to strike,
+    // the section worth a decision is usually the big one.
+    return populated
+        .map { MaterialGroup(it.name.ifBlank { "Unnamed section" }, it.requirements.sortedWith(byQuantity)) }
+        .sortedByDescending { group -> group.rows.sumOf { it.second.toLong() } }
 }
 
 private const val MATERIALS_FIELD_ID = "import-review-materials-field"
@@ -178,7 +233,7 @@ private const val MATERIALS_FIELD_ID = "import-review-materials-field"
  * exclusions would be missed, and the payload's declared row count means nothing can be lost
  * without the server saying so.
  */
-private fun FlowContent.materialsField(rows: List<Map.Entry<Item, Int>>, excluded: Set<String>) {
+private fun FlowContent.materialsField(rows: List<Pair<Item, Int>>, excluded: Set<String>) {
     hiddenInput {
         id = MATERIALS_FIELD_ID
         name = ReviewedMaterialsCodec.FIELD
@@ -228,22 +283,69 @@ private fun namesOf(flagged: List<ImportWarning>): String {
     return if (rest > 0) "$shown and $rest more" else shown
 }
 
-private fun FlowContent.materialsTable(
-    rows: List<Map.Entry<Item, Int>>,
+/**
+ * The count above the list. With sections it reports **distinct materials**, not rows: an item
+ * used in two sections is two rows but one thing to gather, and "580 items" for a 555-material
+ * build would be a quiet lie.
+ */
+private fun FlowContent.materialsSummary(groups: List<MaterialGroup>, allRows: List<Pair<Item, Int>>) {
+    val distinct = allRows.distinctBy { it.first.id }.size
+    div("import-review__summary") {
+        span("section-label") { +"Materials" }
+        span("import-review__count") {
+            +"$distinct ${if (distinct == 1) "item" else "items"}"
+            if (groups.size > 1) +" in ${groups.size} sections"
+        }
+    }
+}
+
+/**
+ * One section of a multi-region schematic (MCO-398), collapsed by default.
+ *
+ * Collapsed is the point: 555 rows in one flat table is a screen people skip, and the thing
+ * that makes it skippable is that nothing tells you where one part of the build ends and the
+ * next begins. The section header carries enough — name, material count, block total — to
+ * decide "not building that" without expanding it.
+ *
+ * The checkbox in the header includes or excludes everything inside. It is deliberately
+ * nameless like every other box on this screen: `import-review.js` folds it into the single
+ * materials field, and it submits nothing of its own.
+ */
+private fun FlowContent.regionGroup(
+    index: Int,
+    group: MaterialGroup,
     excluded: Set<String>,
     placedCounts: Map<String, Int>,
     warnings: ImportWarnings,
 ) {
-    div("import-review__summary") {
-        span("section-label") { +"Materials" }
-        span("import-review__count") {
-            +"${rows.size} ${if (rows.size == 1) "item" else "items"}"
+    val blocks = group.rows.sumOf { it.second.toLong() }
+    details("import-review__region") {
+        summary("import-review__region-summary") {
+            input(type = InputType.checkBox, classes = "import-review__region-include") {
+                id = "region-include-$index"
+                checked = true
+                attributes["aria-label"] = "Include everything in ${group.name}"
+            }
+            span("import-review__region-name") { +(group.name ?: "") }
+            span("import-review__region-meta") {
+                +"${group.rows.size} ${if (group.rows.size == 1) "material" else "materials"}"
+                +" · ${"%,d".format(blocks)} blocks"
+            }
         }
+        materialsTable(index, group.rows, excluded, placedCounts, warnings)
     }
+}
 
+private fun FlowContent.materialsTable(
+    groupIndex: Int,
+    rows: List<Pair<Item, Int>>,
+    excluded: Set<String>,
+    placedCounts: Map<String, Int>,
+    warnings: ImportWarnings,
+) {
     div("import-review__table-wrap") {
         table(classes = "data-table import-review__table") {
-            id = "import-review-table"
+            id = "import-review-table-$groupIndex"
             thead {
                 tr {
                     th { +"Include" }
@@ -253,7 +355,9 @@ private fun FlowContent.materialsTable(
             }
             tbody {
                 rows.forEach { (item, amount) ->
-                    val rowId = item.id.replace(Regex("[^a-zA-Z0-9]"), "-")
+                    // Scoped by group: the same item can legitimately appear in two sections,
+                    // and a duplicate DOM id would point every label at the first one's box.
+                    val rowId = "$groupIndex-" + item.id.replace(Regex("[^a-zA-Z0-9]"), "-")
                     tr("import-review__row") {
                         td {
                             attributes["data-label"] = "Include"
@@ -300,11 +404,5 @@ private fun FlowContent.materialsTable(
                 }
             }
         }
-    }
-
-    // The server refuses an empty list too, but a form with no rows at all should not have
-    // reached this page in the first place.
-    if (rows.isEmpty()) {
-        p("form-error") { +"This schematic contains no recognisable materials." }
     }
 }

--- a/webapp/mc-web/src/main/resources/static/scripts/import-review.js
+++ b/webapp/mc-web/src/main/resources/static/scripts/import-review.js
@@ -47,12 +47,64 @@
         return field.value;
     }
 
+    /** The row checkboxes inside one section (MCO-398). */
+    function rowsIn(regionBox) {
+        var section = regionBox.closest('.import-review__region');
+        return section ? section.querySelectorAll('.import-review__include') : [];
+    }
+
+    /**
+     * Reflects a section's rows back onto its header box: all on, all off, or indeterminate.
+     * Without this, unticking one row of a fully-included section would leave the header
+     * claiming the whole section is in.
+     */
+    function refreshRegion(regionBox) {
+        var rows = rowsIn(regionBox);
+        var checked = 0;
+        for (var i = 0; i < rows.length; i++) {
+            if (rows[i].checked) checked++;
+        }
+        regionBox.checked = rows.length > 0 && checked === rows.length;
+        regionBox.indeterminate = checked > 0 && checked < rows.length;
+    }
+
+    function refreshAllRegions() {
+        var boxes = form.querySelectorAll('.import-review__region-include');
+        for (var i = 0; i < boxes.length; i++) {
+            refreshRegion(boxes[i]);
+        }
+    }
+
     form.addEventListener('change', function (event) {
         var target = event.target;
-        if (target && target.classList && target.classList.contains('import-review__include')) {
+        if (!target || !target.classList) {
+            return;
+        }
+        if (target.classList.contains('import-review__region-include')) {
+            var rows = rowsIn(target);
+            for (var i = 0; i < rows.length; i++) {
+                rows[i].checked = target.checked;
+            }
+            target.indeterminate = false;
+            sync();
+            return;
+        }
+        if (target.classList.contains('import-review__include')) {
+            refreshAllRegions();
             sync();
         }
     });
+
+    // A click on the header checkbox must not also open or close the section — <summary>
+    // toggles the disclosure for any click inside it.
+    form.addEventListener('click', function (event) {
+        var target = event.target;
+        if (target && target.classList && target.classList.contains('import-review__region-include')) {
+            event.stopPropagation();
+        }
+    });
+
+    refreshAllRegions();
 
     form.addEventListener('submit', function () {
         sync();

--- a/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
@@ -139,14 +139,37 @@
     color: var(--text-muted);
 }
 
-.import-review__region-summary::after {
-    content: "▾";
-    color: var(--text-muted);
-    font-size: var(--text-xs);
+/* A worded control, not a bare chevron. Next to a checkbox that is obviously interactive, a
+   small glyph reads as decoration — people were not finding the material list at all. Both
+   labels are in the markup and CSS swaps them, so the control is announced rather than being
+   generated content a screen reader may skip. Pointer events off: the click belongs to the
+   <summary>, which already toggles the section, so this must not become a second target. */
+.import-review__region-toggle {
+    pointer-events: none;
+    white-space: nowrap;
 }
 
-.import-review__region[open] > .import-review__region-summary::after {
-    content: "▴";
+.import-review__region-toggle--open,
+.import-review__region[open] .import-review__region-toggle--closed {
+    display: none;
+}
+
+.import-review__region[open] .import-review__region-toggle--open {
+    display: inline;
+}
+
+/* The header is one big target, so say so on hover rather than only under the button. */
+.import-review__region-summary:hover .import-review__region-toggle {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.import-review__sections-lead {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    margin: 0;
+    max-width: 70ch;
 }
 
 /* The table sits inside the section's border, so it does not need one of its own. */
@@ -203,5 +226,19 @@
 
     .import-review__actions {
         flex-direction: column;
+    }
+
+    /* Checkbox + name, then counts + toggle on a second line. Four items in a row at 375px
+       squeezes the section name to a few characters, which is the one part that has to read. */
+    .import-review__region-summary {
+        flex-wrap: wrap;
+    }
+
+    .import-review__region-meta {
+        margin-left: 0;
+    }
+
+    .import-review__region-toggle {
+        margin-left: auto;
     }
 }

--- a/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
@@ -98,6 +98,62 @@
     gap: var(--space-3);
 }
 
+/* MCO-398 — one collapsible section per Litematica subregion. Follows the fl-shelf pattern
+   (project-list.css): a bordered <details> whose <summary> hides the native marker and lays
+   its parts out in a row. Collapsed by default — the header is meant to be enough to decide
+   on a section without expanding it. */
+.import-review__region {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-surface);
+}
+
+.import-review__region + .import-review__region {
+    margin-top: var(--space-3);
+}
+
+.import-review__region-summary {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    cursor: pointer;
+    list-style: none;
+}
+
+.import-review__region-summary::-webkit-details-marker {
+    display: none;
+}
+
+.import-review__region-name {
+    font-family: var(--font-ui);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+/* Pushed right so the counts line up down the stack regardless of section-name length. */
+.import-review__region-meta {
+    margin-left: auto;
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+.import-review__region-summary::after {
+    content: "▾";
+    color: var(--text-muted);
+    font-size: var(--text-xs);
+}
+
+.import-review__region[open] > .import-review__region-summary::after {
+    content: "▴";
+}
+
+/* The table sits inside the section's border, so it does not need one of its own. */
+.import-review__region > .import-review__table-wrap {
+    padding: 0 var(--space-4) var(--space-4);
+}
+
 .import-review__count {
     font-family: var(--font-ui);
     font-size: var(--text-xs);

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/MapSchematicToMaterialsStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/MapSchematicToMaterialsStepTest.kt
@@ -2,6 +2,7 @@ package app.mcorg.pipeline.project
 
 import app.mcorg.domain.model.minecraft.Item
 import app.mcorg.domain.model.minecraft.Litematica
+import app.mcorg.domain.model.minecraft.LitematicaRegion
 import app.mcorg.pipeline.Result
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
@@ -242,6 +243,104 @@ class MapSchematicToMaterialsStepTest {
         assertIs<Result.Success<SchematicMaterials>>(result)
         assertEquals(listOf("minecraft:oak_planks"), result.value.requirements.map { it.first.id })
         assertTrue(result.value.placedCounts.isEmpty())
+    }
+
+    // ---- subregions (MCO-398) ---------------------------------------------------------
+
+    private fun litematicaWithRegions(vararg regions: Pair<String, Map<String, Int>>): Litematica {
+        val flattened = mutableMapOf<String, Int>()
+        regions.forEach { (_, items) ->
+            items.forEach { (id, count) -> flattened[id] = (flattened[id] ?: 0) + count }
+        }
+        return Litematica(
+            "Build", "", "", Triple(1, 1, 1), flattened,
+            regions.map { (name, items) -> LitematicaRegion(name, items) },
+        )
+    }
+
+    @Test
+    fun `each region resolves to its own material list`() = runBlocking {
+        val result = MapSchematicToMaterialsStep(catalog).process(
+            litematicaWithRegions(
+                "Frame" to mapOf("minecraft:oak_planks" to 500),
+                "Shell" to mapOf("minecraft:birch_wall_sign" to 3),
+            )
+        )
+        assertIs<Result.Success<SchematicMaterials>>(result)
+
+        assertEquals(listOf("Frame", "Shell"), result.value.regions.map { it.name })
+        assertEquals(
+            listOf("minecraft:oak_planks" to 500),
+            result.value.regions[0].requirements.map { it.first.id to it.second },
+        )
+        assertEquals(
+            listOf("minecraft:birch_sign" to 3),
+            result.value.regions[1].requirements.map { it.first.id to it.second },
+            "block-state redirects apply inside a region, not just to the flattened file",
+        )
+    }
+
+    @Test
+    fun `an item in two regions is summed in the flat list and kept apart per region`() = runBlocking {
+        val result = MapSchematicToMaterialsStep(catalog).process(
+            litematicaWithRegions(
+                "Frame" to mapOf("minecraft:oak_planks" to 500),
+                "Shell" to mapOf("minecraft:oak_planks" to 200),
+            )
+        )
+        assertIs<Result.Success<SchematicMaterials>>(result)
+
+        assertEquals(
+            listOf("minecraft:oak_planks" to 700),
+            result.value.requirements.map { it.first.id to it.second },
+        )
+        assertEquals(listOf(500, 200), result.value.regions.map { it.requirements.single().second })
+    }
+
+    @Test
+    fun `a region resolving to nothing is dropped rather than offered as an empty section`() = runBlocking {
+        val result = MapSchematicToMaterialsStep(catalog).process(
+            litematicaWithRegions(
+                "Frame" to mapOf("minecraft:oak_planks" to 5),
+                "Air pocket" to mapOf("minecraft:piston_head" to 9),
+            )
+        )
+        assertIs<Result.Success<SchematicMaterials>>(result)
+
+        assertEquals(listOf("Frame"), result.value.regions.map { it.name })
+    }
+
+    @Test
+    fun `a fluid spanning two regions costs a bucket per region`() = runBlocking {
+        // One bucket per section you actually build. Resolving the flattened file instead would
+        // say one bucket total, and the review screen — which totals the section rows — would
+        // say two. Both paths agree on two so the screen and the create step cannot diverge.
+        val result = MapSchematicToMaterialsStep(catalog).process(
+            litematicaWithRegions(
+                "Pond" to mapOf("minecraft:water" to 900),
+                "Moat" to mapOf("minecraft:water" to 40),
+            )
+        )
+        assertIs<Result.Success<SchematicMaterials>>(result)
+
+        assertEquals(
+            listOf("minecraft:water_bucket" to 2),
+            result.value.requirements.map { it.first.id to it.second },
+        )
+        assertEquals(mapOf("minecraft:water_bucket" to 940), result.value.placedCounts)
+        assertEquals(
+            listOf(900, 40),
+            result.value.regions.map { it.placedCounts.getValue("minecraft:water_bucket") },
+            "each section keeps its own cell count for its own row",
+        )
+    }
+
+    @Test
+    fun `a file with no regions still resolves the flattened list`() {
+        // The pre-MCO-398 path, still taken by directly constructed Litematica and the idea door.
+        val byId = map(mapOf("minecraft:oak_planks" to 12))
+        assertEquals(12, byId["minecraft:oak_planks"])
+        assertTrue(materials(mapOf("minecraft:oak_planks" to 12)).regions.isEmpty())
     }
 
     @Test

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/ValidateReviewedMaterialsStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/ValidateReviewedMaterialsStepTest.kt
@@ -1,0 +1,80 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.pipeline.Result
+import io.ktor.http.parametersOf
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Reading the review screen's submission back — with the repeated ids that section grouping
+ * (MCO-398) makes routine.
+ */
+class ValidateReviewedMaterialsStepTest {
+
+    private val catalog = listOf("minecraft:oak_planks", "minecraft:glass", "minecraft:hopper")
+        .map { Item(it, it.substringAfterLast(':')) }
+
+    private fun submit(vararg rows: ReviewedMaterial): Result<*, SchematicProject> = runBlocking {
+        ValidateReviewedMaterialsStep(catalog).process(
+            parametersOf(
+                "name" to listOf("Build"),
+                ReviewedMaterialsCodec.FIELD to listOf(ReviewedMaterialsCodec.encode(rows.toList())),
+            )
+        )
+    }
+
+    private fun row(id: String, amount: Int, included: Boolean = true) =
+        ReviewedMaterial("minecraft:$id", amount, included)
+
+    @Test
+    fun `the same item in two sections is summed, not overwritten`() {
+        // The bug this guards: `requirements[item] = row.amount` silently let the shell's 200
+        // planks replace the frame's 500. Nothing would have reported the missing 500 — the
+        // same shape of quiet loss MCO-315 was about.
+        val result = submit(row("oak_planks", 500), row("oak_planks", 200))
+        assertIs<Result.Success<SchematicProject>>(result)
+
+        assertEquals(
+            mapOf("minecraft:oak_planks" to 700),
+            result.value.requirements.mapKeys { it.key.id },
+        )
+    }
+
+    @Test
+    fun `a struck row contributes nothing to the sum`() {
+        // Striking the shell's section must remove its contribution and keep the frame's.
+        val result = submit(row("oak_planks", 500), row("oak_planks", 200, included = false))
+        assertIs<Result.Success<SchematicProject>>(result)
+
+        assertEquals(500, result.value.requirements.values.single())
+    }
+
+    @Test
+    fun `distinct items across sections all survive`() {
+        val result = submit(row("oak_planks", 500), row("glass", 4000), row("hopper", 40))
+        assertIs<Result.Success<SchematicProject>>(result)
+
+        assertEquals(
+            mapOf("minecraft:oak_planks" to 500, "minecraft:glass" to 4000, "minecraft:hopper" to 40),
+            result.value.requirements.mapKeys { it.key.id },
+        )
+    }
+
+    @Test
+    fun `striking every section is refused rather than creating an empty project`() {
+        val result = submit(row("oak_planks", 500, included = false), row("glass", 40, included = false))
+
+        assertTrue(result is Result.Failure)
+    }
+
+    @Test
+    fun `an id outside the world catalog is refused`() {
+        val result = submit(ReviewedMaterial("minecraft:not_a_thing", 5, true))
+
+        assertTrue(result is Result.Failure)
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPageTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPageTest.kt
@@ -118,6 +118,41 @@ class ImportReviewPageTest {
     }
 
     @Test
+    fun `each section carries a worded expand control, not just a chevron`() {
+        val html = render(
+            requirements = mapOf(item("glass") to 4000, item("oak_planks") to 700),
+            regions = listOf(frame, shell),
+        )
+
+        assertContains(html, "Show materials")
+        assertContains(html, "Hide materials")
+        assertEquals(
+            2,
+            Regex("import-review__region-toggle--closed").findAll(html).count(),
+            "one expand control per section",
+        )
+    }
+
+    @Test
+    fun `grouped lists say what the sections are`() {
+        // Subregions are a Litematica concept, not a Seam one — a stack of collapsed bars
+        // explains neither what they are nor that they open.
+        val html = render(
+            requirements = mapOf(item("glass") to 4000, item("oak_planks") to 700),
+            regions = listOf(frame, shell),
+        )
+
+        assertContains(html, "built from 2 sections")
+    }
+
+    @Test
+    fun `an ungrouped list gets no sections explainer`() {
+        val html = render(requirements = mapOf(item("oak_planks") to 500))
+
+        assertFalse(html.contains("import-review__sections-lead"))
+    }
+
+    @Test
     fun `a single region renders with no section chrome at all`() {
         // Litematica names a lone region after the schematic, or leaves it "Unnamed" — every
         // real fixture does one or the other, so a header would wrap the whole list in noise.

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPageTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPageTest.kt
@@ -1,0 +1,152 @@
+package app.mcorg.presentation.templated.dsl.pages
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.pipeline.project.ResolvedRegion
+import app.mcorg.test.fixtures.TestDataFactory
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * MCO-398 — the import review's section grouping, rendered.
+ *
+ * These live here rather than in an IT because no real `.litematic` fixture has more than one
+ * region (every file in `mc-nbt/src/test/resources/litematica` is single-region) and `mc-nbt`
+ * is parse-only, so there is no way to synthesise a multi-region upload. The grouping is
+ * therefore exercised where its input can be constructed directly.
+ */
+class ImportReviewPageTest {
+
+    private val user = TestDataFactory.createTestTokenProfile()
+
+    private fun item(id: String) = Item("minecraft:$id", id.replaceFirstChar { it.uppercase() })
+
+    private fun render(
+        requirements: Map<Item, Int>,
+        regions: List<ResolvedRegion> = emptyList(),
+        placedCounts: Map<String, Int> = emptyMap(),
+    ) = importReviewPage(
+        user = user,
+        worldId = 1,
+        worldName = "World",
+        projectName = "Build",
+        requirements = requirements,
+        placedCounts = placedCounts,
+        regions = regions,
+    )
+
+    private val frame = ResolvedRegion(
+        name = "Functional frame",
+        requirements = listOf(item("oak_planks") to 500, item("hopper") to 40),
+    )
+    private val shell = ResolvedRegion(
+        name = "Display glass",
+        requirements = listOf(item("glass") to 4000, item("oak_planks") to 200),
+    )
+
+    @Test
+    fun `two regions render as two named sections with a header checkbox each`() {
+        val html = render(
+            requirements = mapOf(item("glass") to 4000, item("oak_planks") to 700, item("hopper") to 40),
+            regions = listOf(frame, shell),
+        )
+
+        assertContains(html, "import-review__region")
+        assertContains(html, "Functional frame")
+        assertContains(html, "Display glass")
+        assertEquals(
+            2,
+            Regex("import-review__region-include").findAll(html).count(),
+            "one include-everything box per section",
+        )
+    }
+
+    @Test
+    fun `the largest section comes first`() {
+        // A decorative shell is usually the biggest thing in the file and the one you strike,
+        // so it should not be buried under the section you are definitely building.
+        val html = render(
+            requirements = mapOf(item("glass") to 4000, item("oak_planks") to 700, item("hopper") to 40),
+            regions = listOf(frame, shell),
+        )
+
+        assertTrue(
+            html.indexOf("Display glass") < html.indexOf("Functional frame"),
+            "4,200 blocks of shell should sort above 540 of frame",
+        )
+    }
+
+    @Test
+    fun `an item in two sections renders once per section`() {
+        val html = render(
+            requirements = mapOf(item("oak_planks") to 700),
+            regions = listOf(frame, shell),
+        )
+
+        assertEquals(
+            2,
+            Regex("""data-item-id="minecraft:oak_planks"""").findAll(html).count(),
+            "500 in the frame and 200 in the shell are two separate decisions",
+        )
+        // The two rows must not collide on a DOM id, or both labels would target one box.
+        assertContains(html, """id="include-0-minecraft-oak-planks"""")
+        assertContains(html, """id="include-1-minecraft-oak-planks"""")
+    }
+
+    @Test
+    fun `the materials field carries one row per rendered checkbox`() {
+        val html = render(
+            requirements = mapOf(item("glass") to 4000, item("oak_planks") to 700, item("hopper") to 40),
+            regions = listOf(frame, shell),
+        )
+
+        // 4 rows across the two sections, not 3 distinct items — MCO-315's declared count has
+        // to match the checkboxes or the server rejects the submission as truncated.
+        assertContains(html, """value="v1;4;""")
+    }
+
+    @Test
+    fun `the count reports distinct materials, not rows`() {
+        val html = render(
+            requirements = mapOf(item("glass") to 4000, item("oak_planks") to 700, item("hopper") to 40),
+            regions = listOf(frame, shell),
+        )
+
+        assertContains(html, "3 items in 2 sections")
+    }
+
+    @Test
+    fun `a single region renders with no section chrome at all`() {
+        // Litematica names a lone region after the schematic, or leaves it "Unnamed" — every
+        // real fixture does one or the other, so a header would wrap the whole list in noise.
+        val html = render(
+            requirements = mapOf(item("oak_planks") to 500),
+            regions = listOf(ResolvedRegion("WiskeProSorter", listOf(item("oak_planks") to 500))),
+        )
+
+        assertFalse(html.contains("import-review__region"), "no section wrapper")
+        assertFalse(html.contains("WiskeProSorter"), "and no header repeating the schematic name")
+        assertContains(html, "1 item")
+    }
+
+    @Test
+    fun `a schematic with no regions renders exactly as before`() {
+        val html = render(requirements = mapOf(item("oak_planks") to 500, item("hopper") to 40))
+
+        assertFalse(html.contains("import-review__region"))
+        assertContains(html, "2 items")
+        assertContains(html, """value="v1;2;""")
+    }
+
+    @Test
+    fun `an empty region is never offered as a section`() {
+        val html = render(
+            requirements = mapOf(item("oak_planks") to 500),
+            regions = listOf(frame, ResolvedRegion("Air pocket", emptyList())),
+        )
+
+        assertFalse(html.contains("Air pocket"))
+    }
+}


### PR DESCRIPTION
Closes MCO-398.

A 555-row flat table is a screen people skip, and skipping it defeats the point of the review step. The information needed to break it up was already in the file and thrown away on the first line of `extractRegionData` — Litematica stores regions as a map of name to region, and the name was discarded.

## What it does

Regions survive into `Litematica.regions`, and the review screen renders **one collapsible section per region**, each with a header checkbox that includes or excludes the whole thing. "I am not building the decorative shell" becomes a single click rather than a hunt through hundreds of rows for the ones made of glass.

Sections are collapsed by default and sorted **largest first** — the one worth a decision is usually the big one. The header carries name, material count and block total, which is meant to be enough to decide without expanding.

## Single-region files are unchanged, deliberately

No section chrome at all below two regions. That is not a shortcut — it is what the real files ask for:

| Fixture | Region name |
|---|---|
| `Dig_Sort_III` | `Unnamed` |
| `WiskeProSorter` | `WiskeProSorter` |
| `10x Shulker loader` | `10x Shulker loader` |

Every fixture in `mc-nbt/src/test/resources/litematica` is single-region, and Litematica either names the lone region after the schematic or leaves it `Unnamed`. A header there wraps the entire list in noise.

## Two consequences worth a reviewer's eye

**1. Resolution moved per-region, and the flat list is now their sum.**

Not a second resolution of the flattened file — the two disagree about fluids. Per region, a pond spanning two sections costs one bucket per section; over the flattened file it costs one. The screen totals the section rows, so resolving flat would have let the review screen and the create step report **different numbers for the same import**. One bucket per section is the honest reading, and both paths now give it.

**2. An item in two sections is two rows — and both readers of the payload would have lost one.**

`ValidateReviewedMaterialsStep` and `ApplyReviewedRequirementsStep` both did `requirements[item] = row.amount`. With grouping, the shell's 200 planks would have silently replaced the frame's 500. Now summed, with `ValidateReviewedMaterialsStepTest` pinning it. This is the same shape of quiet loss as MCO-315, caught before it shipped rather than after.

The codec itself is unchanged: rows stay `[!]itemId=amount` and regions never enter the payload, so arbitrary user-supplied region names never have to be escaped past `;` `=` `!`. MCO-315's declared row count still matches the rendered checkboxes exactly — one payload row per box.

## Tests

802 unit + 434 database, zero failures.

- **`LitematicaReaderTest`** gains a **synthesised two-region file**. I had assumed this was impossible because `mc-nbt` is parse-only, but the test file's own `DataOutputStream` helpers already write NBT — a 1×1×1 region with a two-entry palette packs at 2 bits per block, so one block state of `1` selects the block over the padding air. No new fixture needed, and the multi-region reader path is covered for real rather than by proxy.
- **`ImportReviewPageTest`** (new) covers the grouping as rendered: two named sections, largest first, per-section DOM ids that do not collide, the declared row count matching the checkboxes, distinct-vs-row counting, and the single-region no-chrome path.
- **`MapSchematicToMaterialsStepTest`** covers per-region resolution, cross-region summing, the fluid-per-section rule, and empty regions being dropped.

## Note on the count

With sections the header reports **distinct materials**, not rows — an item in two sections is two rows but one thing to gather, and "580 items" for a 555-material build would be a quiet lie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
