### PR TITLE
MCO-316: match farm supply against derived plan demand

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/project/ProjectDemand.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/project/ProjectDemand.kt
@@ -1,0 +1,22 @@
+package app.mcorg.domain.model.project
+
+/**
+ * One item a project's derived plan actually needs, and how much of it (MCO-316).
+ *
+ * This is the *derived* demand, not the declared requirement. Importing a schematic declares
+ * finished placed blocks — 5,630 hoppers — while the thing a farm can supply is what those
+ * decompose into: 32,947 iron ingots, 74,564 cobblestone. Matching farms against declared rows
+ * therefore matched almost nothing, and what it did match was a coincidence of decoration.
+ *
+ * [group] and [status] are the engine's own classifications, carried so consumers can filter
+ * without re-deriving: farm supply wants anything a project produces, while a farm-scale
+ * marker (MCO-401) wants raw gathering only.
+ */
+data class ProjectDemand(
+    val projectId: Int,
+    val itemId: String,
+    val itemName: String,
+    val quantity: Long,
+    val group: String,
+    val status: String,
+)

--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/project/ProjectResourceEdge.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/project/ProjectResourceEdge.kt
@@ -14,6 +14,14 @@ data class ProjectResourceEdge(
     val producerName: String,
     val itemName: String?,
     val producerState: ProjectState,
+    /**
+     * How much of [itemName] the consumer's derived plan needs (MCO-316).
+     *
+     * Null where the edge does not come from derived demand — a manual `project_dependencies`
+     * row has no item, and a `solved_by_project_id` link names a declared row rather than a
+     * planned quantity. Null means "no number to show", never "zero".
+     */
+    val quantity: Long? = null,
 ) {
     val isBlocking: Boolean
         get() = producerState != ProjectState.DONE

--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/world/Roadmap.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/world/Roadmap.kt
@@ -136,6 +136,15 @@ data class RoadmapEdge(
      * *and* the resource, so the reader knows what to go and get.
      */
     val itemName: String? = null,
+    /**
+     * How much of [itemName] the consumer's derived plan needs (MCO-316).
+     *
+     * "Cobblestone Generator — 74,564 Cobblestone" is useful; the same cell without a number,
+     * next to a single decorative block, was actively misleading. Null wherever there is no
+     * number to show — a manual sequencing edge, or a declared link that names a row rather
+     * than a planned quantity — and never a stand-in for zero.
+     */
+    val quantity: Long? = null,
 ) {
     /**
      * Checks if this edge represents a blocking dependency

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetFarmSupplyEdgesStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetFarmSupplyEdgesStep.kt
@@ -21,34 +21,59 @@ import app.mcorg.pipeline.failure.AppFailure
  * an operational (DONE) farm supplies now and blocks nothing; a farm still being built
  * blocks its consumers. That falls straight out of the producer's state — no special case.
  *
- * Matching is on declared requirements (`resource_gathering`), not on the derived plan:
- * same granularity as `solved_by_project_id`, and one query instead of one plan derivation
- * per project. Ignored requirements (MCO-247) are not demand and are excluded.
+ * ## Matching is on derived demand (MCO-316)
+ *
+ * It used to be on declared requirements (`resource_gathering`) — "same granularity as
+ * `solved_by_project_id`, and one query instead of one plan derivation per project". That
+ * granularity broke down completely for imported schematics, where every declared row is a
+ * finished *placed block* and the raw materials exist only in the derived plan. On the YAMS
+ * import:
+ *
+ * | Farm produces  | Declared row | Real plan demand | Edge before |
+ * | -------------- | -----------: | ---------------: | ----------- |
+ * | `cobblestone`  |            1 |           74,564 | yes — for 1 |
+ * | `sand`         |            4 |           52,434 | yes — for 4 |
+ * | `gold_nugget`  |            0 |            7,299 | **none**    |
+ *
+ * So the Cobblestone Generator appeared as supplying one decorative cobblestone while covering
+ * the single largest line of gathering work, and the Gold Farm produced no edge at all. The
+ * edges that did exist were accidents of decoration.
+ *
+ * The cost objection still stands, which is why this reads `project_demand` — the plan's own
+ * output, materialised when the project's plan was last derived (see `ProjectDemandStore`) —
+ * rather than deriving a plan per project here. A project nobody has planned yet contributes
+ * no rows and therefore no edges; the roadmap says how many those are rather than quietly
+ * drawing a thinner graph.
  */
 data class GetFarmSupplyEdgesStep(val worldId: Int) : Step<Unit, AppFailure.DatabaseError, List<ProjectResourceEdge>> {
     override suspend fun process(input: Unit): Result<AppFailure.DatabaseError, List<ProjectResourceEdge>> {
         return DatabaseSteps.query<Unit, List<ProjectResourceEdge>>(
             sql = SafeSQL.select("""
-                SELECT DISTINCT
-                  rg.project_id  AS consumer_id,
+                SELECT
+                  d.project_id   AS consumer_id,
                   pc.name        AS consumer_name,
                   pc.state       AS consumer_state,
                   pp.project_id  AS producer_id,
                   prod.name      AS producer_name,
-                  rg.name        AS item_name,
+                  d.item_name    AS item_name,
+                  d.quantity     AS quantity,
                   prod.state     AS producer_state
-                FROM resource_gathering rg
-                JOIN projects pc         ON pc.id = rg.project_id
-                JOIN project_productions pp ON pp.item_id = rg.item_id
-                JOIN projects prod       ON prod.id = pp.project_id
+                FROM project_demand d
+                JOIN projects pc            ON pc.id = d.project_id
+                JOIN project_productions pp ON pp.item_id = d.item_id
+                JOIN projects prod          ON prod.id = pp.project_id
                 WHERE pc.world_id = ?
                   AND prod.world_id = ?
-                  AND prod.id <> rg.project_id
-                  AND rg.ignored = FALSE
+                  AND prod.id <> d.project_id
                   AND prod.state NOT IN (?, ?)
                   -- An explicitly solved requirement already produces an edge via
                   -- GetProjectEdgesStep; deriving a second one would double-count it.
-                  AND rg.solved_by_project_id IS NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM resource_gathering rg
+                      WHERE rg.project_id = d.project_id
+                        AND rg.item_id = d.item_id
+                        AND rg.solved_by_project_id IS NOT NULL
+                  )
             """.trimIndent()),
             parameterSetter = { statement, _ ->
                 statement.setInt(1, worldId)
@@ -68,6 +93,7 @@ data class GetFarmSupplyEdgesStep(val worldId: Int) : Step<Unit, AppFailure.Data
                                 producerName = resultSet.getString("producer_name"),
                                 itemName = resultSet.getString("item_name"),
                                 producerState = ProjectState.valueOf(resultSet.getString("producer_state")),
+                                quantity = resultSet.getLong("quantity"),
                             )
                         )
                     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GenerateGatheringPlanStep.kt
@@ -16,6 +16,7 @@ import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.minecraft.GetItemSourceGraphForVersionStep
 import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
+import org.slf4j.LoggerFactory
 
 /**
  * Input bundle for [GenerateGatheringPlanStep].
@@ -137,6 +138,52 @@ object GenerateGatheringPlanStep : Step<GatheringPlanInput, AppFailure, Gatherin
         }
 
         // 8. Run the engine
-        return Result.success(GatheringPlanner.plan(graph, targets, supplied, overrides))
+        val plan = GatheringPlanner.plan(graph, targets, supplied, overrides)
+
+        // 9. Materialise the demand this plan implies (MCO-316), so the roadmap can match farms
+        // against what the build actually consumes without deriving a plan per project. Written
+        // here because this is the one place a plan already exists; skipped when nothing that
+        // feeds the derivation has changed since the last write.
+        storeDemand(input.projectId, versionString, activeItems, supplied, overrides, plan)
+
+        return Result.success(plan)
     }
+
+    /**
+     * Write-through of the derived demand. Deliberately best-effort.
+     *
+     * [project_demand] is a cache of something recomputable, and this runs on a read path — a
+     * page that renders a plan should not fail because a cache write did. A failure leaves the
+     * previous rows in place with their old fingerprint, so the next derivation retries.
+     */
+    private suspend fun storeDemand(
+        projectId: Int,
+        worldVersion: String,
+        activeItems: List<ResourceGatheringItem>,
+        supplied: Map<String, SupplySource>,
+        overrides: PlanOverrides,
+        plan: GatheringPlan,
+    ) {
+        val fingerprint = DemandFingerprint.of(
+            worldVersion = worldVersion,
+            targets = activeItems.map {
+                Triple(it.itemId, (it.required - it.collected).toLong(), it.sourceType?.name)
+            },
+            supplied = supplied.mapValues { (_, source) -> source.toString() },
+            overrides = overrides.sourceByItem.map { "src:${it.key}" to it.value } +
+                overrides.tagMember.map { "tag:${it.key}" to it.value },
+        )
+
+        val stored = GetStoredDemandFingerprintStep(projectId).process(Unit)
+        if (stored is Result.Success && stored.value == fingerprint) return
+
+        val saved = SaveProjectDemandStep(projectId, fingerprint).process(plan)
+        if (saved is Result.Failure) {
+            // No exception and no row data in the message: a PostgreSQL error appends
+            // `DETAIL: Key (col)=(value)`, which is user content. See documentation/logging.md.
+            logger.warn("Could not store derived demand for project {}", projectId)
+        }
+    }
+
+    private val logger = LoggerFactory.getLogger(GenerateGatheringPlanStep::class.java)
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/ProjectDemandStore.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/ProjectDemandStore.kt
@@ -1,0 +1,218 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.project.ProjectDemand
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+import java.security.MessageDigest
+
+/**
+ * The materialised per-project demand view (MCO-316) — writing it, and knowing when it is stale.
+ *
+ * Reading it is [GetWorldDemandStep]. The two halves are split because they run on different
+ * pages: demand is *written* wherever a plan gets derived anyway (the project page), and *read*
+ * by the roadmap, which must not derive a plan per project to draw a table.
+ */
+
+/** What a project's demand was derived from, hashed. Cheap to recompute; the planner is not. */
+data class DemandFingerprint(val value: String) {
+    companion object {
+        /**
+         * Hashes every input [GenerateGatheringPlanStep] reads.
+         *
+         * Order is normalised so two runs over the same state agree. The world's farm supply is
+         * in here as well as the project's own rows, which means marking any farm DONE
+         * invalidates every other project's stored demand — correct, since that is exactly when
+         * their chains stop expanding past the supplied item.
+         */
+        fun of(
+            worldVersion: String,
+            targets: List<Triple<String, Long, String?>>,
+            supplied: Map<String, String>,
+            overrides: List<Pair<String, String>>,
+        ): DemandFingerprint {
+            val payload = buildString {
+                append("v1|").append(worldVersion).append('\n')
+                targets.sortedBy { it.first }.forEach { (id, amount, source) ->
+                    append(id).append('=').append(amount).append(':').append(source ?: "-").append('\n')
+                }
+                supplied.entries.sortedBy { it.key }.forEach { (id, label) ->
+                    append('s').append(id).append('=').append(label).append('\n')
+                }
+                overrides.sortedBy { it.first }.forEach { (key, value) ->
+                    append('o').append(key).append('=').append(value).append('\n')
+                }
+            }
+            val digest = MessageDigest.getInstance("SHA-256").digest(payload.toByteArray())
+            return DemandFingerprint(digest.joinToString("") { "%02x".format(it) })
+        }
+    }
+}
+
+/** The fingerprint stored against a project, or null when nothing has been derived yet. */
+data class GetStoredDemandFingerprintStep(val projectId: Int) :
+    Step<Unit, AppFailure.DatabaseError, DemandFingerprint?> {
+    override suspend fun process(input: Unit): Result<AppFailure.DatabaseError, DemandFingerprint?> =
+        DatabaseSteps.query<Unit, DemandFingerprint?>(
+            sql = SafeSQL.select("SELECT fingerprint FROM project_demand_state WHERE project_id = ?"),
+            parameterSetter = { statement, _ -> statement.setInt(1, projectId) },
+            resultMapper = { if (it.next()) DemandFingerprint(it.getString("fingerprint")) else null },
+        ).process(Unit)
+}
+
+/**
+ * Replaces a project's stored demand with what the plan just derived.
+ *
+ * Delete-then-insert rather than upsert: an item that has left the plan entirely must leave the
+ * table with it, and a diff would have to find those anyway. The whole thing is one transaction,
+ * so a reader never sees a half-written project.
+ *
+ * Every activity is stored, tags included. A tag can never match a production row — you cannot
+ * produce `#minecraft:planks` — but filtering here would make the table a view of one consumer's
+ * needs rather than the derivation itself, and MCO-401 wants a different slice of it.
+ */
+data class SaveProjectDemandStep(
+    val projectId: Int,
+    val fingerprint: DemandFingerprint,
+) : Step<GatheringPlan, AppFailure.DatabaseError, Unit> {
+
+    override suspend fun process(input: GatheringPlan): Result<AppFailure.DatabaseError, Unit> {
+        val rows = input.activityList.map { activity ->
+            ProjectDemand(
+                projectId = projectId,
+                itemId = activity.item.id,
+                itemName = activity.item.name,
+                quantity = activity.quantity,
+                group = activity.group.name,
+                status = activity.status.name,
+            )
+        }
+
+        return DatabaseSteps.transaction { connection ->
+            object : Step<List<ProjectDemand>, AppFailure.DatabaseError, Unit> {
+                override suspend fun process(
+                    input: List<ProjectDemand>,
+                ): Result<AppFailure.DatabaseError, Unit> {
+                    val cleared = DatabaseSteps.update<List<ProjectDemand>>(
+                        sql = SafeSQL.delete("DELETE FROM project_demand WHERE project_id = ?"),
+                        parameterSetter = { statement, _ -> statement.setInt(1, projectId) },
+                        transactionConnection = connection,
+                    ).process(input)
+                    if (cleared is Result.Failure) return Result.Failure(cleared.error)
+
+                    val inserted = DatabaseSteps.batchUpdate<ProjectDemand>(
+                        SafeSQL.insert(
+                            """
+                            INSERT INTO project_demand
+                                (project_id, item_id, item_name, quantity, activity_group, node_status)
+                            VALUES (?, ?, ?, ?, ?, ?)
+                            """.trimIndent()
+                        ),
+                        parameterSetter = { statement, row ->
+                            statement.setInt(1, row.projectId)
+                            statement.setString(2, row.itemId)
+                            statement.setString(3, row.itemName)
+                            statement.setLong(4, row.quantity)
+                            statement.setString(5, row.group)
+                            statement.setString(6, row.status)
+                        },
+                        transactionConnection = connection,
+                    ).process(input)
+                    if (inserted is Result.Failure) return Result.Failure(inserted.error)
+
+                    val stamped = DatabaseSteps.update<List<ProjectDemand>>(
+                        sql = SafeSQL.insert(
+                            """
+                            INSERT INTO project_demand_state (project_id, fingerprint, derived_at)
+                            VALUES (?, ?, now())
+                            ON CONFLICT (project_id)
+                            DO UPDATE SET fingerprint = EXCLUDED.fingerprint, derived_at = EXCLUDED.derived_at
+                            """.trimIndent()
+                        ),
+                        parameterSetter = { statement, _ ->
+                            statement.setInt(1, projectId)
+                            statement.setString(2, fingerprint.value)
+                        },
+                        transactionConnection = connection,
+                    ).process(input)
+                    if (stamped is Result.Failure) return Result.Failure(stamped.error)
+
+                    return Result.success(Unit)
+                }
+            }
+        }.process(rows)
+    }
+}
+
+/**
+ * Every project's stored demand for one world, for the roadmap.
+ *
+ * Projects whose demand has never been derived simply have no rows. That is visible rather than
+ * wrong: the roadmap draws the edges it can prove, and opening the project derives and stores
+ * the rest. See [GetWorldDemandCoverageStep] for what the screen can say about the gap.
+ */
+data class GetWorldDemandStep(val worldId: Int) :
+    Step<Unit, AppFailure.DatabaseError, List<ProjectDemand>> {
+    override suspend fun process(input: Unit): Result<AppFailure.DatabaseError, List<ProjectDemand>> =
+        DatabaseSteps.query<Unit, List<ProjectDemand>>(
+            sql = SafeSQL.select(
+                """
+                SELECT d.project_id, d.item_id, d.item_name, d.quantity, d.activity_group, d.node_status
+                FROM project_demand d
+                JOIN projects p ON p.id = d.project_id
+                WHERE p.world_id = ?
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ -> statement.setInt(1, worldId) },
+            resultMapper = { resultSet ->
+                buildList {
+                    while (resultSet.next()) {
+                        add(
+                            ProjectDemand(
+                                projectId = resultSet.getInt("project_id"),
+                                itemId = resultSet.getString("item_id"),
+                                itemName = resultSet.getString("item_name"),
+                                quantity = resultSet.getLong("quantity"),
+                                group = resultSet.getString("activity_group"),
+                                status = resultSet.getString("node_status"),
+                            )
+                        )
+                    }
+                }
+            },
+        ).process(Unit)
+}
+
+/**
+ * Which projects in a world have no derived demand stored yet.
+ *
+ * The roadmap uses this to say so rather than quietly drawing a thinner graph — "3 projects have
+ * not been planned yet" is a fact the user can act on, where a missing edge is one they cannot
+ * see. Projects with nothing to gather at all are excluded: they are not waiting on a
+ * derivation, they simply have no requirements.
+ */
+data class GetWorldDemandCoverageStep(val worldId: Int) :
+    Step<Unit, AppFailure.DatabaseError, List<Int>> {
+    override suspend fun process(input: Unit): Result<AppFailure.DatabaseError, List<Int>> =
+        DatabaseSteps.query<Unit, List<Int>>(
+            sql = SafeSQL.select(
+                """
+                SELECT p.id
+                FROM projects p
+                WHERE p.world_id = ?
+                  AND EXISTS (SELECT 1 FROM resource_gathering rg
+                              WHERE rg.project_id = p.id AND rg.ignored = FALSE)
+                  AND NOT EXISTS (SELECT 1 FROM project_demand_state s WHERE s.project_id = p.id)
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ -> statement.setInt(1, worldId) },
+            resultMapper = { resultSet ->
+                buildList {
+                    while (resultSet.next()) add(resultSet.getInt("id"))
+                }
+            },
+        ).process(Unit)
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/roadmap/GetWorldRoadMapStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/roadmap/GetWorldRoadMapStep.kt
@@ -15,6 +15,9 @@ import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.project.commonsteps.GetFarmSupplyEdgesStep
 import app.mcorg.pipeline.project.commonsteps.GetProjectEdgesStep
+import app.mcorg.pipeline.resources.GatheringPlanInput
+import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
+import app.mcorg.pipeline.resources.GetWorldDemandCoverageStep
 import java.sql.ResultSet
 
 /**
@@ -48,6 +51,13 @@ data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadma
             is Result.Failure -> return r
         }
 
+        // Farm edges read materialised demand (MCO-316), which is written wherever a plan is
+        // derived — the project page. A project nobody has opened has none, and would silently
+        // contribute no edges at all, which is the opposite of "import a build and the roadmap
+        // assembles itself". So derive the missing ones here, once each: the write-through in
+        // GenerateGatheringPlanStep means the next load finds them stored.
+        fillMissingDemand()
+
         val declaredEdges = when (val r = GetProjectEdgesStep(worldId).process(Unit)) {
             is Result.Success -> r.value
             is Result.Failure -> return r
@@ -64,6 +74,28 @@ data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadma
             .distinctBy { Triple(it.consumerId, it.producerId, it.itemName) }
 
         return Result.success(buildRoadmap(worldName, projects, edges))
+    }
+
+    /**
+     * Derives and stores demand for projects that have none yet.
+     *
+     * Bounded and self-healing: each project costs one derivation *once*, after which the
+     * write-through keeps it current. A world where every project has been opened does no work
+     * here at all.
+     *
+     * Failures are swallowed on purpose, per project. A project can legitimately have no plan —
+     * everything already collected, or a world whose Minecraft version was never ingested, which
+     * is the normal state in tests — and none of that should stop the roadmap rendering. The
+     * consequence is a missing edge, not a wrong one.
+     */
+    private suspend fun fillMissingDemand() {
+        val uncovered = when (val r = GetWorldDemandCoverageStep(worldId).process(Unit)) {
+            is Result.Success -> r.value
+            is Result.Failure -> return
+        }
+        uncovered.forEach { projectId ->
+            GenerateGatheringPlanStep.process(GatheringPlanInput(projectId = projectId, worldId = worldId))
+        }
     }
 
     private suspend fun getWorldName(): Result<AppFailure.DatabaseError, String?> =
@@ -133,6 +165,7 @@ data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadma
                 toNodeName = edge.producerName,
                 isBlocking = edge.isBlocking,
                 itemName = edge.itemName,
+                quantity = edge.quantity,
             )
         }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/RoadmapPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/RoadmapPage.kt
@@ -187,6 +187,8 @@ private data class RoadmapEdgeEntry(
     val itemName: String?,
     val isResourceEdge: Boolean,
     val isBlocking: Boolean,
+    /** Derived plan demand (MCO-316); null when the edge carries no number. */
+    val quantity: Long? = null,
 )
 
 /**
@@ -205,6 +207,7 @@ private fun FlowContent.dependsOnCell(worldId: Int, edges: List<RoadmapEdge>) {
                 itemName = edge.itemName,
                 isResourceEdge = edge.itemName != null,
                 isBlocking = edge.isBlocking,
+                quantity = edge.quantity,
             )
         }
     )
@@ -259,7 +262,11 @@ private fun FlowContent.roadmapEdgeCell(worldId: Int, entries: List<RoadmapEdgeE
                         +entry.projectName
                     }
                     entry.itemName?.let { item ->
-                        span("roadmap-edge__item") { +" — $item" }
+                        // MCO-316 — first pass, deliberately the plainest thing that stops the
+                        // cell misleading. "Cobblestone Generator — 74,564 Cobblestone" instead
+                        // of a bare item name that used to sit next to a single decorative block.
+                        val amount = entry.quantity?.let { "${"%,d".format(it)} " } ?: ""
+                        span("roadmap-edge__item") { +" — $amount$item" }
                     }
                     span("roadmap-edge__status") { +entry.statusLabel() }
                 }

--- a/webapp/mc-web/src/main/resources/db/migration/V2_54_0__add_project_demand.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_54_0__add_project_demand.sql
@@ -1,0 +1,45 @@
+-- MCO-316: per-project derived demand, materialised.
+--
+-- Farm supply edges used to match a producer's project_productions against the consumer's
+-- *declared* resource_gathering rows. For an imported schematic every declared row is a
+-- finished placed block, so the raw materials the build actually consumes exist only in the
+-- derived plan. On the YAMS import that meant the Cobblestone Generator showed as supplying
+-- one decorative cobblestone against 74,564 of real demand, and the Gold Farm — 7,299 units
+-- of real demand — produced no edge at all, purely because no literal gold nugget is placed.
+--
+-- Deriving a plan per project on every roadmap load is what the original design avoided, so
+-- the derivation is stored instead: written whenever a plan is derived anyway (the project
+-- page), read by the roadmap. project_demand_state carries a fingerprint of the plan's inputs
+-- so a stored row set can be recognised as stale without re-running the planner.
+--
+-- This is a cache, not a source of truth: everything here is recomputable from
+-- resource_gathering + productions + overrides + the version's item graph.
+
+CREATE TABLE project_demand
+(
+    project_id     INT    NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    -- May be a tag id ("#minecraft:planks") as well as an item id. Tags never match a
+    -- production row, which is correct — you cannot produce a tag — but they are stored so
+    -- the table is the whole derived demand rather than a filtered view of it.
+    item_id        TEXT   NOT NULL,
+    item_name      TEXT   NOT NULL,
+    quantity       BIGINT NOT NULL,
+    -- ActivityGroup and PlanNodeStatus as written by the engine. Consumers filter on these:
+    -- farm edges want anything a project produces, MCO-401's farm-scale marker wants
+    -- RAW_GATHER only.
+    activity_group TEXT   NOT NULL,
+    node_status    TEXT   NOT NULL,
+    PRIMARY KEY (project_id, item_id)
+);
+
+-- The roadmap's lookup direction: "who demands this produced item?"
+CREATE INDEX project_demand_item_id_idx ON project_demand (item_id);
+
+CREATE TABLE project_demand_state
+(
+    project_id  INT PRIMARY KEY REFERENCES projects (id) ON DELETE CASCADE,
+    -- Hash of everything the derivation reads. Recomputing it is cheap; re-running the
+    -- planner is not, so this is what decides whether stored demand can be trusted.
+    fingerprint TEXT        NOT NULL,
+    derived_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/webapp/mc-web/src/main/resources/db/migration/V2_55_0__normalise_production_item_ids.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_55_0__normalise_production_item_ids.sql
@@ -1,0 +1,70 @@
+-- MCO-316: normalise legacy project_productions.item_id to namespaced item ids.
+--
+-- project_productions was written back when produced items were picked out of the Minecraft
+-- language file, so its item_id holds a *translation key* — "block.minecraft.cobblestone".
+-- Everything else in the schema uses the namespaced id — "minecraft:cobblestone" — including
+-- minecraft_items, resource_gathering and project_demand. The two never join.
+--
+-- The consequence was silent and total: farm supply matched nothing. Not "matched the wrong
+-- quantity" (MCO-316's premise) but zero rows, in both directions —
+--
+--   * GetFarmSupplyEdgesStep produced no roadmap edge for any real farm; and
+--   * GetWorldFarmSuppliesStep fed translation keys into the planner as supply, where they
+--     match no node in the item graph, so every operational farm supplied nothing to every
+--     gathering plan.
+--
+-- On the dev world that is 104 rows across 23 projects, and 20-odd DONE farms contributing
+-- nothing to a 500,000-item build plan.
+--
+-- The write path has since been fixed on its own: RecordExistingFarmPipeline resolves the
+-- submitted id against the item catalog and stores item.id, so only pre-existing rows carry
+-- the old shape and no new ones can appear. This is a one-time data repair.
+
+UPDATE project_productions pp
+SET item_id    = 'minecraft:' || regexp_replace(pp.item_id, '^(block|item)\.minecraft\.', ''),
+    updated_at = CURRENT_TIMESTAMP
+WHERE pp.item_id ~ '^(block|item)\.minecraft\.[a-z0-9_]+$'
+  -- Stripping the prefix is not a safe mapping on its own: a translation key is not an item
+  -- id, and for a good number of items the two simply differ (block.minecraft.grass is
+  -- minecraft:short_grass). The danger is not the rewrite that lands nowhere — it is the one
+  -- that lands on a real but *different* item. So each rewrite must satisfy both halves:
+  --
+  --   1. the id exists in the catalog *for the version this project's world plans against*, and
+  --   2. the display name the lang file gave this row still matches the catalog's name for it.
+  --
+  -- Two independent sources agreeing on the same item is what makes the mapping evidence rather
+  -- than a guess. Both halves are load-bearing. Existence alone passes block.minecraft.grass →
+  -- minecraft:grass, a real id that has meant nothing since 1.20.3 (the block is short_grass
+  -- now) and would leave a farm supplying an item no current plan can consume — which is the
+  -- version scope. And an id can be current while the row means something else — which is the
+  -- name check. Anything failing either half keeps its old value: no worse than today, and
+  -- re-pickable in the farm's own UI. That is where rows with further dotted segments land
+  -- ("item.minecraft.potion.effect.healing" — a healing potion is minecraft:potion plus a
+  -- component, so it has no id of its own to normalise to).
+  AND EXISTS (SELECT 1
+              FROM minecraft_items mi
+                       JOIN projects proj ON proj.id = pp.project_id
+                       JOIN world w ON w.id = proj.world_id
+              WHERE mi.item_id = 'minecraft:' || regexp_replace(pp.item_id, '^(block|item)\.minecraft\.', '')
+                AND mi.version = w.version
+                -- Catalog names carry a " (Block)" / " (Item)" disambiguator the lang name has not.
+                AND lower(regexp_replace(mi.item_name, ' \((Block|Item)\)$', '')) = lower(pp.name))
+  -- (project_id, item_id) is unique. If a project somehow holds both shapes of the same item,
+  -- keep the row that is already correct rather than failing the migration.
+  AND NOT EXISTS (SELECT 1
+                  FROM project_productions other
+                  WHERE other.project_id = pp.project_id
+                    AND other.item_id = 'minecraft:' || regexp_replace(pp.item_id, '^(block|item)\.minecraft\.', ''));
+
+-- Stored demand must be discarded. The supplied map is keyed by these very item ids and is one
+-- of the fingerprinted inputs, so every plan derived before this migration was derived against
+-- an empty supply set: chains ran past items a farm already covers, and the raw inputs of those
+-- items are in project_demand as demand that does not exist.
+--
+-- The fingerprint alone does not rescue this. It is checked where a plan is *written* (the
+-- project page), not where demand is *read* (the roadmap), and the roadmap only derives for
+-- projects that have no rows at all — so a project with stale rows would keep serving them
+-- until someone happened to open it. Clearing both tables puts every affected project back in
+-- "uncovered", which the roadmap's fill-on-read then re-derives once, correctly.
+DELETE FROM project_demand;
+DELETE FROM project_demand_state;

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/DemandFingerprintTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/DemandFingerprintTest.kt
@@ -1,0 +1,90 @@
+package app.mcorg.pipeline.resources
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * MCO-316 — what decides whether stored demand can be trusted.
+ *
+ * The fingerprint is the whole reason the materialised view is safe to read: re-running the
+ * planner is expensive, hashing its inputs is not. A fingerprint that missed an input would
+ * serve stale demand forever; one that changed spuriously would re-derive on every page load.
+ */
+class DemandFingerprintTest {
+
+    private fun fingerprint(
+        version: String = "1.21.4",
+        targets: List<Triple<String, Long, String?>> = listOf(Triple("minecraft:hopper", 5630L, null)),
+        supplied: Map<String, String> = emptyMap(),
+        overrides: List<Pair<String, String>> = emptyList(),
+    ) = DemandFingerprint.of(version, targets, supplied, overrides)
+
+    @Test
+    fun `the same inputs give the same fingerprint`() {
+        assertEquals(fingerprint(), fingerprint())
+    }
+
+    @Test
+    fun `input order does not matter`() {
+        // The targets arrive from a query with no ORDER BY, so two loads of unchanged data must
+        // not look like a change.
+        val a = fingerprint(
+            targets = listOf(Triple("minecraft:hopper", 5630L, null), Triple("minecraft:chest", 128L, null)),
+        )
+        val b = fingerprint(
+            targets = listOf(Triple("minecraft:chest", 128L, null), Triple("minecraft:hopper", 5630L, null)),
+        )
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `a changed quantity changes the fingerprint`() {
+        assertNotEquals(
+            fingerprint(targets = listOf(Triple("minecraft:hopper", 5630L, null))),
+            fingerprint(targets = listOf(Triple("minecraft:hopper", 5631L, null))),
+        )
+    }
+
+    @Test
+    fun `an added target changes the fingerprint`() {
+        assertNotEquals(
+            fingerprint(),
+            fingerprint(
+                targets = listOf(Triple("minecraft:hopper", 5630L, null), Triple("minecraft:chest", 1L, null)),
+            ),
+        )
+    }
+
+    @Test
+    fun `a farm coming online changes the fingerprint`() {
+        // The case that makes this more than a per-project hash: marking a farm DONE stops every
+        // other project's chain expanding past the item it supplies, so their stored demand is
+        // stale even though nothing about those projects changed.
+        assertNotEquals(
+            fingerprint(supplied = emptyMap()),
+            fingerprint(supplied = mapOf("minecraft:iron_ingot" to "Farm(Iron Farm)")),
+        )
+    }
+
+    @Test
+    fun `a source pin changes the fingerprint`() {
+        assertNotEquals(
+            fingerprint(),
+            fingerprint(overrides = listOf("src:minecraft:iron_ingot" to "smelting")),
+        )
+    }
+
+    @Test
+    fun `a new Minecraft version changes the fingerprint`() {
+        // The item-source graph is version-keyed, so the same targets can plan differently.
+        assertNotEquals(fingerprint(version = "1.21.4"), fingerprint(version = "1.21.5"))
+    }
+
+    @Test
+    fun `the fingerprint is a fixed-length hex digest`() {
+        val value = fingerprint().value
+        assertEquals(64, value.length)
+        assertEquals(true, value.all { it in "0123456789abcdef" })
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/world/roadmap/GetWorldRoadMapStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/world/roadmap/GetWorldRoadMapStepTest.kt
@@ -388,6 +388,7 @@ class GetWorldRoadMapStepTest : WithUser() {
         val consumer = createTestProject(worldId, "Beacon", ProjectType.BUILDING, ProjectStage.PLANNING)
         val farm = createTestProject(worldId, "Iron Farm", ProjectType.FARMING, ProjectStage.BUILDING)
         createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot", 32)
+        createDemand(consumer, "minecraft:iron_ingot", "Iron Ingot", 32)
         createProduction(farm, "minecraft:iron_ingot", "Iron Ingot")
 
         val roadmap = (GetWorldRoadMapStep(worldId).process(Unit) as Result.Success).value
@@ -395,6 +396,7 @@ class GetWorldRoadMapStepTest : WithUser() {
         val edge = roadmap.edges.single()
         assertEquals(farm, edge.toNodeId)
         assertEquals("Iron Ingot", edge.itemName)
+        assertEquals(32L, edge.quantity, "the edge carries the derived demand (MCO-316)")
         assertTrue(edge.isBlocking, "a farm that is not running yet still blocks")
 
         deleteTestWorld(worldId)
@@ -406,6 +408,7 @@ class GetWorldRoadMapStepTest : WithUser() {
         val consumer = createTestProject(worldId, "Beacon", ProjectType.BUILDING, ProjectStage.PLANNING)
         val farm = createTestProject(worldId, "Iron Farm", ProjectType.FARMING, ProjectStage.COMPLETED)
         createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot", 32)
+        createDemand(consumer, "minecraft:iron_ingot", "Iron Ingot", 32)
         createProduction(farm, "minecraft:iron_ingot", "Iron Ingot")
 
         val roadmap = (GetWorldRoadMapStep(worldId).process(Unit) as Result.Success).value
@@ -505,6 +508,38 @@ class GetWorldRoadMapStepTest : WithUser() {
         DatabaseSteps.update<Unit>(
             SafeSQL.update("UPDATE resource_gathering SET ignored = TRUE WHERE id = ?"),
             parameterSetter = { statement, _ -> statement.setInt(1, requirementId) }
+        ).process(Unit)
+    }
+
+    /**
+     * Seeds derived plan demand (MCO-316) — what farm edges now match, in place of the declared
+     * `resource_gathering` rows they used to. Deriving it for real needs an ingested
+     * item-source graph, which these tests do not have; the derivation is covered where it lives.
+     */
+    private fun createDemand(projectId: Int, itemId: String, name: String, quantity: Long) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                """
+                INSERT INTO project_demand
+                    (project_id, item_id, item_name, quantity, activity_group, node_status)
+                VALUES (?, ?, ?, ?, 'GATHER', 'RESOLVED')
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ ->
+                statement.setInt(1, projectId)
+                statement.setString(2, itemId)
+                statement.setString(3, name)
+                statement.setLong(4, quantity)
+            }
+        ).process(Unit)
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                """
+                INSERT INTO project_demand_state (project_id, fingerprint)
+                VALUES (?, 'seeded') ON CONFLICT (project_id) DO NOTHING
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ -> statement.setInt(1, projectId) }
         ).process(Unit)
     }
 

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/WorldRoadmapIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/WorldRoadmapIT.kt
@@ -53,6 +53,7 @@ class WorldRoadmapIT : WithUser() {
         val consumer = createProject(worldId, "Beacon Build")
         val farm = createProject(worldId, "Iron Farm")
         createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot")
+        createDemand(consumer, "minecraft:iron_ingot", "Iron Ingot", 32)
         createProduction(farm, "minecraft:iron_ingot", "Iron Ingot")
 
         val response = client.get("/worlds/$worldId/roadmap") { addAuthCookie(this) }
@@ -85,6 +86,7 @@ class WorldRoadmapIT : WithUser() {
         val consumer = createProject(worldId, "Beacon Build")
         val farm = createProject(worldId, "Iron Farm")
         createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot")
+        createDemand(consumer, "minecraft:iron_ingot", "Iron Ingot", 32)
         createProduction(farm, "minecraft:iron_ingot", "Iron Ingot")
         runBlocking { UpdateProjectStageStep(farm).process(ProjectStage.COMPLETED) }
 
@@ -107,6 +109,71 @@ class WorldRoadmapIT : WithUser() {
         assertContains(farmRow.supplies, "Beacon Build")
         assertContains(farmRow.supplies, STATUS_SUPPLYING)
         assertFalse(farmRow.supplies.contains(STATUS_BLOCKING), "a DONE farm blocks nothing")
+
+        deleteWorld(worldId)
+    }
+
+    @Test
+    fun `a farm supplying a material the build never places still gets an edge`() = testApplication {
+        // MCO-316's headline case, from the YAMS import. The build declares 5,630 hoppers and
+        // places no literal gold nugget, so matching declared rows found nothing and the Gold
+        // Farm — 7,299 units of real demand — produced no edge whatsoever. Matching derived
+        // demand finds it.
+        setupRoutes()
+        val worldId = createWorld("Derived Demand World")
+        val consumer = createProject(worldId, "YAMS")
+        val farm = createProject(worldId, "Gold Farm")
+        createRequirement(consumer, "minecraft:hopper", "Hopper")
+        createDemand(consumer, "minecraft:gold_nugget", "Gold Nugget", 7299)
+        createProduction(farm, "minecraft:gold_nugget", "Gold Nugget")
+
+        val body = client.get("/worlds/$worldId/roadmap") { addAuthCookie(this) }.bodyAsText()
+
+        val consumerRow = roadmapRow(body, "YAMS")
+        assertContains(consumerRow.dependsOn, "Gold Farm")
+        assertContains(consumerRow.dependsOn, "Gold Nugget")
+
+        deleteWorld(worldId)
+    }
+
+    @Test
+    fun `the edge says how much of the demand the farm covers`() = testApplication {
+        // "Cobblestone Generator — Cobblestone" next to a single decorative block was the
+        // misleading half of the same bug: the farm covered the largest line of gathering work
+        // in the project and the cell gave no way to tell.
+        setupRoutes()
+        val worldId = createWorld("Quantified Roadmap World")
+        val consumer = createProject(worldId, "YAMS")
+        val farm = createProject(worldId, "Cobblestone Generator")
+        createRequirement(consumer, "minecraft:cobblestone", "Cobblestone")
+        createDemand(consumer, "minecraft:cobblestone", "Cobblestone", 74564)
+        createProduction(farm, "minecraft:cobblestone", "Cobblestone")
+
+        val body = client.get("/worlds/$worldId/roadmap") { addAuthCookie(this) }.bodyAsText()
+
+        val consumerRow = roadmapRow(body, "YAMS")
+        assertContains(consumerRow.dependsOn, "74,564 Cobblestone")
+
+        deleteWorld(worldId)
+    }
+
+    @Test
+    fun `a project with no derived demand contributes no farm edges`() = testApplication {
+        // The honest consequence of matching derived demand: a project nobody has planned has
+        // nothing to match. The roadmap tries to fill it in (see GetWorldRoadMapStep), which
+        // needs an ingested graph these tests do not have — so here it stays empty rather than
+        // inventing an edge from the declared row.
+        setupRoutes()
+        val worldId = createWorld("Unplanned Roadmap World")
+        val consumer = createProject(worldId, "Unopened Build")
+        val farm = createProject(worldId, "Iron Farm")
+        createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot")
+        createProduction(farm, "minecraft:iron_ingot", "Iron Ingot")
+
+        val body = client.get("/worlds/$worldId/roadmap") { addAuthCookie(this) }.bodyAsText()
+
+        val consumerRow = roadmapRow(body, "Unopened Build")
+        assertFalse(consumerRow.dependsOn.contains("Iron Farm"))
 
         deleteWorld(worldId)
     }
@@ -228,6 +295,43 @@ class WorldRoadmapIT : WithUser() {
                 stmt.setString(2, itemId)
                 stmt.setString(3, name)
             }
+        ).process(Unit)
+    }
+
+    /**
+     * Seeds derived plan demand directly (MCO-316).
+     *
+     * Farm edges match this rather than `resource_gathering`, and deriving it for real needs an
+     * ingested item-source graph that these tests deliberately do not have. Seeding keeps the
+     * roadmap's own logic under test instead of the engine's — the derivation itself is covered
+     * where it lives.
+     */
+    private fun createDemand(projectId: Int, itemId: String, name: String, quantity: Long) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                """
+                INSERT INTO project_demand
+                    (project_id, item_id, item_name, quantity, activity_group, node_status)
+                VALUES (?, ?, ?, ?, 'GATHER', 'RESOLVED')
+                """.trimIndent()
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+                stmt.setString(3, name)
+                stmt.setLong(4, quantity)
+            }
+        ).process(Unit)
+        // Marking it derived stops the roadmap trying to fill this project in.
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                """
+                INSERT INTO project_demand_state (project_id, fingerprint)
+                VALUES (?, 'seeded')
+                ON CONFLICT (project_id) DO NOTHING
+                """.trimIndent()
+            ),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, projectId) }
         ).process(Unit)
     }
 


### PR DESCRIPTION
Closes MCO-316 — https://linear.app/evegul/issue/MCO-316/farm-supply-edges-should-match-derived-plan-demand-not-declared

Farm supply edges on the roadmap matched a producer's `project_productions` against the consumer's **declared** `resource_gathering` rows. For an imported schematic every declared row is a finished *placed block*, so the raw materials the build actually consumes exist only in the derived plan:

| Farm produces | Declared row | Real plan demand | Edge before |
| --- | ---: | ---: | --- |
| `cobblestone` | 1 | 74,564 | yes — for 1 |
| `sand` | 4 | 52,434 | yes — for 4 |
| `gold_nugget` | 0 | 7,299 | **none** |

The edges that existed were accidents of decoration.

## Match on derived demand instead

New `project_demand` table holds each project's plan output, written through from `GenerateGatheringPlanStep` — the one place a plan already exists. `GetFarmSupplyEdgesStep` reads it and carries the quantity onto the edge.

The issue's cost objection ("one query instead of one plan derivation per project") is what the table is for; it is a cache, and everything in it is recomputable.

**Staleness** is decided by `DemandFingerprint`: a SHA-256 over version + targets + supply + overrides. Hashing the inputs is cheap, re-planning is not. World supply is deliberately in the hash — marking any farm DONE stops every other project's chains expanding past the item it supplies.

**Fill-on-read**: the roadmap derives demand once for projects that have none. Without it a project you imported but never opened contributes no edges, which inverts the point of the feature. Per-project failures are swallowed — a fully-collected project or an un-ingested world must not stop the roadmap rendering.

## Second commit: the reason none of this worked

`project_productions.item_id` held **translation keys** (`block.minecraft.cobblestone`) from when produced items were picked out of the Minecraft language file. Every other table uses the namespaced id (`minecraft:cobblestone`). The join never matched — 0 rows on the dev world, before and after the change above.

It was silent and total in both directions:

* `GetFarmSupplyEdgesStep` produced no roadmap edge for any real farm; and
* `GetWorldFarmSuppliesStep` fed translation keys into the planner as supply, where they match no node in the item graph — so every operational farm supplied nothing to every gathering plan.

104 rows across 23 projects, ~20 DONE farms contributing nothing to a 500,000-item build. The write path was already fixed independently (`RecordExistingFarmPipeline` resolves against the item catalog), so `V2_55_0` is a one-time repair.

**Stripping the prefix is not a safe mapping**, so each rewrite is corroborated twice: the id must exist in the catalog *for the version its world plans against*, and the lang-file display name must still match the catalog's name. Both halves are load-bearing — existence alone accepts `block.minecraft.grass` → `minecraft:grass`, a real id that has meant nothing since 1.20.3. Rows failing either check keep their old value; one does (`item.minecraft.potion.effect.healing` — a healing potion is `minecraft:potion` plus a component).

Verified against real data: 103 of 104 rewrite, all 103 corroborated by both checks; adversarial rows (stale id, unknown id, mismatched name) all skipped.

Afterwards, world 3's roadmap goes **2 edges → 113**, and YAMS' derived demand drops **682,951 → 584,974** as farm-supplied chains terminate at their leaves.

| Farm | Now covers |
| --- | ---: |
| Cobble farm | 74,557 Cobblestone |
| Witch hut farm | 63,213 Redstone Dust |
| First trading setup | 47,051 Glass |
| Earlygame iron farm | 32,967 Iron Ingot |

## The UI is one line, on purpose

The roadmap cell prints `Cobble farm — 74,557 Cobblestone`. That is the plainest thing that stops the cell misleading; the display is a separate conversation.

## Known gaps, filed not hidden

* **MCO-404** — the fingerprint is checked where demand is *written*, not where the roadmap *reads* it, so a project with stale rows keeps serving them. This is why `V2_55_0` clears `project_demand` outright. Needs a load test before picking an approach.
* **MCO-403** — "Collect from farms" rows on the project page still show no quantity, so the plan page and the roadmap disagree about whether the number is worth showing.
* **MCO-405** — roadmap ordering puts 20 finished farms above the project you are building.

## Tests

836 unit + 437 database, zero failures. New: `DemandFingerprintTest` (8), plus roadmap coverage in `WorldRoadmapIT` and `GetWorldRoadMapStepTest` for the derived-demand path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
