### PR TITLE
Stop the worktree DB prune from deleting live locked worktrees

### DIFF
--- a/webapp/scripts/worktree-db-cleanup.sh
+++ b/webapp/scripts/worktree-db-cleanup.sh
@@ -32,7 +32,12 @@ delete_branch() {
 
 prune() {
   local active nb wt orphans=0
-  active="$(git worktree list | sed -n 's/.*\[\(.*\)\]/\1/p')"
+  # --porcelain, not the human format. `git worktree list` appends annotations *after* the
+  # bracketed branch ("[branch] locked", "[branch] prunable"), which a bracket-stripping sed
+  # leaves on the line — so an exact-line match against the branch name fails and the worktree
+  # reads as an orphan. That deleted a live locked worktree's database once; the porcelain form
+  # emits one "branch refs/heads/<name>" line with nothing appended.
+  active="$(git worktree list --porcelain | sed -n 's|^branch refs/heads/||p')"
   while IFS= read -r nb; do
     [ -z "$nb" ] && continue
     wt="${nb#wt/}"


### PR DESCRIPTION
`worktree-db-cleanup.sh --prune` parsed `git worktree list` with a bracket-stripping sed. That format appends annotations **after** the bracketed branch name:

```
/path/to/wt  1cde82b [worktree-mco-326-epic-c-prod-safety] locked
```

sed replaces only the matched span, so ` locked` stays on the line and the exact-line match (`grep -qxF`) fails. Any **locked** or **prunable** worktree read as an orphan and had its database deleted while still in use.

Not hypothetical — it deleted `wt/worktree-mco-326-epic-c-prod-safety` during a routine prune today. The worktree's commits were safe in git; its Neon branch had to be re-forked.

Fix: `git worktree list --porcelain`, which emits one `branch refs/heads/<name>` line per worktree with nothing appended — annotations are on their own lines, out of reach, rather than being parsed around.

Verified against a tree containing a locked worktree:

| | extraction |
| --- | --- |
| before | `worktree-mco-326-epic-c-prod-safety locked` |
| after | `worktree-mco-326-epic-c-prod-safety` |

and the prune then classifies it KEEP, while a genuinely dead branch still classifies as prune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)