### PR TITLE
MCO-401: mark bulk raw demand as farm-worthy against a world threshold

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/world/World.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/world/World.kt
@@ -13,5 +13,15 @@ data class World(
     val createdAt: ZonedDateTime,
     val updatedAt: ZonedDateTime,
     val pinned: Boolean = false,
-    val lastOpenedAt: ZonedDateTime? = null
-)
+    val lastOpenedAt: ZonedDateTime? = null,
+    /**
+     * Raw-gather demand at or above this is farm-scale (MCO-401). Defaults to
+     * [DEFAULT_FARM_SCALE_THRESHOLD]; editable per world in settings.
+     */
+    val farmScaleThreshold: Int = DEFAULT_FARM_SCALE_THRESHOLD,
+) {
+    companion object {
+        /** One shulker box — the unit players already judge bulk in. */
+        const val DEFAULT_FARM_SCALE_THRESHOLD = 1728
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
@@ -1,5 +1,6 @@
 package app.mcorg.pipeline.project
 
+import app.mcorg.domain.model.user.Role
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.project.commonsteps.GetProjectByIdStep
@@ -14,7 +15,9 @@ import app.mcorg.pipeline.task.SearchTasksInput
 import app.mcorg.pipeline.task.SearchTasksStep
 import app.mcorg.presentation.handler.defaultHandleError
 import app.mcorg.presentation.templated.dsl.pages.gatheringPlannerFragment
+import app.mcorg.pipeline.world.ValidateWorldMemberRole
 import app.mcorg.presentation.utils.getProjectId
+import app.mcorg.presentation.utils.getUser
 import app.mcorg.presentation.utils.getWorldId
 import app.mcorg.presentation.utils.respondBadRequest
 import app.mcorg.presentation.utils.respondHtml
@@ -72,9 +75,13 @@ suspend fun ApplicationCall.handleGetDetailContent() {
     val farmScaleThreshold = GetFarmScaleThresholdStep.process(worldId).getOrNull()
         ?: World.DEFAULT_FARM_SCALE_THRESHOLD
 
+    // The roll-up's threshold is a link to world settings for admins only, so the fragment
+    // needs the same role answer the full page computes.
+    val isAdmin = ValidateWorldMemberRole<Unit>(getUser(), Role.ADMIN, worldId).process(Unit) is Result.Success
+
     respondHtml(
         gatheringPlannerFragment(
-            project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold,
+            project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold, isAdmin,
         )
     )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
@@ -4,6 +4,8 @@ import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.project.commonsteps.GetProjectByIdStep
 import app.mcorg.pipeline.resources.GatheringPlanInput
+import app.mcorg.domain.model.world.World
+import app.mcorg.pipeline.resources.GetFarmScaleThresholdStep
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
 import app.mcorg.pipeline.resources.pendingFarmSuppliesFor
 import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
@@ -65,5 +67,14 @@ suspend fun ApplicationCall.handleGetDetailContent() {
 
     val pendingFarms = pendingFarmSuppliesFor(worldId, projectId, plan)
 
-    respondHtml(gatheringPlannerFragment(project, resources, tasks, plan, lens, progressMap, pendingFarms))
+    // Same fallback as the full page (MCO-401): the lens fragment must not silently drop the
+    // farm-scale roll-up, or switching lens would look like the markers disappeared.
+    val farmScaleThreshold = GetFarmScaleThresholdStep.process(worldId).getOrNull()
+        ?: World.DEFAULT_FARM_SCALE_THRESHOLD
+
+    respondHtml(
+        gatheringPlannerFragment(
+            project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold,
+        )
+    )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -9,6 +9,8 @@ import app.mcorg.pipeline.project.commonsteps.GetViewPreferenceInput
 import app.mcorg.pipeline.project.commonsteps.GetViewPreferenceStep
 import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.pipeline.resources.GatheringPlanInput
+import app.mcorg.domain.model.world.World
+import app.mcorg.pipeline.resources.GetFarmScaleThresholdStep
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
 import app.mcorg.pipeline.resources.pendingFarmSuppliesFor
 import app.mcorg.pipeline.resources.GetPlanOverridesStep
@@ -94,6 +96,11 @@ suspend fun ApplicationCall.handleGetProject() {
     // Farms promised but not running yet — the plan's partial-dependency notice (MCO-299)
     val pendingFarms = pendingFarmSuppliesFor(worldId, projectId, plan)
 
+    // The world's "worth a farm" line (MCO-401). Falls back to the default rather than
+    // failing the page: a missing marker beats a missing plan.
+    val farmScaleThreshold = GetFarmScaleThresholdStep.process(worldId).getOrNull()
+        ?: World.DEFAULT_FARM_SCALE_THRESHOLD
+
     // ?drill=<item> deep-links into a target's chain so reload/share lands on the drill,
     // not the plan. Resolves only when the plan derives and the item is an actual target;
     // otherwise falls through to the normal lens render.
@@ -115,6 +122,7 @@ suspend fun ApplicationCall.handleGetProject() {
             drillTarget = drillTarget, drillCandidateCounts = drillCandidateCounts,
             drillNodeIngredients = drillNodeIngredients, drillHighlightItemId = drillItemId,
             drillOverrides = drillOverrides, drillGraph = drillGraph,
+            farmScaleThreshold = farmScaleThreshold,
         )
     )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/FarmScaleDemand.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/FarmScaleDemand.kt
@@ -1,0 +1,69 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.engine.plan.Activity
+import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.engine.plan.PlanNodeStatus
+
+/**
+ * One raw material whose demand is large enough to be worth a farm (MCO-401).
+ *
+ * Not a suggestion of *which* farm — that is MCO-294, and it needs an idea bank this does
+ * not. This is only the classification: "this quantity is farm-scale", which is computable
+ * from the plan alone and is the input that turns one imported build into a list of
+ * candidate prerequisite farm projects.
+ */
+data class FarmScaleDemand(
+    val itemId: String,
+    val itemName: String,
+    val quantity: Long,
+)
+
+/**
+ * Classifies plan demand against a world's farm-scale threshold.
+ *
+ * ## What counts
+ *
+ * **Raw-gather leaves only.** A crafted intermediate is not farmable — its *inputs* are, and
+ * they appear in the plan in their own right. Marking "21,888 Stick" would suggest building a
+ * stick farm rather than a tree farm, and double-counts wood that is already listed.
+ *
+ * **Supplied items are excluded automatically**, without a special case: an item an operational
+ * farm already covers resolves to [PlanNodeStatus.SUPPLIED], not [PlanNodeStatus.RAW_GATHER], so
+ * it never reaches the threshold test. That is the whole reason this reads plan status rather
+ * than raw quantities — telling someone to build a gold farm they already have is exactly the
+ * failure MCO-316 was about.
+ *
+ * ## What this V1 deliberately does not do
+ *
+ * - **Cost is ignored.** 1,728 diamonds and 1,728 cobblestone are not the same problem, but
+ *   weighting by acquisition cost needs a cost model that does not exist yet. Absolute count is
+ *   the honest version; the flaw is real and worth knowing rather than hiding behind a formula.
+ * - **No family grouping.** 1,000 each of six plank types is a tree farm, yet no single row
+ *   crosses the line. Families are what OPEN_TAG rows already represent, and those are not
+ *   raw-gather — see below.
+ * - **Open tags are invisible here.** An unresolved tag ("#minecraft:planks", 121,774 on the
+ *   YAMS import — the single largest line in the plan) is [PlanNodeStatus.OPEN_TAG], not
+ *   raw-gather, so it is not classified at all. Resolving the tag turns it into real raw demand
+ *   that this then sees. Until MCO-400 makes that wall tractable, the roll-up understates a
+ *   plan with many open tags, and says so rather than guessing.
+ */
+object FarmScaleDemands {
+
+    /** Farm-scale raw demand in [plan], largest first. */
+    fun of(plan: GatheringPlan, threshold: Int): List<FarmScaleDemand> =
+        plan.activityList
+            .filter { it.isFarmScale(threshold) }
+            .map { FarmScaleDemand(itemId = it.item.id, itemName = it.item.name, quantity = it.quantity) }
+            .sortedByDescending { it.quantity }
+
+    /** Item ids in [plan] that are farm-scale — for marking rows without re-deriving the rule. */
+    fun itemIdsIn(plan: GatheringPlan, threshold: Int): Set<String> =
+        plan.activityList.filter { it.isFarmScale(threshold) }.mapTo(mutableSetOf()) { it.item.id }
+
+    /**
+     * At or above the threshold, not merely past it: a threshold of 1,728 is read as "a shulker
+     * box is enough to want a farm", and exactly one shulker box should qualify.
+     */
+    private fun Activity.isFarmScale(threshold: Int): Boolean =
+        status == PlanNodeStatus.RAW_GATHER && quantity >= threshold
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GetFarmScaleThresholdStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GetFarmScaleThresholdStep.kt
@@ -1,0 +1,34 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.world.World
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+
+/**
+ * The world's farm-scale threshold (MCO-401) — the raw-gather quantity at or above which the
+ * plan marks a material as worth a farm.
+ *
+ * One column rather than [app.mcorg.pipeline.world.commonsteps.GetWorldStep], for the same
+ * reason [GetWorldVersionStep] exists: the plan page needs this number and nothing else about
+ * the world, and GetWorldStep's aggregate joins every project to count them.
+ *
+ * A missing world falls back to the default instead of failing. This decorates a plan that has
+ * already rendered — losing the marker is a worse outcome than the marker being computed
+ * against the default, and the caller has already established the world exists.
+ */
+object GetFarmScaleThresholdStep : Step<Int, AppFailure, Int> {
+
+    private val query = DatabaseSteps.query<Int, Int?>(
+        sql = SafeSQL.select("SELECT farm_scale_threshold FROM world WHERE id = ?"),
+        parameterSetter = { ps, worldId -> ps.setInt(1, worldId) },
+        resultMapper = { rs -> if (rs.next()) rs.getInt("farm_scale_threshold") else null }
+    )
+
+    override suspend fun process(input: Int): Result<AppFailure, Int> = when (val r = query.process(input)) {
+        is Result.Success -> Result.success(r.value ?: World.DEFAULT_FARM_SCALE_THRESHOLD)
+        is Result.Failure -> r
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/commonsteps/GetPermittedWorldsStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/commonsteps/GetPermittedWorldsStep.kt
@@ -34,13 +34,14 @@ object GetPermittedWorldsStep : Step<GetPermittedWorldsInput, AppFailure.Databas
                     w.updated_at,
                     wm.pinned,
                     wm.last_opened_at,
+                    w.farm_scale_threshold,
                     COALESCE(COUNT(DISTINCT p.id), 0) as total_projects,
                     COALESCE(COUNT(DISTINCT CASE WHEN p.stage = 'COMPLETED' THEN p.id END), 0) as completed_projects
                 FROM world w
                 INNER JOIN world_members wm ON w.id = wm.world_id
                 LEFT JOIN projects p ON w.id = p.world_id
                 WHERE wm.user_id = ? AND (? = '' OR LOWER(w.name) ILIKE '%' || ? || '%' OR LOWER(w.description) ILIKE '%' || ? || '%')
-                GROUP BY w.id, w.name, w.description, w.version, w.created_at, w.updated_at, wm.pinned, wm.last_opened_at
+                GROUP BY w.id, w.name, w.description, w.version, w.created_at, w.updated_at, wm.pinned, wm.last_opened_at, w.farm_scale_threshold
                 ORDER BY $sortByValue
             """.trimIndent()),
             parameterSetter = { statement, inputData ->

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/commonsteps/GetWorldStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/commonsteps/GetWorldStep.kt
@@ -35,8 +35,9 @@ object GetWorldStep : Step<Int, AppFailure.DatabaseError, World> {
             world.name, 
             world.description, 
             world.version, 
-            world.created_at, 
+            world.created_at,
             world.updated_at,
+            world.farm_scale_threshold,
             COALESCE(COUNT(projects.id), 0) as total_projects,
             COALESCE(SUM(CASE WHEN projects.stage = 'COMPLETED' THEN 1 ELSE 0 END), 0) as completed_projects
         FROM world 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/extractors/WorldExtractors.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/extractors/WorldExtractors.kt
@@ -18,5 +18,6 @@ fun ResultSet.toWorld() = World(
     completedProjects = getInt("completed_projects"),
     totalProjects = getInt("total_projects"),
     createdAt = getTimestamp("created_at").toInstant().atZone(java.time.ZoneOffset.UTC),
-    updatedAt = getTimestamp("updated_at").toInstant().atZone(java.time.ZoneOffset.UTC)
+    updatedAt = getTimestamp("updated_at").toInstant().atZone(java.time.ZoneOffset.UTC),
+    farmScaleThreshold = getInt("farm_scale_threshold"),
 )

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/settings/general/UpdateFarmScaleThresholdPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/settings/general/UpdateFarmScaleThresholdPipeline.kt
@@ -1,0 +1,94 @@
+package app.mcorg.pipeline.world.settings.general
+
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.failure.ValidationFailure
+import app.mcorg.presentation.handler.handlePipeline
+import app.mcorg.presentation.templated.dsl.AlertType
+import app.mcorg.presentation.templated.dsl.createAlert
+import app.mcorg.presentation.utils.getWorldId
+import app.mcorg.presentation.utils.respondHtml
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.request.*
+import kotlinx.html.li
+import kotlinx.html.stream.createHTML
+
+/** Same ceiling as the input's `max` — a threshold nothing can reach is a disabled feature. */
+private const val MAX_FARM_SCALE_THRESHOLD = 10_000_000
+
+/**
+ * Updates a world's farm-scale threshold (MCO-401) — the raw-gather quantity at or above which
+ * a plan marks a material as worth building a farm for.
+ */
+suspend fun ApplicationCall.handleUpdateFarmScaleThreshold() {
+    val parameters = receiveParameters()
+    val worldId = getWorldId()
+
+    handlePipeline(
+        onSuccess = {
+            respondHtml(createHTML().li {
+                createAlert(
+                    id = "farm-scale-threshold-updated-success-alert",
+                    type = AlertType.SUCCESS,
+                    title = "Farm-scale threshold updated",
+                    autoClose = true
+                )
+            })
+        },
+    ) {
+        val threshold = ValidateFarmScaleThresholdStep.run(parameters)
+        UpdateFarmScaleThresholdStep(worldId).run(threshold)
+    }
+}
+
+/**
+ * A whole number of items, at least 1.
+ *
+ * Zero or negative would mark *every* raw material farm-scale, which conveys exactly as much
+ * as marking none — so it is rejected here as well as by the column's CHECK constraint, to say
+ * why rather than fail on write.
+ */
+object ValidateFarmScaleThresholdStep : Step<Parameters, AppFailure.ValidationError, Int> {
+    override suspend fun process(input: Parameters): Result<AppFailure.ValidationError, Int> {
+        val raw = input["farmScaleThreshold"]?.trim()
+
+        val parsed = raw?.toIntOrNull()
+        val failure = when {
+            raw.isNullOrEmpty() -> "A threshold is required"
+            parsed == null -> "The threshold must be a whole number"
+            parsed < 1 -> "The threshold must be at least 1 — zero would mark everything"
+            parsed > MAX_FARM_SCALE_THRESHOLD -> "The threshold must be at most ${"%,d".format(MAX_FARM_SCALE_THRESHOLD)}"
+            else -> null
+        }
+
+        return if (failure != null) {
+            Result.failure(
+                AppFailure.ValidationError(
+                    listOf(ValidationFailure.CustomValidation("farmScaleThreshold", failure))
+                )
+            )
+        } else {
+            Result.success(parsed!!)
+        }
+    }
+}
+
+data class UpdateFarmScaleThresholdStep(val worldId: Int) : Step<Int, AppFailure.DatabaseError, Int> {
+    override suspend fun process(input: Int): Result<AppFailure.DatabaseError, Int> {
+        return DatabaseSteps.update<Int>(
+            sql = SafeSQL.update("""
+                UPDATE world
+                SET farm_scale_threshold = ?, updated_at = CURRENT_TIMESTAMP
+                WHERE id = ?
+            """),
+            parameterSetter = { statement, threshold ->
+                statement.setInt(1, threshold)
+                statement.setInt(2, worldId)
+            }
+        ).process(input).map { input }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -51,6 +51,7 @@ import app.mcorg.pipeline.world.handleDeleteWorld
 import app.mcorg.pipeline.world.handleSearchWorlds
 import app.mcorg.pipeline.world.handleTogglePin
 import app.mcorg.pipeline.world.settings.general.handleUpdateWorldDescription
+import app.mcorg.pipeline.world.settings.general.handleUpdateFarmScaleThreshold
 import app.mcorg.pipeline.world.settings.general.handleUpdateWorldName
 import app.mcorg.pipeline.world.settings.general.handleUpdateWorldVersion
 import app.mcorg.pipeline.world.settings.handleConnectDiscord
@@ -283,6 +284,9 @@ class WorldHandler {
                     }
                     patch("/version") {
                         call.handleUpdateWorldVersion()
+                    }
+                    patch("/farm-scale-threshold") {
+                        call.handleUpdateFarmScaleThreshold()
                     }
                     method(HttpMethod.Delete) {
                         install(WorldOwnerPlugin)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -139,7 +139,7 @@ fun projectDetailPage(
                     // ?drill=<item> deep-links straight into a target's chain (reload/share-safe).
                     drillChainContent(project, drillTarget, drillCandidateCounts, drillNodeIngredients, overrides = drillOverrides, graph = drillGraph, highlightItemId = drillHighlightItemId)
                 } else {
-                    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold)
+                    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold, isWorldAdmin)
                 }
             }
         }
@@ -243,6 +243,7 @@ fun FlowContent.gatheringPlannerContent(
     progressMap: Map<String, Int> = emptyMap(),
     pendingFarms: List<PendingFarmSupply> = emptyList(),
     farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
+    isWorldAdmin: Boolean = false,
 ) {
     val activeLens = when (lens) {
         "next", "sessions" -> lens
@@ -271,7 +272,7 @@ fun FlowContent.gatheringPlannerContent(
     // Active lens body
     when (activeLens) {
         "next", "sessions" -> lensComingSoon(project.worldId, project.id, activeLens)
-        else -> listLensContent(project, resources, tasks, plan, progressMap, pendingFarms, farmScaleThreshold)
+        else -> listLensContent(project, resources, tasks, plan, progressMap, pendingFarms, farmScaleThreshold, isWorldAdmin)
     }
 }
 
@@ -302,6 +303,7 @@ private fun FlowContent.listLensContent(
     progressMap: Map<String, Int> = emptyMap(),
     pendingFarms: List<PendingFarmSupply> = emptyList(),
     farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
+    isWorldAdmin: Boolean = false,
 ) {
     // Resolution toggle (client-side; default "targets" applied by plan-view.js).
     listResolutionToggle()
@@ -405,7 +407,7 @@ private fun FlowContent.listLensContent(
         id = "list-breakdown-view"
         attributes["data-resolution-view"] = "breakdown"
 
-        gatheringPlanSections(project, plan, progressMap, pendingFarms, farmScaleThreshold)
+        gatheringPlanSections(project, plan, progressMap, pendingFarms, farmScaleThreshold, isWorldAdmin)
     }
 
     // Tasks section (collapsed)
@@ -481,6 +483,7 @@ fun FlowContent.gatheringPlanSections(
     progressMap: Map<String, Int> = emptyMap(),
     pendingFarms: List<PendingFarmSupply> = emptyList(),
     farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
+    isWorldAdmin: Boolean = false,
 ) {
     if (plan == null) {
         // Empty state — no resources yet or all collected
@@ -504,7 +507,7 @@ fun FlowContent.gatheringPlanSections(
 
         // Above the work sections on purpose: this is not a step in the plan, it is the answer
         // to "what should I build first", and it is what turns one import into a roadmap.
-        farmScaleRollUp(farmScale, farmScaleThreshold)
+        farmScaleRollUp(farmScale, farmScaleThreshold, project.worldId, isWorldAdmin)
 
         groupOrder.forEach { group ->
             val activities = byGroup[group] ?: return@forEach
@@ -554,7 +557,12 @@ fun FlowContent.gatheringPlanSections(
  * apart. Items an operational farm already supplies never appear — they are solved, not
  * suggestions (see [FarmScaleDemands]).
  */
-private fun FlowContent.farmScaleRollUp(demands: List<FarmScaleDemand>, threshold: Int) {
+private fun FlowContent.farmScaleRollUp(
+    demands: List<FarmScaleDemand>,
+    threshold: Int,
+    worldId: Int,
+    canEditThreshold: Boolean,
+) {
     if (demands.isEmpty()) return
 
     div("plan-farm-scale") {
@@ -562,7 +570,19 @@ private fun FlowContent.farmScaleRollUp(demands: List<FarmScaleDemand>, threshol
         span("section-label") { +"Worth a farm" }
         p("plan-farm-scale__lead") {
             +"${demands.size} raw ${if (demands.size == 1) "material needs" else "materials need"} more than "
-            +"%,d".format(threshold)
+            // The number is the judgement this whole list rests on, so it is the thing to edit:
+            // disagreeing with the list means disagreeing with the threshold. Admin-only, matching
+            // how every other route to world settings is gated (settingsHref in Navigation.kt) —
+            // a link that 403s is worse than no link.
+            if (canEditThreshold) {
+                a(classes = "plan-farm-scale__threshold") {
+                    href = "/worlds/$worldId/settings"
+                    title = "Change this world's farm-scale threshold"
+                    +"%,d".format(threshold)
+                }
+            } else {
+                +"%,d".format(threshold)
+            }
             +" — each is a candidate for its own farm project."
         }
         div("plan-farm-scale__list") {
@@ -1168,9 +1188,12 @@ fun gatheringPlannerFragment(
     progressMap: Map<String, Int> = emptyMap(),
     pendingFarms: List<PendingFarmSupply> = emptyList(),
     farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
+    isWorldAdmin: Boolean = false,
 ): String = createHTML().div {
     id = "project-content"
-    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold)
+    gatheringPlannerContent(
+        project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold, isWorldAdmin,
+    )
 }
 
 /** OOB fragment to update #project-progress after task create/complete. */

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -5,6 +5,7 @@ import app.mcorg.domain.model.project.ProjectProduction
 import app.mcorg.domain.model.resources.ResourceGatheringItem
 import app.mcorg.domain.model.task.ActionTask
 import app.mcorg.domain.model.user.TokenProfile
+import app.mcorg.domain.model.world.World
 import app.mcorg.engine.model.ItemSourceGraph
 import app.mcorg.engine.plan.Activity
 import app.mcorg.engine.plan.ActivityGroup
@@ -12,6 +13,8 @@ import app.mcorg.engine.plan.GatheringPlan
 import app.mcorg.engine.plan.PlanNodeStatus
 import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.engine.plan.SupplySource
+import app.mcorg.pipeline.resources.FarmScaleDemand
+import app.mcorg.pipeline.resources.FarmScaleDemands
 import app.mcorg.presentation.hxDelete
 import app.mcorg.presentation.hxDeleteWithConfirm
 import app.mcorg.presentation.hxGet
@@ -67,6 +70,7 @@ fun projectDetailPage(
     drillHighlightItemId: String? = null,
     drillOverrides: PlanOverrides = PlanOverrides.NONE,
     drillGraph: ItemSourceGraph? = null,
+    farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
 ): String = pageShell(
     pageTitle = "Seam — ${project.name}",
     user = user,
@@ -135,7 +139,7 @@ fun projectDetailPage(
                     // ?drill=<item> deep-links straight into a target's chain (reload/share-safe).
                     drillChainContent(project, drillTarget, drillCandidateCounts, drillNodeIngredients, overrides = drillOverrides, graph = drillGraph, highlightItemId = drillHighlightItemId)
                 } else {
-                    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap, pendingFarms)
+                    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold)
                 }
             }
         }
@@ -238,6 +242,7 @@ fun FlowContent.gatheringPlannerContent(
     lens: String = "list",
     progressMap: Map<String, Int> = emptyMap(),
     pendingFarms: List<PendingFarmSupply> = emptyList(),
+    farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
 ) {
     val activeLens = when (lens) {
         "next", "sessions" -> lens
@@ -266,7 +271,7 @@ fun FlowContent.gatheringPlannerContent(
     // Active lens body
     when (activeLens) {
         "next", "sessions" -> lensComingSoon(project.worldId, project.id, activeLens)
-        else -> listLensContent(project, resources, tasks, plan, progressMap, pendingFarms)
+        else -> listLensContent(project, resources, tasks, plan, progressMap, pendingFarms, farmScaleThreshold)
     }
 }
 
@@ -296,6 +301,7 @@ private fun FlowContent.listLensContent(
     plan: GatheringPlan?,
     progressMap: Map<String, Int> = emptyMap(),
     pendingFarms: List<PendingFarmSupply> = emptyList(),
+    farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
 ) {
     // Resolution toggle (client-side; default "targets" applied by plan-view.js).
     listResolutionToggle()
@@ -399,7 +405,7 @@ private fun FlowContent.listLensContent(
         id = "list-breakdown-view"
         attributes["data-resolution-view"] = "breakdown"
 
-        gatheringPlanSections(project, plan, progressMap, pendingFarms)
+        gatheringPlanSections(project, plan, progressMap, pendingFarms, farmScaleThreshold)
     }
 
     // Tasks section (collapsed)
@@ -474,6 +480,7 @@ fun FlowContent.gatheringPlanSections(
     plan: GatheringPlan?,
     progressMap: Map<String, Int> = emptyMap(),
     pendingFarms: List<PendingFarmSupply> = emptyList(),
+    farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
 ) {
     if (plan == null) {
         // Empty state — no resources yet or all collected
@@ -489,9 +496,16 @@ fun FlowContent.gatheringPlanSections(
     val groupOrder = ActivityGroup.values()
     val nodeIngredients = buildNodeIngredients(plan)
     val feedsLabels = buildFeedsLabels(plan)
+    val farmScale = FarmScaleDemands.of(plan, farmScaleThreshold)
+    val farmScaleIds = farmScale.mapTo(mutableSetOf()) { it.itemId }
 
     div {
         id = "gathering-plan-sections"
+
+        // Above the work sections on purpose: this is not a step in the plan, it is the answer
+        // to "what should I build first", and it is what turns one import into a roadmap.
+        farmScaleRollUp(farmScale, farmScaleThreshold)
+
         groupOrder.forEach { group ->
             val activities = byGroup[group] ?: return@forEach
             if (activities.isEmpty()) return@forEach
@@ -509,13 +523,56 @@ fun FlowContent.gatheringPlanSections(
                 span("section-label") { +groupLabel(group) }
                 div("resource-list") {
                     ordered.forEach { activity ->
-                        planActivityRow(project.worldId, project.id, activity, progressMap, nodeIngredients, feedsLabels)
+                        planActivityRow(
+                            project.worldId,
+                            project.id,
+                            activity,
+                            progressMap,
+                            nodeIngredients,
+                            feedsLabels,
+                            isFarmScale = activity.item.id in farmScaleIds,
+                        )
                     }
                 }
             }
         }
 
         pendingFarmNotice(project.worldId, pendingFarms)
+    }
+}
+
+/**
+ * The farm-scale roll-up (MCO-401): raw materials whose demand is large enough to be worth a
+ * farm, largest first.
+ *
+ * This list *is* the roadmap-building input — each line is a candidate prerequisite farm
+ * project — which is why it leads the plan rather than sitting at the bottom with the notices.
+ * Ordering carries the meaning: the top line is where to start.
+ *
+ * It names quantities and nothing else. Suggesting *which* farm to build is MCO-294 and needs
+ * an idea bank; saying "this is farm-scale" needs only the plan, which is why the two shipped
+ * apart. Items an operational farm already supplies never appear — they are solved, not
+ * suggestions (see [FarmScaleDemands]).
+ */
+private fun FlowContent.farmScaleRollUp(demands: List<FarmScaleDemand>, threshold: Int) {
+    if (demands.isEmpty()) return
+
+    div("plan-farm-scale") {
+        id = "plan-farm-scale"
+        span("section-label") { +"Worth a farm" }
+        p("plan-farm-scale__lead") {
+            +"${demands.size} raw ${if (demands.size == 1) "material needs" else "materials need"} more than "
+            +"%,d".format(threshold)
+            +" — each is a candidate for its own farm project."
+        }
+        div("plan-farm-scale__list") {
+            demands.forEach { demand ->
+                div("plan-farm-scale__item") {
+                    span("plan-farm-scale__quantity") { +"%,d".format(demand.quantity) }
+                    span("plan-farm-scale__name") { +demand.itemName }
+                }
+            }
+        }
     }
 }
 
@@ -580,13 +637,22 @@ private fun FlowContent.planActivityRow(
     progressMap: Map<String, Int> = emptyMap(),
     nodeIngredients: Map<String, String> = emptyMap(),
     feedsLabels: Map<String, FeedsLabel> = emptyMap(),
+    isFarmScale: Boolean = false,
 ) {
     when (activity.status) {
         PlanNodeStatus.SUPPLIED -> suppliedActivityRow(worldId, projectId, activity, feedsLabels[activity.item.id])
         PlanNodeStatus.OPEN_TAG -> openTagActivityRow(worldId, projectId, activity)
         PlanNodeStatus.BLOCKED -> blockedActivityRow(worldId, projectId, activity)
         PlanNodeStatus.RESOLVED, PlanNodeStatus.RAW_GATHER ->
-            counterActivityRow(worldId, projectId, activity, progressMap, nodeIngredients, feedsLabels[activity.item.id])
+            counterActivityRow(
+                worldId,
+                projectId,
+                activity,
+                progressMap,
+                nodeIngredients,
+                feedsLabels[activity.item.id],
+                isFarmScale = isFarmScale,
+            )
     }
 }
 
@@ -696,6 +762,7 @@ fun FlowContent.counterActivityRow(
     progressMap: Map<String, Int> = emptyMap(),
     nodeIngredients: Map<String, String> = emptyMap(),
     feedsLabel: FeedsLabel? = null,
+    isFarmScale: Boolean = false,
 ) {
     val itemSlug = activity.item.id.replace(":", "-")
     val rowId = "plan-activity-$itemSlug"
@@ -719,6 +786,16 @@ fun FlowContent.counterActivityRow(
 
         div("resource-row__desktop") {
             div("resource-row__name") { +activity.item.name }
+
+            // MCO-401: says the quantity is farm-scale, not which farm — that is MCO-294 and
+            // needs an idea bank. On the row rather than only in the roll-up, so the judgement
+            // is visible while reading the gathering work itself.
+            if (isFarmScale) {
+                span("badge plan-farm-scale__badge") {
+                    attributes["title"] = "More than this world's farm-scale threshold — worth a farm"
+                    +"Farm-scale"
+                }
+            }
 
             div("resource-row__progress") {
                 div("progress") {
@@ -1090,9 +1167,10 @@ fun gatheringPlannerFragment(
     lens: String = "list",
     progressMap: Map<String, Int> = emptyMap(),
     pendingFarms: List<PendingFarmSupply> = emptyList(),
+    farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
 ): String = createHTML().div {
     id = "project-content"
-    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap, pendingFarms)
+    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold)
 }
 
 /** OOB fragment to update #project-progress after task create/complete. */

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/settings/GeneralTab.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/settings/GeneralTab.kt
@@ -88,6 +88,47 @@ fun FORM.worldVersionForm(world: World, supportedVersions: List<MinecraftVersion
     }
 }
 
+/**
+ * The farm-scale threshold (MCO-401) — raw demand at or above this is marked "worth a farm"
+ * in every project's plan.
+ *
+ * Lives in General rather than a planning tab of its own because it is a fact about the world's
+ * scale, alongside its name and version: a superflat testing world and a megabase want different
+ * numbers, and the same number applies to every project in the world.
+ */
+fun FORM.farmScaleThresholdForm(world: World) {
+    id = "world-farm-scale-form"
+    classes += "settings-form"
+    hxTargetError(".validation-error-message")
+    encType = FormEncType.applicationXWwwFormUrlEncoded
+
+    hxTarget("#$ALERT_CONTAINER_ID")
+    hxSwap("afterbegin")
+    hxPatch("/worlds/${world.id}/settings/farm-scale-threshold")
+    hxTrigger("input changed delay:500ms from:#world-farm-scale-input, submit")
+
+    label {
+        htmlFor = "world-farm-scale-input"
+        +"Worth a farm above"
+    }
+    input(classes = "form-control") {
+        name = "farmScaleThreshold"
+        id = "world-farm-scale-input"
+        type = InputType.number
+        value = world.farmScaleThreshold.toString()
+        required = true
+        min = "1"
+        max = "10000000"
+    }
+    p("settings-form__helper subtle") {
+        +"Raw materials a project needs this many of are marked as worth building a farm for. "
+        +"The default, 1,728, is one shulker box."
+    }
+    p("validation-error-message") {
+        id = "validation-error-farm-scale-threshold"
+    }
+}
+
 fun DIV.generalSection(data: SettingsPageData) {
     section(
         title = "General Settings",
@@ -97,5 +138,6 @@ fun DIV.generalSection(data: SettingsPageData) {
         form { worldNameForm(data.world) }
         form { worldDescriptionForm(data.world) }
         form { worldVersionForm(data.world, data.supportedVersions) }
+        form { farmScaleThresholdForm(data.world) }
     }
 }

--- a/webapp/mc-web/src/main/resources/db/migration/V2_56_0__add_world_farm_scale_threshold.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_56_0__add_world_farm_scale_threshold.sql
@@ -1,0 +1,15 @@
+-- MCO-401: the quantity above which a raw material is worth a farm, per world.
+--
+-- Default 1,728 — one shulker box. Players do not think in "is 40,000 a lot"; they think
+-- "that is more than a shulker of cobble", so the unit is the one already in their head.
+--
+-- World-scoped rather than global because the number is a judgement about a world's scale:
+-- a superflat testing world and a 500,000-item megabase do not want the same line. It is not
+-- per-user, because the demand it classifies belongs to the world's projects, not to whoever
+-- is looking at them.
+ALTER TABLE world
+    ADD COLUMN farm_scale_threshold INT NOT NULL DEFAULT 1728;
+
+-- 0 or negative would mark every raw material farm-scale, which is the same as marking none.
+ALTER TABLE world
+    ADD CONSTRAINT world_farm_scale_threshold_positive CHECK (farm_scale_threshold > 0);

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
@@ -609,3 +609,58 @@
 .plan-pending-farms__project:hover {
     text-decoration: underline;
 }
+
+/* MCO-401 — farm-scale roll-up. Leads the plan because it is where the roadmap starts:
+   each line is a candidate prerequisite farm project, largest demand first. */
+.plan-farm-scale {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
+    padding: var(--space-3);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    background: var(--surface-raised);
+}
+
+.plan-farm-scale__lead {
+    margin: 0;
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+.plan-farm-scale__list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.plan-farm-scale__item {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+}
+
+/* Quantity leads and is tabular so the column of numbers stays scannable — the
+   ordering is the message, and ragged digits undo it. */
+.plan-farm-scale__quantity {
+    min-width: 6ch;
+    text-align: right;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    font-variant-numeric: tabular-nums;
+    color: var(--text);
+}
+
+.plan-farm-scale__name {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text);
+}
+
+.plan-farm-scale__badge {
+    background: var(--accent-subtle, transparent);
+    border: 1px solid var(--accent);
+    color: var(--accent);
+}

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
@@ -664,3 +664,16 @@
     border: 1px solid var(--accent);
     color: var(--accent);
 }
+
+/* The threshold is editable in place of being merely stated: disagreeing with the
+   roll-up means disagreeing with this number, so it links to where it is set. */
+.plan-farm-scale__threshold {
+    color: var(--accent);
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 2px;
+}
+
+.plan-farm-scale__threshold:hover {
+    text-decoration-style: solid;
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/FarmScaleDemandsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/FarmScaleDemandsTest.kt
@@ -1,0 +1,139 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftTag
+import app.mcorg.domain.model.world.World
+import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.engine.plan.PlanNode
+import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.PlanTarget
+import app.mcorg.engine.plan.SupplySource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * MCO-401 — which raw demand is worth a farm.
+ *
+ * The rule is small, but every exclusion in it is load-bearing: the roll-up is meant to be a
+ * list of candidate farm projects, and a single wrong entry ("build a gold farm" when one is
+ * already running) makes the whole list untrustworthy.
+ */
+class FarmScaleDemandsTest {
+
+    private val cobblestone = Item("minecraft:cobblestone", "Cobblestone")
+    private val ironIngot = Item("minecraft:iron_ingot", "Iron Ingot")
+    private val stick = Item("minecraft:stick", "Stick")
+    private val ice = Item("minecraft:ice", "Ice")
+    private val planks = MinecraftTag("#minecraft:planks", "Planks", emptyList())
+
+    private val threshold = World.DEFAULT_FARM_SCALE_THRESHOLD
+
+    private fun plan(vararg nodes: PlanNode) = GatheringPlan(
+        nodes = nodes.associateBy { it.item.id },
+        targets = nodes.map { PlanTarget(it.item, it.quantity) },
+    )
+
+    private fun node(
+        item: app.mcorg.domain.model.minecraft.MinecraftId,
+        quantity: Long,
+        status: PlanNodeStatus = PlanNodeStatus.RAW_GATHER,
+        supply: SupplySource? = null,
+    ) = PlanNode(item = item, quantity = quantity, crafts = 0, leftover = 0, status = status, supply = supply)
+
+    @Test
+    fun `raw demand at or above the threshold is farm-scale`() {
+        val result = FarmScaleDemands.of(plan(node(cobblestone, 74_557)), threshold)
+
+        assertEquals(1, result.size)
+        assertEquals(FarmScaleDemand("minecraft:cobblestone", "Cobblestone", 74_557), result.first())
+    }
+
+    @Test
+    fun `exactly one shulker box qualifies`() {
+        // The threshold is read as "a shulker box is enough to want a farm", so the boundary
+        // itself is inside the set, not just past it.
+        assertEquals(1, FarmScaleDemands.of(plan(node(ice, 1_728)), threshold).size)
+        assertTrue(FarmScaleDemands.of(plan(node(ice, 1_727)), threshold).isEmpty())
+    }
+
+    @Test
+    fun `an item an operational farm already supplies is not a suggestion`() {
+        // The exclusion that matters most: it is already solved. A supplied item resolves to
+        // SUPPLIED rather than RAW_GATHER, so it never reaches the threshold test — no special
+        // case, and no "build a gold farm" next to the gold farm you already built.
+        val result = FarmScaleDemands.of(
+            plan(node(ironIngot, 32_967, PlanNodeStatus.SUPPLIED, SupplySource.Farm("Earlygame iron farm"))),
+            threshold,
+        )
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `a crafted intermediate is never farm-scale however large`() {
+        // 21,888 sticks is real demand, but you do not build a stick farm — you build a tree
+        // farm, and the wood appears in the plan on its own.
+        val result = FarmScaleDemands.of(plan(node(stick, 21_888, PlanNodeStatus.RESOLVED)), threshold)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `an unresolved tag is not classified`() {
+        // #minecraft:planks is the single largest line on the YAMS import (121,774) and is
+        // deliberately absent: OPEN_TAG is a question, not demand for a specific item. Picking
+        // the variant turns it into raw demand this then sees.
+        val result = FarmScaleDemands.of(plan(node(planks, 121_774, PlanNodeStatus.OPEN_TAG)), threshold)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `a blocked item is not classified`() {
+        // No feasible source — a farm is not the missing piece, a source is.
+        val result = FarmScaleDemands.of(plan(node(ice, 20_611, PlanNodeStatus.BLOCKED)), threshold)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `the roll-up is ordered largest first`() {
+        // Ordering is the feature: the top of this list is where the roadmap starts.
+        val result = FarmScaleDemands.of(
+            plan(node(ice, 20_611), node(cobblestone, 74_557), node(ironIngot, 32_967)),
+            threshold,
+        )
+
+        assertEquals(listOf(74_557L, 32_967L, 20_611L), result.map { it.quantity })
+    }
+
+    @Test
+    fun `a world can raise its own threshold`() {
+        // A superflat testing world and a megabase do not want the same line.
+        val plan = plan(node(ice, 20_611), node(cobblestone, 74_557))
+
+        assertEquals(2, FarmScaleDemands.of(plan, threshold).size)
+        assertEquals(listOf("minecraft:cobblestone"), FarmScaleDemands.of(plan, 50_000).map { it.itemId })
+    }
+
+    @Test
+    fun `marked item ids match the roll-up`() {
+        // The row marker and the roll-up must not be able to disagree — same rule, one place.
+        val plan = plan(
+            node(cobblestone, 74_557),
+            node(stick, 21_888, PlanNodeStatus.RESOLVED),
+            node(ice, 12),
+        )
+
+        assertEquals(
+            FarmScaleDemands.of(plan, threshold).map { it.itemId }.toSet(),
+            FarmScaleDemands.itemIdsIn(plan, threshold),
+        )
+    }
+
+    @Test
+    fun `an empty plan yields nothing`() {
+        assertTrue(FarmScaleDemands.of(plan(), threshold).isEmpty())
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/UpdateFarmScaleThresholdIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/UpdateFarmScaleThresholdIT.kt
@@ -1,0 +1,159 @@
+package app.mcorg.presentation.handler.world
+
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.world.World
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.pipeline.world.settings.general.handleUpdateFarmScaleThreshold
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.WorldAdminPlugin
+import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.patch
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.patch
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+
+/**
+ * `PATCH /worlds/{worldId}/settings/farm-scale-threshold` (MCO-401) — the world-level line
+ * above which raw demand is marked as worth a farm.
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class UpdateFarmScaleThresholdIT : WithUser() {
+
+    @Test
+    fun `a new world starts at one shulker box`() = testApplication {
+        setupRoutes()
+        val worldId = createWorld("Threshold Default World")
+
+        assertEquals(World.DEFAULT_FARM_SCALE_THRESHOLD, storedThreshold(worldId))
+        assertEquals(1728, World.DEFAULT_FARM_SCALE_THRESHOLD)
+    }
+
+    @Test
+    fun `an admin can raise the threshold`() = testApplication {
+        setupRoutes()
+        val worldId = createWorld("Threshold Update World")
+
+        val response = client.patch("/worlds/$worldId/settings/farm-scale-threshold") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("farmScaleThreshold=50000")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals(50_000, storedThreshold(worldId))
+    }
+
+    @Test
+    fun `zero is rejected rather than silently disabling every marker`() = testApplication {
+        // A threshold of 0 marks every raw material, which conveys exactly as much as marking
+        // none. Rejecting it says why, instead of leaving a plan where the badge is meaningless.
+        setupRoutes()
+        val worldId = createWorld("Threshold Zero World")
+
+        val response = client.patch("/worlds/$worldId/settings/farm-scale-threshold") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("farmScaleThreshold=0")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertEquals(World.DEFAULT_FARM_SCALE_THRESHOLD, storedThreshold(worldId))
+    }
+
+    @Test
+    fun `a non-numeric threshold is rejected`() = testApplication {
+        setupRoutes()
+        val worldId = createWorld("Threshold Text World")
+
+        val response = client.patch("/worlds/$worldId/settings/farm-scale-threshold") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("farmScaleThreshold=a+shulker+box")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertEquals(World.DEFAULT_FARM_SCALE_THRESHOLD, storedThreshold(worldId))
+    }
+
+    @Test
+    fun `a missing threshold is rejected`() = testApplication {
+        setupRoutes()
+        val worldId = createWorld("Threshold Missing World")
+
+        val response = client.patch("/worlds/$worldId/settings/farm-scale-threshold") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("")
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertEquals(World.DEFAULT_FARM_SCALE_THRESHOLD, storedThreshold(worldId))
+    }
+
+    @Test
+    fun `an unauthenticated request is sent to sign-in rather than changing anything`() = testApplication {
+        setupRoutes()
+        val worldId = createWorld("Threshold Auth World")
+
+        val response = client.patch("/worlds/$worldId/settings/farm-scale-threshold") {
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("farmScaleThreshold=50000")
+        }
+
+        // AuthPlugin redirects rather than 401s — this is a browser surface, not an API.
+        assertEquals(HttpStatusCode.Found, response.status)
+        assertEquals(World.DEFAULT_FARM_SCALE_THRESHOLD, storedThreshold(worldId))
+    }
+
+    // ---- fixtures ------------------------------------------------------------------
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
+                route("/settings") {
+                    install(WorldAdminPlugin)
+                    patch("/farm-scale-threshold") { call.handleUpdateFarmScaleThreshold() }
+                }
+            }
+        }
+    }
+
+    private fun createWorld(name: String): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(name = name, description = "test", version = MinecraftVersion.fromString("1.20.1"))
+        )
+        (result as Result.Success).value
+    }
+
+    private fun storedThreshold(worldId: Int): Int = runBlocking {
+        val result = DatabaseSteps.query<Int, Int?>(
+            SafeSQL.select("SELECT farm_scale_threshold FROM world WHERE id = ?"),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) },
+            resultMapper = { rs -> if (rs.next()) rs.getInt("farm_scale_threshold") else null }
+        ).process(worldId)
+        (result as Result.Success).value!!
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/FarmScaleRollUpTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/FarmScaleRollUpTest.kt
@@ -1,0 +1,139 @@
+package app.mcorg.presentation.templated.dsl.pages
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.project.Project
+import app.mcorg.domain.model.project.ProjectStage
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.domain.model.project.ProjectType
+import app.mcorg.domain.model.world.World
+import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.engine.plan.PlanNode
+import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.PlanTarget
+import app.mcorg.engine.plan.SupplySource
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * MCO-401 — the "Worth a farm" roll-up as rendered.
+ *
+ * Rendered rather than integration-tested end to end: the roll-up only appears once a plan has
+ * derived, and deriving one needs an ingested item graph that no test fixture provides (the
+ * existing GatheringPlannerIT asserts page structure against a null plan for the same reason).
+ * This drives the real template with a real plan, so everything but the DB read is covered;
+ * the threshold's own storage is covered by WorldSettingsIT.
+ */
+class FarmScaleRollUpTest {
+
+    private val cobblestone = Item("minecraft:cobblestone", "Cobblestone")
+    private val ice = Item("minecraft:ice", "Ice")
+    private val ironIngot = Item("minecraft:iron_ingot", "Iron Ingot")
+    private val torch = Item("minecraft:torch", "Torch")
+
+    private fun project() = Project(
+        id = 2,
+        worldId = 1,
+        name = "Storage System",
+        description = "",
+        type = ProjectType.BUILDING,
+        stage = ProjectStage.PLANNING,
+        state = ProjectState.ACTIVE,
+        location = null,
+        tasksTotal = 0,
+        tasksCompleted = 0,
+        importedFromIdea = null,
+        createdAt = ZonedDateTime.now(),
+        updatedAt = ZonedDateTime.now(),
+    )
+
+    private fun plan(vararg nodes: PlanNode) = GatheringPlan(
+        nodes = nodes.associateBy { it.item.id },
+        targets = nodes.map { PlanTarget(it.item, it.quantity) },
+    )
+
+    private fun node(
+        item: Item,
+        quantity: Long,
+        status: PlanNodeStatus = PlanNodeStatus.RAW_GATHER,
+        supply: SupplySource? = null,
+    ) = PlanNode(item = item, quantity = quantity, crafts = 0, leftover = 0, status = status, supply = supply)
+
+    private fun render(plan: GatheringPlan, threshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD) =
+        gatheringPlannerFragment(
+            project = project(),
+            resources = emptyList(),
+            tasks = emptyList(),
+            plan = plan,
+            farmScaleThreshold = threshold,
+        )
+
+    @Test
+    fun `bulk raw demand is rolled up largest first`() {
+        val html = render(plan(node(ice, 20_611), node(cobblestone, 74_557)))
+
+        assertContains(html, "Worth a farm")
+        assertContains(html, "74,557")
+        assertContains(html, "20,611")
+        // The ordering is the message — the top line is where the roadmap starts.
+        assertTrue(html.indexOf("74,557") < html.indexOf("20,611"))
+    }
+
+    @Test
+    fun `the lead line counts the materials and names the threshold`() {
+        val html = render(plan(node(ice, 20_611), node(cobblestone, 74_557)))
+
+        assertContains(html, "2 raw materials need more than 1,728")
+    }
+
+    @Test
+    fun `one material reads in the singular`() {
+        val html = render(plan(node(ice, 20_611)))
+
+        assertContains(html, "1 raw material needs more than 1,728")
+    }
+
+    @Test
+    fun `a plan with nothing farm-scale shows no roll-up at all`() {
+        // Not an empty panel: a plan under the threshold has no farm question to answer, and a
+        // heading with nothing under it reads as a bug.
+        val html = render(plan(node(torch, 64), node(ice, 12)))
+
+        assertFalse(html.contains("plan-farm-scale"))
+        assertFalse(html.contains("Worth a farm"))
+    }
+
+    @Test
+    fun `an item an operational farm already supplies stays out of the roll-up`() {
+        val html = render(
+            plan(
+                node(cobblestone, 74_557),
+                node(ironIngot, 32_967, PlanNodeStatus.SUPPLIED, SupplySource.Farm("Iron Farm")),
+            )
+        )
+
+        assertContains(html, "1 raw material needs")
+        assertFalse(html.contains("32,967"))
+    }
+
+    @Test
+    fun `farm-scale rows carry the badge and others do not`() {
+        val html = render(plan(node(cobblestone, 74_557), node(ice, 12)))
+
+        assertContains(html, "plan-farm-scale__badge")
+        // One badge, for the one row over the line — not one per raw row.
+        assertTrue(html.split("plan-farm-scale__badge").size - 1 == 1)
+    }
+
+    @Test
+    fun `raising the world threshold shrinks the roll-up`() {
+        val plan = plan(node(cobblestone, 74_557), node(ice, 20_611))
+
+        val html = render(plan, threshold = 50_000)
+
+        assertContains(html, "1 raw material needs more than 50,000")
+        assertFalse(html.contains("20,611"))
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/FarmScaleRollUpTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/FarmScaleRollUpTest.kt
@@ -61,14 +61,18 @@ class FarmScaleRollUpTest {
         supply: SupplySource? = null,
     ) = PlanNode(item = item, quantity = quantity, crafts = 0, leftover = 0, status = status, supply = supply)
 
-    private fun render(plan: GatheringPlan, threshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD) =
-        gatheringPlannerFragment(
-            project = project(),
-            resources = emptyList(),
-            tasks = emptyList(),
-            plan = plan,
-            farmScaleThreshold = threshold,
-        )
+    private fun render(
+        plan: GatheringPlan,
+        threshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
+        isWorldAdmin: Boolean = true,
+    ) = gatheringPlannerFragment(
+        project = project(),
+        resources = emptyList(),
+        tasks = emptyList(),
+        plan = plan,
+        farmScaleThreshold = threshold,
+        isWorldAdmin = isWorldAdmin,
+    )
 
     @Test
     fun `bulk raw demand is rolled up largest first`() {
@@ -85,14 +89,17 @@ class FarmScaleRollUpTest {
     fun `the lead line counts the materials and names the threshold`() {
         val html = render(plan(node(ice, 20_611), node(cobblestone, 74_557)))
 
-        assertContains(html, "2 raw materials need more than 1,728")
+        // The threshold sits in its own anchor, so assert the prose and the number separately.
+        assertContains(html, "2 raw materials need more than ")
+        assertContains(html, ">1,728<")
     }
 
     @Test
     fun `one material reads in the singular`() {
         val html = render(plan(node(ice, 20_611)))
 
-        assertContains(html, "1 raw material needs more than 1,728")
+        assertContains(html, "1 raw material needs more than ")
+        assertContains(html, ">1,728<")
     }
 
     @Test
@@ -128,12 +135,32 @@ class FarmScaleRollUpTest {
     }
 
     @Test
+    fun `an admin can click the threshold through to world settings`() {
+        // The number is the judgement the list rests on, so it is the thing to edit.
+        val html = render(plan(node(cobblestone, 74_557)))
+
+        assertContains(html, """href="/worlds/1/settings"""")
+        assertContains(html, "plan-farm-scale__threshold")
+    }
+
+    @Test
+    fun `a non-admin sees the threshold as plain text`() {
+        // World settings is admin-gated, and a link that 403s is worse than no link.
+        val html = render(plan(node(cobblestone, 74_557)), isWorldAdmin = false)
+
+        assertContains(html, "1,728")
+        assertFalse(html.contains("plan-farm-scale__threshold"))
+        assertFalse(html.contains("/worlds/1/settings"))
+    }
+
+    @Test
     fun `raising the world threshold shrinks the roll-up`() {
         val plan = plan(node(cobblestone, 74_557), node(ice, 20_611))
 
         val html = render(plan, threshold = 50_000)
 
-        assertContains(html, "1 raw material needs more than 50,000")
+        assertContains(html, "1 raw material needs more than ")
+        assertContains(html, ">50,000<")
         assertFalse(html.contains("20,611"))
     }
 }


### PR DESCRIPTION
Closes MCO-401 — https://linear.app/evegul/issue/MCO-401/mark-bulk-raw-demand-as-farm-worthy-against-a-world-level-threshold

An imported build leaves ~500,000 items to gather with no way to see **which of them want a farm** — the question that decides the roadmap, and one you want answered before starting rather than three weeks into gathering.

MCO-294 is the designed answer but needs an idea bank with more than one idea in it. The marker does not: "this demand is large enough to want a farm" is computable from the plan alone, so it ships first, and MCO-294 later hangs idea matches off markers that already exist.

## What this adds

- **A world-level threshold**, default **1,728** — one shulker box, because that is the unit players already judge bulk in ("more than a shulker of cobble"). World-scoped rather than global: a superflat test world and a megabase do not want the same line. Editable in world settings, and the number in the roll-up links straight there.
- **Row markers + a roll-up.** Raw-gather demand at or above the threshold gets a badge on its plan row and an entry in a "Worth a farm" list above the work sections, largest first. That list *is* the roadmap-building input — each line is a candidate prerequisite farm project — which is why ordering carries the meaning and why it leads rather than trails.
- **Existing supply excluded with no special case.** An item an operational farm already covers resolves to `SUPPLIED`, never `RAW_GATHER`, so it never reaches the threshold test. Telling someone to build the gold farm they already built is exactly the failure MCO-316 was about.

## Against the real YAMS plan

**Ice 20,611 · Sand 5,436 · Water 2,413.** Everything else large is already farm-supplied — MCO-316 doing its job, and the supplied-exclusion working.

## Three V1 limitations, documented at the rule rather than papered over

- **Cost is ignored.** 1,728 diamonds and 1,728 cobblestone are not the same problem. "2,413 Water" above is a fair verdict on absolute counts — you do not build a water farm. Weighting by acquisition cost needs a cost model that does not exist yet; absolute count is the honest version.
- **No family grouping.** 1,000 each of six plank types is a tree farm that no single row reveals.
- **Open tags are not classified at all.** An unresolved tag is `OPEN_TAG`, not raw-gather. On the YAMS import that hides the single largest line in the whole plan — **121,774 `#minecraft:planks`** — until MCO-400 makes the tag wall tractable. The roll-up understates a plan with many open tags; it says so rather than guessing.

That last one is the strongest argument for doing MCO-400 next: the largest gathering commitment in the build is currently invisible to the feature meant to surface it.

## Follow-up filed

**MCO-407** — dismissing suggestions. The threshold is the only control today and a blunt one: raising it to silence "2,413 Water" silences every smaller correct suggestion too. Scoped deliberately as *dismissal, not solution* — recording how an item is actually solved already lives in `solved_by_project_id` / farm supply / MCO-294, and a "dismiss = I have a plan" would quietly become a second, weaker supply record nothing else reads.

## Tests

**855 unit + 443 database, zero failures.**

- `FarmScaleDemandsTest` (10) — the rule, with every exclusion pinned: supplied items, crafted intermediates, open tags, blocked items, the boundary (exactly one shulker box qualifies), ordering, and the row markers agreeing with the roll-up.
- `FarmScaleRollUpTest` (9) — the rendered roll-up, including the admin gate on the threshold link.
- `UpdateFarmScaleThresholdIT` (6) — storage, validation (zero, non-numeric, missing), and auth.

The roll-up is covered by a render test rather than end-to-end: it only appears once a plan derives, and deriving one needs an ingested item graph no fixture provides — `GatheringPlannerIT` asserts against a null plan for the same reason. Everything but the DB read is exercised; the threshold's own storage is covered by the IT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
