### PR TITLE
MCO-400: order "Needs attention" by what each question decides

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -51,6 +51,7 @@ import app.mcorg.pipeline.resources.PendingFarmSupply
 import app.mcorg.pipeline.resources.buildNodeIngredients
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import kotlin.math.roundToInt
 
 fun projectDetailPage(
     user: TokenProfile,
@@ -524,17 +525,21 @@ fun FlowContent.gatheringPlanSections(
 
             div("project-detail__section") {
                 span("section-label") { +groupLabel(group) }
-                div("resource-list") {
-                    ordered.forEach { activity ->
-                        planActivityRow(
-                            project.worldId,
-                            project.id,
-                            activity,
-                            progressMap,
-                            nodeIngredients,
-                            feedsLabels,
-                            isFarmScale = activity.item.id in farmScaleIds,
-                        )
+                if (group == ActivityGroup.NEEDS_ATTENTION) {
+                    needsAttentionList(project, ordered)
+                } else {
+                    div("resource-list") {
+                        ordered.forEach { activity ->
+                            planActivityRow(
+                                project.worldId,
+                                project.id,
+                                activity,
+                                progressMap,
+                                nodeIngredients,
+                                feedsLabels,
+                                isFarmScale = activity.item.id in farmScaleIds,
+                            )
+                        }
                     }
                 }
             }
@@ -728,6 +733,112 @@ private fun FlowContent.suppliedActivityRow(
     }
 }
 
+/**
+ * "Needs attention", ordered and collapsed (MCO-400).
+ *
+ * The section used to render every unresolved question as an equal amber callout in id order.
+ * On the YAMS import that is 25 stacked warnings opening with "Charcoal or Coal" (2 items) and
+ * burying "Planks" (110,824 items — 96% of all the material behind these questions) at
+ * position 19. The count was never the real problem: the questions are already one per tag, not
+ * one per consumer. The problem is that a two-item decision and a hundred-thousand-item decision
+ * look exactly alike, in an order that has nothing to do with either.
+ *
+ * So: blocked rows first, since they cannot be answered by picking at all and no amount of
+ * variant-choosing moves them; then the questions by how much material each decides, with the
+ * tail folded away.
+ */
+private fun FlowContent.needsAttentionList(project: Project, activities: List<Activity>) {
+    val blocked = activities.filter { it.status == PlanNodeStatus.BLOCKED }
+    val questions = activities
+        .filter { it.status == PlanNodeStatus.OPEN_TAG }
+        .sortedWith(compareByDescending<Activity> { it.quantity }.thenBy { it.item.name })
+
+    div("resource-list") {
+        blocked.forEach { blockedActivityRow(project.worldId, project.id, it) }
+    }
+
+    if (questions.isEmpty()) return
+
+    val leadCount = leadingQuestionCount(questions)
+    val lead = questions.take(leadCount)
+    val rest = questions.drop(leadCount)
+
+    div("plan-attention") {
+        id = "plan-attention"
+        p("plan-attention__lead") { +attentionLead(questions, leadCount) }
+        div("resource-list") {
+            lead.forEach { openTagActivityRow(project.worldId, project.id, it) }
+        }
+        if (rest.isNotEmpty()) {
+            details("plan-attention__rest") {
+                summary {
+                    span("btn btn--ghost btn--sm plan-attention__toggle") {
+                        span("plan-attention__toggle--closed") { +"Show ${rest.size} smaller choices ▾" }
+                        span("plan-attention__toggle--open") { +"Hide smaller choices ▴" }
+                    }
+                }
+                div("resource-list") {
+                    rest.forEach { openTagActivityRow(project.worldId, project.id, it) }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * How many questions to show before folding the rest away.
+ *
+ * Enough to cover [ATTENTION_COVERAGE] of the material the questions decide, capped at
+ * [MAX_LEADING_QUESTIONS] — coverage alone would expand nearly everything when demand happens to
+ * be spread evenly, which is the wall again. Always at least one: a section whose every question
+ * is hidden behind a toggle reads as an empty section.
+ *
+ * A remainder of one or two is not worth a fold, so those stay open.
+ */
+private fun leadingQuestionCount(questionsByQuantityDesc: List<Activity>): Int {
+    val total = questionsByQuantityDesc.sumOf { it.quantity }
+    if (total <= 0) return questionsByQuantityDesc.size.coerceAtMost(MAX_LEADING_QUESTIONS)
+
+    var covered = 0L
+    var count = 0
+    for (activity in questionsByQuantityDesc) {
+        covered += activity.quantity
+        count++
+        if (count >= MAX_LEADING_QUESTIONS) break
+        if (covered.toDouble() / total >= ATTENTION_COVERAGE) break
+    }
+    return if (questionsByQuantityDesc.size - count < MIN_FOLDED) questionsByQuantityDesc.size else count
+}
+
+/**
+ * "25 variant choices — these 1 decide 96% of the material behind them."
+ *
+ * The percentage is the point: it is what tells you that answering the top question is most of
+ * the work, and that the twenty below it are detail. Stated only when something is actually
+ * folded away, and only when the quantities can support the claim.
+ */
+private fun attentionLead(questions: List<Activity>, leadCount: Int): String {
+    val plural = if (questions.size == 1) "variant choice" else "variant choices"
+    if (leadCount >= questions.size) return "${questions.size} $plural — pick to sharpen the plan."
+
+    val total = questions.sumOf { it.quantity }
+    if (total <= 0) return "${questions.size} $plural — largest first."
+
+    val covered = questions.take(leadCount).sumOf { it.quantity }
+    val percent = (covered * 100.0 / total).roundToInt()
+    val these = if (leadCount == 1) "the first decides" else "these $leadCount decide"
+    return "${questions.size} $plural — $these $percent% of the material behind them."
+}
+
+/** Show questions until they cover this share of the material the whole section decides. */
+private const val ATTENTION_COVERAGE = 0.9
+
+/** Never lead with more than this many, however flat the distribution. */
+private const val MAX_LEADING_QUESTIONS = 5
+
+/** A remainder smaller than this is not worth hiding behind a toggle. */
+private const val MIN_FOLDED = 3
+
 /** OPEN_TAG row: amber callout, indicates variant pick needed. */
 private fun FlowContent.openTagActivityRow(worldId: Int, projectId: Int, activity: Activity) {
     val encodedItemId = URLEncoder.encode(activity.item.id, StandardCharsets.UTF_8)
@@ -736,6 +847,11 @@ private fun FlowContent.openTagActivityRow(worldId: Int, projectId: Int, activit
         id = "plan-activity-${activity.item.id.replace(":", "-")}"
         span("callout__icon") { +"!" }
         div("callout__body") {
+            // The quantity leads (MCO-400). Without it every question looks alike, and on a real
+            // import they are not: on the YAMS build one choice carries 110,824 items and the
+            // next-but-three carries 2. Same words, four orders of magnitude apart.
+            span("plan-attention__quantity") { +"%,d".format(activity.quantity) }
+            +" "
             span { +activity.item.name }
             +" — Pick a variant (open tag)"
         }

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
@@ -677,3 +677,49 @@
 .plan-farm-scale__threshold:hover {
     text-decoration-style: solid;
 }
+
+/* MCO-400 — "Needs attention" ordered by what each question decides, tail folded away. */
+.plan-attention {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.plan-attention__lead {
+    margin: 0;
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+/* The number is why the ordering is trustworthy, so it reads as data, not prose. */
+.plan-attention__quantity {
+    font-family: var(--font-mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--text);
+}
+
+.plan-attention__rest {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.plan-attention__rest > summary {
+    list-style: none;
+    cursor: pointer;
+}
+
+.plan-attention__rest > summary::-webkit-details-marker {
+    display: none;
+}
+
+.plan-attention__toggle {
+    display: inline-flex;
+}
+
+/* Swap the toggle's wording on open — the control says what it will do, not what it is. */
+.plan-attention__rest[open] .plan-attention__toggle--closed,
+.plan-attention__rest:not([open]) .plan-attention__toggle--open {
+    display: none;
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/NeedsAttentionSectionTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/NeedsAttentionSectionTest.kt
@@ -1,0 +1,181 @@
+package app.mcorg.presentation.templated.dsl.pages
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftId
+import app.mcorg.domain.model.minecraft.MinecraftTag
+import app.mcorg.domain.model.project.Project
+import app.mcorg.domain.model.project.ProjectStage
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.domain.model.project.ProjectType
+import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.engine.plan.PlanNode
+import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.PlanTarget
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * MCO-400 — "Needs attention", ordered by what each question decides.
+ *
+ * The section used to render every question as an equal amber callout in id order. On the YAMS
+ * import that opened with "Charcoal or Coal" (2 items) and buried "Planks" (110,824 — 96% of all
+ * the material behind these questions) at position 19. These tests pin the ordering, the fold,
+ * and the two things that must never be folded.
+ */
+class NeedsAttentionSectionTest {
+
+    private fun tag(id: String, name: String) = MinecraftTag("#minecraft:$id", name, emptyList())
+
+    private val planks = tag("planks", "Planks")
+    private val woodenSlabs = tag("wooden_slabs", "Wooden Slabs")
+    private val coals = tag("coals", "Coals")
+    private val oakLogs = tag("oak_logs", "Oak Logs")
+    private val logs = tag("logs", "Logs")
+    private val netherPortal = Item("minecraft:nether_portal", "Nether Portal")
+
+    private fun project() = Project(
+        id = 2,
+        worldId = 1,
+        name = "Storage System",
+        description = "",
+        type = ProjectType.BUILDING,
+        stage = ProjectStage.PLANNING,
+        state = ProjectState.ACTIVE,
+        location = null,
+        tasksTotal = 0,
+        tasksCompleted = 0,
+        importedFromIdea = null,
+        createdAt = ZonedDateTime.now(),
+        updatedAt = ZonedDateTime.now(),
+    )
+
+    private fun plan(vararg nodes: PlanNode) = GatheringPlan(
+        nodes = nodes.associateBy { it.item.id },
+        targets = nodes.map { PlanTarget(it.item, it.quantity) },
+    )
+
+    private fun question(item: MinecraftId, quantity: Long) =
+        PlanNode(item = item, quantity = quantity, crafts = 0, leftover = 0, status = PlanNodeStatus.OPEN_TAG)
+
+    private fun blocked(item: MinecraftId, quantity: Long) =
+        PlanNode(item = item, quantity = quantity, crafts = 0, leftover = 0, status = PlanNodeStatus.BLOCKED)
+
+    private fun render(plan: GatheringPlan) = gatheringPlannerFragment(
+        project = project(),
+        resources = emptyList(),
+        tasks = emptyList(),
+        plan = plan,
+    )
+
+    /**
+     * Everything in the section before the fold — what someone actually sees on arriving.
+     * Anchored on the section label, not the questions: blocked rows render ahead of them.
+     */
+    private fun visiblePart(html: String): String {
+        val start = html.indexOf("Needs attention")
+        val fold = html.indexOf("plan-attention__rest", start + 1)
+        return if (fold > 0) html.substring(start, fold) else html.substring(start)
+    }
+
+    @Test
+    fun `the question deciding the most material leads`() {
+        val html = render(
+            plan(
+                question(coals, 1),
+                question(planks, 110_824),
+                question(woodenSlabs, 3_540),
+                question(oakLogs, 46),
+                question(logs, 10),
+            )
+        )
+
+        assertContains(visiblePart(html), "Planks")
+        assertFalse(visiblePart(html).contains("Coals"))
+    }
+
+    @Test
+    fun `each question carries its quantity`() {
+        // Without the number every question looks alike, which is the whole failure: on a real
+        // import two of them are four orders of magnitude apart.
+        val html = render(plan(question(planks, 110_824)))
+
+        assertContains(html, "110,824")
+        assertContains(html, "plan-attention__quantity")
+    }
+
+    @Test
+    fun `the lead says how much of the material the visible questions decide`() {
+        val html = render(
+            plan(
+                question(planks, 110_824),
+                question(woodenSlabs, 3_540),
+                question(coals, 1),
+                question(oakLogs, 46),
+                question(logs, 10),
+            )
+        )
+
+        assertContains(html, "5 variant choices — the first decides 97% of the material behind them.")
+    }
+
+    @Test
+    fun `a small set is not folded at all`() {
+        // Hiding one or two questions behind a toggle costs a click and saves nothing.
+        val html = render(plan(question(planks, 110_824), question(coals, 1)))
+
+        assertContains(html, "2 variant choices — pick to sharpen the plan.")
+        assertFalse(html.contains("plan-attention__rest"))
+    }
+
+    @Test
+    fun `a flat distribution still leads with at most five`() {
+        // Coverage alone would expand nearly everything when no single question dominates —
+        // which is the wall again, just sorted.
+        val nodes = (1..12).map { question(tag("filler_$it", "Filler $it"), 1_000L) }
+        val html = render(plan(*nodes.toTypedArray()))
+
+        assertContains(html, "Show 7 smaller choices")
+    }
+
+    @Test
+    fun `blocked rows are never folded away`() {
+        // They cannot be answered by picking a variant at all, so no amount of choosing clears
+        // them — hiding them behind a "smaller choices" toggle would misfile them as trivial.
+        val nodes = (1..12).map { question(tag("filler_$it", "Filler $it"), 1_000L) } + blocked(netherPortal, 2)
+        val html = render(plan(*nodes.toTypedArray()))
+
+        assertContains(visiblePart(html), "Blocked: ")
+        assertContains(visiblePart(html), "Nether Portal")
+    }
+
+    @Test
+    fun `a section of only blocked rows has no lead line or toggle`() {
+        val html = render(plan(blocked(netherPortal, 2)))
+
+        assertContains(html, "Nether Portal")
+        assertFalse(html.contains("variant choices"))
+        assertFalse(html.contains("plan-attention__rest"))
+    }
+
+    @Test
+    fun `every question is still present, folded or not`() {
+        // Ordering and folding, never dropping — a hidden question is still a question.
+        val html = render(
+            plan(
+                question(planks, 110_824),
+                question(woodenSlabs, 3_540),
+                question(coals, 1),
+                question(oakLogs, 46),
+                question(logs, 10),
+            )
+        )
+
+        listOf("Planks", "Wooden Slabs", "Coals", "Oak Logs", "Logs").forEach {
+            assertContains(html, it)
+        }
+        assertTrue(html.contains("Show 4 smaller choices"))
+    }
+}


### PR DESCRIPTION
Closes MCO-400 — https://linear.app/evegul/issue/MCO-400/how-to-make-it-opens-with-a-wall-of-open-tag-questions-auto-resolve

Opening "How to make it" on the YAMS import gave **27 identical amber callouts in id order**: it started with *Charcoal or Coal* (2 items) and put *Planks* — **110,824 items, 96% of all the material behind these questions** — at position 19.

## The spike corrected the issue before any code

Recorded in full on the issue. Two of its assumptions did not survive contact with real data:

- **"Identical tags across consumers are one question, not N" was already true.** The plan carries one node per tag, so `#minecraft:planks` renders exactly once. Nothing to deduplicate.
- **"Single-member tags never reach NEEDS_ATTENTION" fires zero times.** Every open tag on a real import has 2–44 members. That rule would have shrunk the wall by nothing.

**The count was never the problem.** A two-item decision and a hundred-thousand-item decision looking identical, in an order related to neither, is the problem.

| Tag | Demand | Was at |
| --- | ---: | ---: |
| `#minecraft:planks` | 110,824 | #19 |
| `#minecraft:wooden_slabs` | 3,540 | #25 |
| `#minecraft:stone_crafting_materials` | 435 | #23 |
| 7 `#mcorg:choice/*` from the import | 2–9 each | **#1–#7** |

## What changed — presentation only, no selector or scorer involvement

- **Each question carries its quantity.** They never showed a number at all; this alone does most of the work, and it is what makes the ordering trustworthy rather than arbitrary.
- **Questions sort by quantity**, so the one deciding the most leads.
- **The tail folds** behind "Show N smaller choices". N is what remains after covering 90% of the material the questions decide, **capped at five** so a flat distribution cannot re-create the wall just sorted, **floored at one** so the section is never entirely hidden, and **not folded at all below three** — hiding one or two costs a click and saves nothing. A test pins each guard.
- **Blocked rows lead and never fold.** They cannot be answered by picking a variant, so no amount of choosing clears them; filing them under "smaller choices" would misrepresent what they are.

On YAMS the section becomes two blocked rows, `110,824 Planks`, and a toggle for the other 24, under *"25 variant choices — the first decides 96% of the material behind them."*

**Nothing is dropped.** Every question is still present and answerable — this orders and folds, it never hides work.

## Confirmed in the running app

Driven locally against the real import. Answering a question re-ranks and shrinks the list, so it reads as working through a short list rather than facing a wall — an emergent consequence of ranking, not something built for.

## What is deliberately not here

- **Option B — auto-resolve low-impact tags** stays behind MCO-320: unresolved tags currently pay no cost in `minDepth`, so auto-picking would bake that distortion into defaults nobody sees.
- **Option C — answer the wood family once.** 13 of the 25 questions are "which wood?", and they want one answer, not thirteen. Filed separately rather than growing this PR.

## Tests

**863 unit + 443 database, zero failures.** `NeedsAttentionSectionTest` (8) covers ordering, the quantity on each row, the lead copy in each of its forms, all three fold guards, blocked rows never folding, and that every question survives folding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
