### PR TITLE
MCO-412: move idea production rates out of JSON into relational modes

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/idea/IdeaProduction.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/idea/IdeaProduction.kt
@@ -16,8 +16,11 @@ data class IdeaProductionMode(
     val id: Int,
     val name: String,
     val position: Int,
-    /** Item id -> items per hour. */
-    val rates: Map<String, Int>,
+    /**
+     * Item id -> items per hour, or null where the author knows *what* it makes but has never
+     * measured how fast. A missing rate is information; an invented one is not.
+     */
+    val rates: Map<String, Int?>,
 ) {
     val isImplicit: Boolean get() = name == DEFAULT_MODE_NAME
 
@@ -42,3 +45,14 @@ data class IdeaProductionMode(
 fun List<IdeaProductionMode>.bestRateFor(itemId: String): Pair<IdeaProductionMode, Int>? =
     mapNotNull { mode -> mode.rates[itemId]?.let { mode to it } }
         .maxByOrNull { (_, rate) -> rate }
+
+/**
+ * Whether any mode makes [itemId] at all, measured or not.
+ *
+ * Separate from [bestRateFor] because the two answer different questions and a farm can answer
+ * one without the other: an unmeasured bamboo farm plainly produces bamboo, and a suggestion that
+ * ignored it because no one timed it would be hiding the design for the wrong reason. Whether a
+ * *quantity* can be quoted is [bestRateFor]'s business.
+ */
+fun List<IdeaProductionMode>.produces(itemId: String): Boolean =
+    any { mode -> mode.rates.containsKey(itemId) }

--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/idea/IdeaProduction.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/idea/IdeaProduction.kt
@@ -1,0 +1,44 @@
+package app.mcorg.domain.model.idea
+
+/**
+ * One way an idea can be run, and what it produces that way.
+ *
+ * A farm that can be run more than one way produces different things at different rates depending
+ * on how: an ice farm at full speed or slowed for lag, a nether fortress farm with a
+ * wither-skeleton filter on or off. Modes are flat rather than combinations of axes — the
+ * six-mode fortress farm is rare enough that listing six modes beats a model that multiplies
+ * dimensions for every farm that has none.
+ *
+ * Most ideas have exactly one mode. [isImplicit] marks the one created for them without asking,
+ * so the UI can keep saying nothing about modes until there are two.
+ */
+data class IdeaProductionMode(
+    val id: Int,
+    val name: String,
+    val position: Int,
+    /** Item id -> items per hour. */
+    val rates: Map<String, Int>,
+) {
+    val isImplicit: Boolean get() = name == DEFAULT_MODE_NAME
+
+    companion object {
+        /**
+         * The name given to the single mode created for an idea that never mentioned modes.
+         * Only ever shown when a second mode exists to contrast it with.
+         */
+        const val DEFAULT_MODE_NAME = "Default"
+    }
+}
+
+/**
+ * The best rate any of [modes] achieves for [itemId], with the mode that achieves it.
+ *
+ * "Best" rather than a designated default (decision, 2026-08-16): the question a farm suggestion
+ * answers is "can this cover my demand at all", and rejecting a farm because its *default* mode is
+ * the slow one would hide a farm that plainly covers the work. The mode is returned alongside so
+ * the answer can name its own assumption — "62,000/h in Max speed" — rather than quietly promise
+ * a best case.
+ */
+fun List<IdeaProductionMode>.bestRateFor(itemId: String): Pair<IdeaProductionMode, Int>? =
+    mapNotNull { mode -> mode.rates[itemId]?.let { mode to it } }
+        .maxByOrNull { (_, rate) -> rate }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/domain/idea/schema/IdeaCategorySchemas.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/domain/idea/schema/IdeaCategorySchemas.kt
@@ -78,25 +78,10 @@ object IdeaCategorySchemas {
     val FARM = ideaCategory(IdeaCategory.FARM) {
         sizeField()
 
-        /**
-         * The one structured field the engine will consume: MCO-294 matches bulk raw demand
-         * against farm output. Flat item -> rate; the old Mode -> (Item -> Rate) nesting was
-         * the single most tedious thing in the form and never got filled.
-         */
-        typedMapField("productionRate") {
-            label = "Production Rate"
-            helpText = "What this farm produces, per hour"
-            types {
-                selectKey {
-                    label = "Item"
-                    dynamicOptionsConfig = DynamicOptionsConfig.items()
-                }
-                rateValue {
-                    label = "Rate"
-                    min = 0.0
-                }
-            }
-        }
+        // Production moved out of category data entirely (MCO-412): it is relational now, and it
+        // belongs to any idea rather than to the FARM category — a mob farm inside a storage build
+        // produces too. The form renders it from its own section; leaving the field here as well
+        // would offer two places to type the same number into two different stores.
 
         tileable()
         directional()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/CreateIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/CreateIdeaPipeline.kt
@@ -11,6 +11,8 @@ import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.idea.commonsteps.IdeaProductionModeInput
+import app.mcorg.pipeline.idea.commonsteps.replaceIdeaProductionModes
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
@@ -26,6 +28,12 @@ data class CreateIdeaInput(
     val versionRange: MinecraftVersionRange,
     val testData: PerformanceTestData?,
     val itemRequirements: Map<String, Int>,
+    /**
+     * What the idea produces, by mode. Empty for anything that produces nothing — most builds.
+     * Relational rather than part of [categoryData] so demand can be matched against it and so a
+     * mob farm inside a storage build can declare output without being categorised as a farm.
+     */
+    val productionModes: List<IdeaProductionModeInput> = emptyList(),
     val categoryData: Map<String, CategoryValue>,
 )
 
@@ -117,6 +125,11 @@ data class CreateIdeaStep(val userId: Int) : Step<CreateIdeaInput, AppFailure.Da
                             if (requirementResult is Result.Failure) {
                                 return requirementResult
                             }
+                        }
+
+                        val productions = replaceIdeaProductionModes(ideaId, input.productionModes, connection)
+                        if (productions is Result.Failure) {
+                            return productions
                         }
 
                         return Result.success(ideaId)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/commonsteps/IdeaProductionSteps.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/commonsteps/IdeaProductionSteps.kt
@@ -32,6 +32,14 @@ data class IdeaProductionModeInput(
  *
  * Modes with no rates are dropped: a named way of running a farm that produces nothing is a form
  * artefact, not a fact about the farm.
+ *
+ * Modes that resolve to the *same* name are merged rather than inserted twice, which would violate
+ * `UNIQUE (idea_id, name)` and roll the whole publish back. The form rejects this case with a
+ * field-level message (`ValidateIdeaProductionsStep`), but a bodyless publish re-publishes stored
+ * draft JSON without re-validating it, so the collision has to be survivable here too. Merging is
+ * the non-lossy reading: two modes claiming the same name claim to be the same way of running the
+ * farm, so their items combine, and the faster of two rates for one item wins — consistent with
+ * [app.mcorg.domain.model.idea.bestRateFor], which already answers "how fast, at best".
  */
 suspend fun replaceIdeaProductionModes(
     ideaId: Int,
@@ -45,7 +53,7 @@ suspend fun replaceIdeaProductionModes(
     ).process(ideaId)
     if (cleared is Result.Failure) return cleared
 
-    val populated = modes.filter { it.rates.isNotEmpty() }
+    val populated = modes.filter { it.rates.isNotEmpty() }.mergeByResolvedName()
     if (populated.isEmpty()) return Result.success(Unit)
 
     populated.forEachIndexed { index, mode ->
@@ -55,7 +63,8 @@ suspend fun replaceIdeaProductionModes(
             ),
             parameterSetter = { statement, _ ->
                 statement.setInt(1, ideaId)
-                statement.setString(2, mode.name.ifBlank { IdeaProductionMode.DEFAULT_MODE_NAME })
+                // Already resolved by mergeByResolvedName — blank became DEFAULT_MODE_NAME there.
+                statement.setString(2, mode.name)
                 statement.setInt(3, index)
             },
             resultMapper = { rs -> if (rs.next()) rs.getInt("id") else null },
@@ -83,6 +92,36 @@ suspend fun replaceIdeaProductionModes(
 
     return Result.success(Unit)
 }
+
+/**
+ * Collapses modes sharing a resolved name into one, preserving first-seen order.
+ *
+ * Blank resolves to [IdeaProductionMode.DEFAULT_MODE_NAME] first, so two unnamed modes are one
+ * collision rather than two rows the unique index would reject. Where both carry the same item, the
+ * higher rate wins and a measured rate beats an unmeasured one — a null here means "never timed",
+ * not "zero", so it must never displace a real number.
+ */
+internal fun List<IdeaProductionModeInput>.mergeByResolvedName(): List<IdeaProductionModeInput> =
+    fold(LinkedHashMap<String, IdeaProductionModeInput>()) { acc, mode ->
+        val name = mode.name.trim().ifBlank { IdeaProductionMode.DEFAULT_MODE_NAME }
+        val existing = acc[name]
+        acc[name] = if (existing == null) {
+            mode.copy(name = name)
+        } else {
+            val rates = existing.rates.toMutableMap()
+            mode.rates.forEach { (itemId, rate) ->
+                val current = rates[itemId]
+                rates[itemId] = when {
+                    !rates.containsKey(itemId) -> rate
+                    current == null -> rate
+                    rate == null -> current
+                    else -> maxOf(current, rate)
+                }
+            }
+            existing.copy(rates = rates)
+        }
+        acc
+    }.values.toList()
 
 /** An idea's production modes, in the author's order, each with its rates. */
 data class GetIdeaProductionModesStep(val ideaId: Int) :

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/commonsteps/IdeaProductionSteps.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/commonsteps/IdeaProductionSteps.kt
@@ -17,7 +17,8 @@ import app.mcorg.pipeline.TransactionConnection
  */
 data class IdeaProductionModeInput(
     val name: String,
-    val rates: Map<String, Int>,
+    /** Item id -> rate, or null where the author knows what it makes but not how fast. */
+    val rates: Map<String, Int?>,
 )
 
 /**
@@ -66,14 +67,14 @@ suspend fun replaceIdeaProductionModes(
             is Result.Failure -> return modeIdResult
         }
 
-        val rates = DatabaseSteps.batchUpdate<Pair<String, Int>>(
+        val rates = DatabaseSteps.batchUpdate<Pair<String, Int?>>(
             SafeSQL.insert(
                 "INSERT INTO idea_production_rates (mode_id, item_id, rate_per_hour) VALUES (?, ?, ?)"
             ),
             parameterSetter = { statement, (itemId, rate) ->
                 statement.setInt(1, modeId)
                 statement.setString(2, itemId)
-                statement.setInt(3, rate)
+                if (rate == null) statement.setNull(3, java.sql.Types.INTEGER) else statement.setInt(3, rate)
             },
             transactionConnection = connection,
         ).process(mode.rates.toList())
@@ -115,7 +116,10 @@ data class GetIdeaProductionModesStep(val ideaId: Int) :
                     }
                     val itemId = rs.getString("item_id")
                     if (itemId != null) {
-                        byId[id] = mode.copy(rates = mode.rates + (itemId to rs.getInt("rate_per_hour")))
+                        // getInt returns 0 for SQL NULL, and 0 is not what a missing rate means —
+                        // wasNull is the only way to tell "unmeasured" from a real zero.
+                        val rate = rs.getInt("rate_per_hour").takeUnless { rs.wasNull() }
+                        byId[id] = mode.copy(rates = mode.rates + (itemId to rate))
                     }
                 }
                 byId.values.toList()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/commonsteps/IdeaProductionSteps.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/commonsteps/IdeaProductionSteps.kt
@@ -1,0 +1,124 @@
+package app.mcorg.pipeline.idea.commonsteps
+
+import app.mcorg.domain.model.idea.IdeaProductionMode
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.TransactionConnection
+
+/**
+ * A mode as submitted, before it has an id.
+ *
+ * [name] is blank for the implicit single mode — the form never asks for one until a second mode
+ * exists, so blank means "the only way this runs" and is stored as
+ * [IdeaProductionMode.DEFAULT_MODE_NAME].
+ */
+data class IdeaProductionModeInput(
+    val name: String,
+    val rates: Map<String, Int>,
+)
+
+/**
+ * Replaces an idea's production modes wholesale.
+ *
+ * Delete-then-insert rather than a diff: modes are identified by name, and a rename is
+ * indistinguishable from a delete plus an add without an id the form does not carry. The rows are
+ * few (one mode for almost every idea, six for the worst case anyone has described) and always
+ * written inside the caller's transaction, so the churn costs nothing and the alternative would be
+ * a merge whose only purpose is preserving surrogate ids nothing references.
+ *
+ * Modes with no rates are dropped: a named way of running a farm that produces nothing is a form
+ * artefact, not a fact about the farm.
+ */
+suspend fun replaceIdeaProductionModes(
+    ideaId: Int,
+    modes: List<IdeaProductionModeInput>,
+    connection: TransactionConnection,
+): Result<AppFailure.DatabaseError, Unit> {
+    val cleared = DatabaseSteps.update<Int>(
+        SafeSQL.delete("DELETE FROM idea_production_modes WHERE idea_id = ?"),
+        parameterSetter = { statement, id -> statement.setInt(1, id) },
+        transactionConnection = connection,
+    ).process(ideaId)
+    if (cleared is Result.Failure) return cleared
+
+    val populated = modes.filter { it.rates.isNotEmpty() }
+    if (populated.isEmpty()) return Result.success(Unit)
+
+    populated.forEachIndexed { index, mode ->
+        val modeIdResult = DatabaseSteps.query<Unit, Int?>(
+            SafeSQL.insert(
+                "INSERT INTO idea_production_modes (idea_id, name, position) VALUES (?, ?, ?) RETURNING id"
+            ),
+            parameterSetter = { statement, _ ->
+                statement.setInt(1, ideaId)
+                statement.setString(2, mode.name.ifBlank { IdeaProductionMode.DEFAULT_MODE_NAME })
+                statement.setInt(3, index)
+            },
+            resultMapper = { rs -> if (rs.next()) rs.getInt("id") else null },
+            transactionConnection = connection,
+        ).process(Unit)
+
+        val modeId = when (modeIdResult) {
+            is Result.Success -> modeIdResult.value ?: return Result.failure(AppFailure.DatabaseError.NotFound)
+            is Result.Failure -> return modeIdResult
+        }
+
+        val rates = DatabaseSteps.batchUpdate<Pair<String, Int>>(
+            SafeSQL.insert(
+                "INSERT INTO idea_production_rates (mode_id, item_id, rate_per_hour) VALUES (?, ?, ?)"
+            ),
+            parameterSetter = { statement, (itemId, rate) ->
+                statement.setInt(1, modeId)
+                statement.setString(2, itemId)
+                statement.setInt(3, rate)
+            },
+            transactionConnection = connection,
+        ).process(mode.rates.toList())
+        if (rates is Result.Failure) return rates
+    }
+
+    return Result.success(Unit)
+}
+
+/** An idea's production modes, in the author's order, each with its rates. */
+data class GetIdeaProductionModesStep(val ideaId: Int) :
+    Step<Unit, AppFailure.DatabaseError, List<IdeaProductionMode>> {
+
+    override suspend fun process(input: Unit): Result<AppFailure.DatabaseError, List<IdeaProductionMode>> =
+        DatabaseSteps.query<Unit, List<IdeaProductionMode>>(
+            sql = SafeSQL.select(
+                """
+                SELECT m.id, m.name, m.position, r.item_id, r.rate_per_hour
+                FROM idea_production_modes m
+                LEFT JOIN idea_production_rates r ON r.mode_id = m.id
+                WHERE m.idea_id = ?
+                ORDER BY m.position, m.id, r.item_id
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ -> statement.setInt(1, ideaId) },
+            resultMapper = { rs ->
+                // LEFT JOIN so a mode with no rates still arrives; the row then carries a null
+                // item and contributes nothing but the mode itself.
+                val byId = linkedMapOf<Int, IdeaProductionMode>()
+                while (rs.next()) {
+                    val id = rs.getInt("id")
+                    val mode = byId.getOrPut(id) {
+                        IdeaProductionMode(
+                            id = id,
+                            name = rs.getString("name"),
+                            position = rs.getInt("position"),
+                            rates = emptyMap(),
+                        )
+                    }
+                    val itemId = rs.getString("item_id")
+                    if (itemId != null) {
+                        byId[id] = mode.copy(rates = mode.rates + (itemId to rs.getInt("rate_per_hour")))
+                    }
+                }
+                byId.values.toList()
+            }
+        ).process(Unit)
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DeserializeDraftStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DeserializeDraftStep.kt
@@ -21,7 +21,7 @@ import kotlinx.serialization.json.Json
 @Serializable
 data class DraftProductionMode(
     val name: String = "",
-    val rates: Map<String, Int> = emptyMap(),
+    val rates: Map<String, Int?> = emptyMap(),
 )
 
 @Serializable

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DeserializeDraftStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DeserializeDraftStep.kt
@@ -11,10 +11,18 @@ import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.failure.ValidationFailure
 import app.mcorg.pipeline.idea.CreateIdeaInput
+import app.mcorg.pipeline.idea.commonsteps.IdeaProductionModeInput
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
+
+/** One mode as the draft holds it — named, with its item -> rate map. */
+@Serializable
+data class DraftProductionMode(
+    val name: String = "",
+    val rates: Map<String, Int> = emptyMap(),
+)
 
 @Serializable
 data class DraftData(
@@ -25,6 +33,8 @@ data class DraftData(
     val author: Author? = null,
     val versionRange: MinecraftVersionRange? = null,
     val itemRequirements: Map<String, Int>? = null,
+    /** What the idea produces, by mode (MCO-412). Absent for anything that produces nothing. */
+    val productionModes: List<DraftProductionMode>? = null,
     val categoryData: Map<String, CategoryValue>? = null
 )
 
@@ -91,6 +101,8 @@ object DeserializeDraftStep : Step<IdeaDraft, AppFailure.ValidationError, Create
                 versionRange = data.versionRange!!,
                 testData = null,
                 itemRequirements = data.itemRequirements ?: emptyMap(),
+                productionModes = data.productionModes.orEmpty()
+                    .map { IdeaProductionModeInput(name = it.name, rates = it.rates) },
                 categoryData = categoryData ?: emptyMap()
             )
         )

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
@@ -39,7 +39,9 @@ import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.put
@@ -264,7 +266,8 @@ private fun buildFormJson(params: Parameters, fallbackAuthorName: String): Strin
 /**
  * Converts form params for a given wizard stage into a JSON string suitable for JSONB merge.
  */
-private fun buildStageJson(stage: DraftWizardStage, params: Parameters): String {
+/** Internal rather than private so the per-stage parsing can be tested directly. */
+internal fun buildStageJson(stage: DraftWizardStage, params: Parameters): String {
     return when (stage) {
         DraftWizardStage.BASIC_INFO -> buildJsonObject {
             params["name"]?.let { put("name", it) }
@@ -326,6 +329,43 @@ private fun buildStageJson(stage: DraftWizardStage, params: Parameters): String 
             if (items.isNotEmpty()) {
                 putJsonObject("itemRequirements") {
                     items.forEach { (k, v) -> put(k, v) }
+                }
+            }
+        }.toString()
+
+        // productionMode[i][name] names a mode; productionRate[i][<item id>] is one of its rates.
+        // The index groups them and is positional only — it is the order the author added them in,
+        // and it is re-assigned on every save, so nothing may reference it.
+        DraftWizardStage.PRODUCTIONS -> buildJsonObject {
+            val names = params.names()
+                .filter { it.startsWith("productionMode[") && it.endsWith("][name]") }
+                .associate { key ->
+                    key.removePrefix("productionMode[").removeSuffix("][name]") to (params[key] ?: "")
+                }
+            val ratesByMode = params.names()
+                .filter { it.startsWith("productionRate[") }
+                .mapNotNull { key ->
+                    val body = key.removePrefix("productionRate[")
+                    val index = body.substringBefore("]", missingDelimiterValue = "")
+                    val itemId = body.substringAfter("][", missingDelimiterValue = "").removeSuffix("]")
+                    val rate = params[key]?.toIntOrNull()
+                    if (index.isBlank() || itemId.isBlank() || rate == null || rate < 0) null
+                    else Triple(index, itemId, rate)
+                }
+                .groupBy({ it.first }, { it.second to it.third })
+
+            // A mode with no rates says nothing about the farm, so it does not survive the form.
+            val modes = ratesByMode.keys.sortedBy { it.toIntOrNull() ?: Int.MAX_VALUE }
+            if (modes.isNotEmpty()) {
+                putJsonArray("productionModes") {
+                    modes.forEach { index ->
+                        addJsonObject {
+                            put("name", names[index] ?: "")
+                            putJsonObject("rates") {
+                                ratesByMode[index].orEmpty().forEach { (itemId, rate) -> put(itemId, rate) }
+                            }
+                        }
+                    }
                 }
             }
         }.toString()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
@@ -38,6 +38,7 @@ import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonObject
@@ -348,8 +349,13 @@ internal fun buildStageJson(stage: DraftWizardStage, params: Parameters): String
                     val body = key.removePrefix("productionRate[")
                     val index = body.substringBefore("]", missingDelimiterValue = "")
                     val itemId = body.substringAfter("][", missingDelimiterValue = "").removeSuffix("]")
-                    val rate = params[key]?.toIntOrNull()
-                    if (index.isBlank() || itemId.isBlank() || rate == null || rate < 0) null
+                    val raw = params[key]?.trim().orEmpty()
+                    // Blank is "produces this, never measured how fast" — a small private bamboo
+                    // farm still tells you it makes bamboo. Only a *malformed* rate is discarded,
+                    // and the item with it, since there is nothing to trust in the row.
+                    val rate = if (raw.isEmpty()) null else raw.toIntOrNull()
+                    val malformed = raw.isNotEmpty() && (rate == null || rate < 0)
+                    if (index.isBlank() || itemId.isBlank() || malformed) null
                     else Triple(index, itemId, rate)
                 }
                 .groupBy({ it.first }, { it.second to it.third })
@@ -362,7 +368,9 @@ internal fun buildStageJson(stage: DraftWizardStage, params: Parameters): String
                         addJsonObject {
                             put("name", names[index] ?: "")
                             putJsonObject("rates") {
-                                ratesByMode[index].orEmpty().forEach { (itemId, rate) -> put(itemId, rate) }
+                                ratesByMode[index].orEmpty().forEach { (itemId, rate) ->
+                                    if (rate == null) put(itemId, JsonNull) else put(itemId, rate)
+                                }
                             }
                         }
                     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/RevertIdeaToDraftStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/RevertIdeaToDraftStep.kt
@@ -15,7 +15,11 @@ import kotlinx.serialization.json.put
 
 data class RevertIdeaToDraftInput(val ideaId: Int, val userId: Int)
 
-private data class RawIdeaExtras(val categoryDataJson: String, val itemRequirementsJson: String)
+private data class RawIdeaExtras(
+    val categoryDataJson: String,
+    val itemRequirementsJson: String,
+    val productionModesJson: String,
+)
 
 class RevertIdeaToDraftStep : Step<RevertIdeaToDraftInput, AppFailure, Int> {
     override suspend fun process(input: RevertIdeaToDraftInput): Result<AppFailure, Int> {
@@ -35,7 +39,21 @@ class RevertIdeaToDraftStep : Step<RevertIdeaToDraftInput, AppFailure, Int> {
                         (SELECT json_object_agg(item_id, quantity)
                          FROM idea_item_requirements WHERE idea_id = i.id),
                         '{}'
-                    )::text AS item_requirements
+                    )::text AS item_requirements,
+                    COALESCE(
+                        (SELECT json_agg(
+                                    json_build_object('name', m.name, 'rates', COALESCE(m.rates, '{}'::json))
+                                    ORDER BY m.position, m.id
+                                )
+                         FROM (
+                             SELECT pm.id, pm.name, pm.position,
+                                    (SELECT json_object_agg(r.item_id, r.rate_per_hour)
+                                     FROM idea_production_rates r WHERE r.mode_id = pm.id) AS rates
+                             FROM idea_production_modes pm
+                             WHERE pm.idea_id = i.id
+                         ) m),
+                        '[]'
+                    )::text AS production_modes
                 FROM ideas i
                 WHERE i.id = ?
                 """.trimIndent()
@@ -44,12 +62,17 @@ class RevertIdeaToDraftStep : Step<RevertIdeaToDraftInput, AppFailure, Int> {
             resultMapper = { rs ->
                 if (rs.next()) RawIdeaExtras(
                     categoryDataJson = rs.getString("category_data") ?: "{}",
-                    itemRequirementsJson = rs.getString("item_requirements") ?: "{}"
-                ) else RawIdeaExtras("{}", "{}")
+                    itemRequirementsJson = rs.getString("item_requirements") ?: "{}",
+                    productionModesJson = rs.getString("production_modes") ?: "[]"
+                ) else RawIdeaExtras("{}", "{}", "[]")
             }
-        ).process(input.ideaId).getOrNull() ?: RawIdeaExtras("{}", "{}")
+        ).process(input.ideaId).getOrNull() ?: RawIdeaExtras("{}", "{}", "[]")
 
-        // Build draft JSON — categoryData and itemRequirements are copied verbatim from DB
+        // Build draft JSON — categoryData, itemRequirements and productionModes are copied verbatim
+        // from DB. Everything the idea holds has to come back, because publishing the draft replaces
+        // the idea wholesale: replaceIdeaProductionModes opens with an unconditional DELETE, so a
+        // key missing here is not "left alone", it is deleted on save. Editing a description used to
+        // silently wipe every rate the farm had.
         val draftData = buildJsonObject {
             put("name", idea.name)
             put("description", idea.description)
@@ -62,6 +85,9 @@ class RevertIdeaToDraftStep : Step<RevertIdeaToDraftInput, AppFailure, Int> {
             }
             if (extras.itemRequirementsJson != "{}") {
                 put("itemRequirements", Json.parseToJsonElement(extras.itemRequirementsJson))
+            }
+            if (extras.productionModesJson != "[]") {
+                put("productionModes", Json.parseToJsonElement(extras.productionModesJson))
             }
         }.toString()
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/UpdateExistingIdeaStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/UpdateExistingIdeaStep.kt
@@ -7,6 +7,7 @@ import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.idea.commonsteps.replaceIdeaProductionModes
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.idea.CreateIdeaInput
 import kotlinx.serialization.builtins.MapSerializer
@@ -73,6 +74,13 @@ class UpdateExistingIdeaStep : Step<UpdateExistingIdeaInput, AppFailure.Database
 
                             if (requirementResult is Result.Failure) return requirementResult
                         }
+
+                        val productions = replaceIdeaProductionModes(
+                            input.ideaId,
+                            input.createInput.productionModes,
+                            connection,
+                        )
+                        if (productions is Result.Failure) return productions
 
                         return Result.success(input.ideaId)
                     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/ValidateStageStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/ValidateStageStep.kt
@@ -11,6 +11,7 @@ import app.mcorg.pipeline.idea.validators.ValidateIdeaDescriptionStep
 import app.mcorg.pipeline.idea.validators.ValidateIdeaDifficultyStep
 import app.mcorg.pipeline.idea.validators.ValidateIdeaMinecraftVersionStep
 import app.mcorg.pipeline.idea.validators.ValidateIdeaNameStep
+import app.mcorg.pipeline.idea.validators.ValidateIdeaProductionsStep
 import app.mcorg.presentation.templated.idea.createwizard.DraftWizardStage
 import io.ktor.http.Parameters
 
@@ -35,9 +36,12 @@ object ValidateStageStep : Step<ValidateStageInput, AppFailure, List<ValidationF
             DraftWizardStage.VERSION_COMPATIBILITY ->
                 (ValidateIdeaMinecraftVersionStep.process(input.params) as? Result.Failure)?.error ?: emptyList()
             DraftWizardStage.ITEM_REQUIREMENTS -> emptyList()
-            // Nothing to reject: a non-numeric or negative rate is dropped while the draft JSON is
-            // built, and an idea that produces nothing is the normal case rather than an error.
-            DraftWizardStage.PRODUCTIONS -> emptyList()
+            // A non-numeric or negative rate is still dropped while the draft JSON is built, and an
+            // idea that produces nothing is the normal case rather than an error. What *is* rejected
+            // is a colliding mode name and an item id the catalog does not have — both of which
+            // used to surface as either a 23505 rollback or nothing at all. See the step's doc.
+            DraftWizardStage.PRODUCTIONS ->
+                (ValidateIdeaProductionsStep().process(input.params) as? Result.Success)?.value ?: emptyList()
             DraftWizardStage.CATEGORY_FIELDS -> buildList {
                 val categoryResult = ValidateIdeaCategoryStep.process(input.params)
                 if (categoryResult is Result.Failure) {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/ValidateStageStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/ValidateStageStep.kt
@@ -35,6 +35,9 @@ object ValidateStageStep : Step<ValidateStageInput, AppFailure, List<ValidationF
             DraftWizardStage.VERSION_COMPATIBILITY ->
                 (ValidateIdeaMinecraftVersionStep.process(input.params) as? Result.Failure)?.error ?: emptyList()
             DraftWizardStage.ITEM_REQUIREMENTS -> emptyList()
+            // Nothing to reject: a non-numeric or negative rate is dropped while the draft JSON is
+            // built, and an idea that produces nothing is the normal case rather than an error.
+            DraftWizardStage.PRODUCTIONS -> emptyList()
             DraftWizardStage.CATEGORY_FIELDS -> buildList {
                 val categoryResult = ValidateIdeaCategoryStep.process(input.params)
                 if (categoryResult is Result.Failure) {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/single/GetIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/single/GetIdeaPipeline.kt
@@ -1,6 +1,7 @@
 package app.mcorg.pipeline.idea.single
 
 import app.mcorg.domain.model.idea.Comment
+import app.mcorg.pipeline.idea.commonsteps.GetIdeaProductionModesStep
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.SafeSQL
@@ -25,7 +26,9 @@ suspend fun ApplicationCall.handleGetIdea() {
 
     handlePipeline(
         onSuccess = { (idea, comments, materials) ->
-            respondHtml(ideaPage(user, idea, comments, materials))
+            val productionModes = GetIdeaProductionModesStep(idea.id).process(Unit).getOrNull().orEmpty()
+
+            respondHtml(ideaPage(user, idea, comments, materials, productionModes))
         }
     ) {
         parallel(

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaProductionsStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaProductionsStep.kt
@@ -1,0 +1,112 @@
+package app.mcorg.pipeline.idea.validators
+
+import app.mcorg.domain.model.idea.IdeaProductionMode
+import app.mcorg.domain.model.minecraft.MinecraftVersionRange
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.pipeline.failure.ValidationFailure
+import app.mcorg.pipeline.idea.commonsteps.GetItemsInVersionRangeStep
+import io.ktor.http.Parameters
+
+/**
+ * Validates the PRODUCTIONS stage of the idea form (MCO-412).
+ *
+ * Two things are rejected here, and both were previously silent:
+ *
+ * 1. **Two modes resolving to the same name.** `idea_production_modes` carries
+ *    `UNIQUE (idea_id, name)`, and a blank name is stored as
+ *    [IdeaProductionMode.DEFAULT_MODE_NAME] — so two unnamed modes collide just as surely as two
+ *    called "Max speed". Reaching the insert turns that into a 23505 and a rolled-back publish with
+ *    no field-level message, which reads as "the site is broken" rather than "name the second one".
+ *
+ * 2. **An item id that is not in the catalog.** The item field is free text and the client prepends
+ *    `minecraft:` to anything without a colon, so "Blue Ice" becomes `minecraft:Blue Ice` and stores
+ *    happily. Nothing downstream forgives it: MCO-294 matches farm supply by item id, so the row
+ *    never matches anything, and `ImportIdeaPipeline` fails the *entire* import of that idea into
+ *    every world. Catching it here is late — after the whole form is filled — but it names the id,
+ *    which is the part that was missing. The proper fix is a per-mode item search; see MCO-417.
+ *
+ * The version range comes from the same submitted parameters, matching what the retired
+ * category-data validation did: the single-page form (MCO-310) posts every stage at once.
+ */
+data class ValidateIdeaProductionsStep(
+    /**
+     * The ids the catalog has for a version range, or null when it cannot be read. Injected so the
+     * name checks stay testable without a database; production uses [catalogItemIds].
+     */
+    private val knownItemIds: suspend (MinecraftVersionRange) -> Set<String>? = ::catalogItemIds,
+) : Step<Parameters, AppFailure, List<ValidationFailure>> {
+
+    override suspend fun process(input: Parameters): Result<AppFailure, List<ValidationFailure>> {
+        val modes = parseModes(input)
+        if (modes.isEmpty()) return Result.success(emptyList())
+
+        return Result.success(duplicateNameErrors(modes) + unknownItemErrors(input, modes))
+    }
+
+    /** Mode index -> (submitted name, item ids). Mirrors `buildStageJson`'s parameter shape. */
+    private fun parseModes(params: Parameters): Map<String, Pair<String, List<String>>> {
+        val names = params.names()
+            .filter { it.startsWith("productionMode[") && it.endsWith("][name]") }
+            .associate { key ->
+                key.removePrefix("productionMode[").removeSuffix("][name]") to (params[key] ?: "")
+            }
+        val itemsByMode = params.names()
+            .filter { it.startsWith("productionRate[") }
+            .mapNotNull { key ->
+                val body = key.removePrefix("productionRate[")
+                val index = body.substringBefore("]", missingDelimiterValue = "")
+                val itemId = body.substringAfter("][", missingDelimiterValue = "").removeSuffix("]")
+                if (index.isBlank() || itemId.isBlank()) null else index to itemId
+            }
+            .groupBy({ it.first }, { it.second })
+
+        // Only modes that carry rates survive the save, so only those can collide or hold a bad id.
+        return itemsByMode.mapValues { (index, items) -> (names[index] ?: "") to items }
+    }
+
+    private fun duplicateNameErrors(modes: Map<String, Pair<String, List<String>>>): List<ValidationFailure> {
+        val resolved = modes.mapValues { (_, mode) -> mode.first.trim().ifBlank { IdeaProductionMode.DEFAULT_MODE_NAME } }
+        return resolved.values
+            .groupingBy { it }
+            .eachCount()
+            .filterValues { it > 1 }
+            .keys
+            .map { name ->
+                val index = resolved.entries.first { it.value == name }.key
+                val message = if (name == IdeaProductionMode.DEFAULT_MODE_NAME) {
+                    "Give each way of running this a name — more than one is unnamed, and they cannot all be the default."
+                } else {
+                    "Two ways of running this are both called \"$name\". Names have to differ."
+                }
+                ValidationFailure.CustomValidation("productionMode[$index][name]", message)
+            }
+    }
+
+    private suspend fun unknownItemErrors(
+        params: Parameters,
+        modes: Map<String, Pair<String, List<String>>>,
+    ): List<ValidationFailure> {
+        val submitted = modes.values.flatMap { it.second }.distinct()
+        if (submitted.isEmpty()) return emptyList()
+
+        val versionRange = ValidateIdeaMinecraftVersionStep.process(params).getOrNull()
+            ?: MinecraftVersionRange.Unbounded
+        // A catalog we cannot read is not evidence the ids are wrong — stay silent rather than
+        // rejecting a form that is fine.
+        val known = knownItemIds(versionRange) ?: return emptyList()
+
+        return submitted.filterNot { it in known }.map { itemId ->
+            val index = modes.entries.first { itemId in it.value.second }.key
+            ValidationFailure.CustomValidation(
+                "productionRate[$index][$itemId]",
+                "\"$itemId\" is not an item in this version. Use the exact id, like minecraft:blue_ice.",
+            )
+        }
+    }
+}
+
+/** The real catalog lookup, kept out of the step so tests can substitute a set of ids. */
+private suspend fun catalogItemIds(versionRange: MinecraftVersionRange): Set<String>? =
+    GetItemsInVersionRangeStep.process(versionRange).getOrNull()?.mapTo(mutableSetOf()) { it.id }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -321,12 +321,16 @@ private val GetIdeaForImportStep = DatabaseSteps.transaction { connection ->
 /**
  * The rates an imported farm project should record, chosen from the idea's modes.
  *
- * A farm in a world runs one way at a time, so the project stores a flat item -> rate set — the
- * shape `project_productions` has always had. The mode is a fact about how *you* run it rather
- * than about the design, so the project keeps the rates and not the modes (decision, 2026-08-16).
+ * **Interim, and known to be the wrong shape** (Even, 2026-08-16, reversing the same day's earlier
+ * call): which mode a farm runs in is a *runtime* choice, not a build-time one. You might run the
+ * fortress farm skeletons-only this week and everything-on next, and flattening the choice at
+ * import means re-typing rates to switch. The modes belong on the project, with one active —
+ * filed separately because it reaches into project_productions, the supply map and the
+ * production editor.
  *
- * With one mode there is nothing to choose. With several and no explicit choice, the mode
- * producing the most across its items wins: an import that silently picked the slowest would
+ * Until then the project records one mode's rates flat, which is what `project_productions` has
+ * always held. With one mode there is nothing to choose. With several and no explicit choice, the
+ * mode producing the most across its items wins: an import that silently picked the slowest would
  * under-promise supply for no reason the user could see.
  */
 internal fun ratesForImport(modes: List<IdeaProductionMode>, chosenModeName: String? = null): Map<String, Int> {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -336,8 +336,11 @@ private val GetIdeaForImportStep = DatabaseSteps.transaction { connection ->
 internal fun ratesForImport(modes: List<IdeaProductionMode>, chosenModeName: String? = null): Map<String, Int> {
     if (modes.isEmpty()) return emptyMap()
     val chosen = chosenModeName?.let { name -> modes.firstOrNull { it.name == name } }
-        ?: modes.maxByOrNull { mode -> mode.rates.values.sumOf { it.toLong() } }
-    return chosen?.rates ?: emptyMap()
+        ?: modes.maxByOrNull { mode -> mode.rates.values.sumOf { (it ?: 0).toLong() } }
+    // An unmeasured rate becomes 0, which is what project_productions already means by it —
+    // ProductionPanel prints "rate unknown" for exactly this. The two sides represent the same
+    // fact differently until MCO-413 unifies them, and this is the one place that maps between.
+    return chosen?.rates.orEmpty().mapValues { (_, rate) -> rate ?: 0 }
 }
 
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -9,6 +9,8 @@ import app.mcorg.domain.model.minecraft.MinecraftVersionRange
 import app.mcorg.domain.model.project.ProjectType
 import app.mcorg.event.IdeaImported
 import app.mcorg.event.eventBus
+import app.mcorg.domain.model.idea.IdeaProductionMode
+import app.mcorg.pipeline.idea.commonsteps.GetIdeaProductionModesStep
 import app.mcorg.pipeline.Result
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
@@ -258,7 +260,7 @@ private val GetIdeaForImportStep = DatabaseSteps.transaction { connection ->
         override suspend fun process(input: Int): Result<AppFailure.DatabaseError, Pair<BasicIdeaInfo, Map<String, Int>>> {
             val ideaInfo = DatabaseSteps.query<Int, BasicIdeaInfo>(
                 sql = SafeSQL.select("""
-                    SELECT id, name, description, category, category_data ->> 'productionRate' as production_rate
+                    SELECT id, name, description, category
                     FROM ideas
                     WHERE id = ?
                 """.trimIndent()),
@@ -272,11 +274,8 @@ private val GetIdeaForImportStep = DatabaseSteps.transaction { connection ->
                         resultSet.getString("name"),
                         resultSet.getString("description"),
                         IdeaCategory.valueOf(resultSet.getString("category")),
-                        extractProductionRates(
-                            resultSet.getString("production_rate")
-                                ?.let { Json.decodeFromString<CategoryValue>(it) as? CategoryValue.MapValue }?.value
-                                ?: emptyMap()
-                        )
+                        // Read from the idea's own production tables below, not from category JSON.
+                        emptyMap()
                     )
                 },
                 transactionConnection = connection
@@ -306,27 +305,37 @@ private val GetIdeaForImportStep = DatabaseSteps.transaction { connection ->
                 return Result.Failure(requirementInfo.error)
             }
 
-            return Result.Success(Pair(ideaInfo.getOrNull()!!, requirementInfo.getOrNull()!!))
-        }
-    }
-}
-
-private fun extractProductionRates(productionRateData: Map<String, CategoryValue>): Map<String, Int> {
-    val productionRates = mutableMapOf<String, Int>()
-    val modeMap = productionRateData["value"] as? CategoryValue.MapValue ?: return productionRates
-
-    for (mode in modeMap.value.values) {
-        if (mode is CategoryValue.MapValue) {
-            for ((itemId, amountValue) in mode.value) {
-                if (amountValue is CategoryValue.IntValue) {
-                    productionRates[itemId] = (productionRates[itemId] ?: 0) // TODO: Support multiple production entries?
-                }
+            // Productions live in their own tables now (MCO-412). The idea carries modes; the
+            // project records the rates of the one it will be run in.
+            val modes = GetIdeaProductionModesStep(input).process(Unit)
+            if (modes is Result.Failure) {
+                return Result.Failure(modes.error)
             }
+
+            val info = ideaInfo.getOrNull()!!.copy(productionRate = ratesForImport(modes.getOrNull()!!))
+            return Result.Success(Pair(info, requirementInfo.getOrNull()!!))
         }
     }
-
-    return productionRates
 }
+
+/**
+ * The rates an imported farm project should record, chosen from the idea's modes.
+ *
+ * A farm in a world runs one way at a time, so the project stores a flat item -> rate set — the
+ * shape `project_productions` has always had. The mode is a fact about how *you* run it rather
+ * than about the design, so the project keeps the rates and not the modes (decision, 2026-08-16).
+ *
+ * With one mode there is nothing to choose. With several and no explicit choice, the mode
+ * producing the most across its items wins: an import that silently picked the slowest would
+ * under-promise supply for no reason the user could see.
+ */
+internal fun ratesForImport(modes: List<IdeaProductionMode>, chosenModeName: String? = null): Map<String, Int> {
+    if (modes.isEmpty()) return emptyMap()
+    val chosen = chosenModeName?.let { name -> modes.firstOrNull { it.name == name } }
+        ?: modes.maxByOrNull { mode -> mode.rates.values.sumOf { it.toLong() } }
+    return chosen?.rates ?: emptyMap()
+}
+
 
 private data class ValidateItemIdsStep(val availableIds: List<Item>) : Step<Pair<BasicIdeaInfo, Map<String, Int>>, AppFailure, IdeaForImport> {
     override suspend fun process(input: Pair<BasicIdeaInfo, Map<String, Int>>): Result<AppFailure, IdeaForImport> {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaPage.kt
@@ -3,6 +3,7 @@ package app.mcorg.presentation.templated.idea
 import app.mcorg.domain.model.idea.Comment
 import app.mcorg.domain.model.idea.Idea
 import app.mcorg.domain.model.idea.IdeaVisibility
+import app.mcorg.domain.model.idea.IdeaProductionMode
 import app.mcorg.domain.model.user.TokenProfile
 import app.mcorg.pipeline.idea.single.IdeaMaterial
 import app.mcorg.presentation.hxDeleteWithConfirm
@@ -29,6 +30,7 @@ fun ideaPage(
     idea: Idea,
     comments: List<Comment>,
     materials: List<IdeaMaterial> = emptyList(),
+    productionModes: List<IdeaProductionMode> = emptyList(),
 ): String = pageShell(
     pageTitle = "Seam — ${idea.name}",
     user = user,
@@ -46,6 +48,7 @@ fun ideaPage(
             div("idea-detail") {
                 ideaDetailHeader(user, idea)
                 ideaDetailFields(idea)
+                ideaProductionModes(productionModes)
                 ideaMaterialList(materials)
                 ideaRatingDistribution(idea, comments)
                 ideaCommentsSection(user.id, idea, comments)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaProductionModes.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaProductionModes.kt
@@ -30,13 +30,22 @@ fun FlowContent.ideaProductionModes(modes: List<IdeaProductionMode>) {
                     span("idea-productions__mode-name") { +mode.name }
                 }
                 ul("idea-productions__rates") {
-                    mode.rates.entries.sortedByDescending { it.value }.forEach { (itemId, rate) ->
-                        li("idea-productions__rate") {
-                            span("idea-productions__quantity") { +"%,d".format(rate) }
-                            +" / hour "
-                            span("idea-productions__item") { +itemId.removePrefix("minecraft:").replace('_', ' ') }
+                    // Measured output first; an unmeasured item is still output and still listed,
+                    // it just cannot claim a number.
+                    mode.rates.entries
+                        .sortedWith(compareByDescending<Map.Entry<String, Int?>> { it.value ?: -1 }.thenBy { it.key })
+                        .forEach { (itemId, rate) ->
+                            li("idea-productions__rate") {
+                                if (rate != null) {
+                                    span("idea-productions__quantity") { +"%,d".format(rate) }
+                                    +" / hour "
+                                }
+                                span("idea-productions__item") { +itemId.removePrefix("minecraft:").replace('_', ' ') }
+                                if (rate == null) {
+                                    span("idea-productions__unmeasured") { +" — rate unmeasured" }
+                                }
+                            }
                         }
-                    }
                 }
             }
         }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaProductionModes.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaProductionModes.kt
@@ -1,0 +1,44 @@
+package app.mcorg.presentation.templated.idea
+
+import app.mcorg.domain.model.idea.IdeaProductionMode
+import kotlinx.html.FlowContent
+import kotlinx.html.div
+import kotlinx.html.h2
+import kotlinx.html.li
+import kotlinx.html.section
+import kotlinx.html.span
+import kotlinx.html.ul
+
+/**
+ * What an idea produces (MCO-412), read from its own tables rather than category data.
+ *
+ * A mode name only appears when there is more than one. An author who never mentioned modes gets
+ * the implicit "Default", and printing that word back at them would name a choice they did not
+ * make — the list is just items and rates until the design actually has alternatives.
+ */
+fun FlowContent.ideaProductionModes(modes: List<IdeaProductionMode>) {
+    val populated = modes.filter { it.rates.isNotEmpty() }
+    if (populated.isEmpty()) return
+
+    val named = populated.size > 1
+
+    section("idea-productions") {
+        h2("idea-detail__section-title") { +"Produces" }
+        populated.forEach { mode ->
+            div("idea-productions__mode") {
+                if (named) {
+                    span("idea-productions__mode-name") { +mode.name }
+                }
+                ul("idea-productions__rates") {
+                    mode.rates.entries.sortedByDescending { it.value }.forEach { (itemId, rate) ->
+                        li("idea-productions__rate") {
+                            span("idea-productions__quantity") { +"%,d".format(rate) }
+                            +" / hour "
+                            span("idea-productions__item") { +itemId.removePrefix("minecraft:").replace('_', ' ') }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftFormPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftFormPage.kt
@@ -116,11 +116,13 @@ private fun FlowContent.draftFormContent(
             draftCategorySelect(draft)
         }
 
-        optionalSection("Design details", "Size, production rate, and anything else measurable") {
+        optionalSection("Design details", "Size, and anything else measurable") {
             draftCategorySchemaFields(draft)
         }
 
-        optionalSection("Materials", "What it takes to build — or drop in a .litematic") {
+        // "Materials" alone stopped covering this section when production moved in (MCO-412):
+        // it now holds both what the design consumes and what it makes.
+        optionalSection("Materials and output", "What it takes to build and what it produces — or drop in a .litematic") {
             draftItemRequirementFields(draft)
             draftProductionFields(draft)
         }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftFormPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftFormPage.kt
@@ -122,6 +122,7 @@ private fun FlowContent.draftFormContent(
 
         optionalSection("Materials", "What it takes to build — or drop in a .litematic") {
             draftItemRequirementFields(draft)
+            draftProductionFields(draft)
         }
 
         optionalSection("Versions and credit", "Defaults to all versions, credited to you") {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
@@ -125,7 +125,9 @@ private fun FlowContent.productionModeBlock(index: Int, mode: DraftProductionMod
                 attributes["data-mode-index"] = index.toString()
             }
             input(type = InputType.number, classes = "form-control production-item-rate") {
-                placeholder = "Per hour"
+                // Optional on purpose: knowing a farm makes bamboo is worth recording even when
+                // nobody has timed it, and an invented rate would be worse than none.
+                placeholder = "Per hour (optional)"
                 min = "0"
                 attributes["data-mode-index"] = index.toString()
             }
@@ -138,20 +140,22 @@ private fun FlowContent.productionModeBlock(index: Int, mode: DraftProductionMod
 
         ul("wizard-item-list production-mode__rates") {
             id = "production-rates-$index"
-            mode.rates.entries.sortedByDescending { it.value }.forEach { (itemId, rate) ->
-                li("item-req") {
-                    span { +"$itemId × $rate/h" }
-                    hiddenInput {
-                        name = "productionRate[$index][$itemId]"
-                        value = rate.toString()
-                    }
-                    button(classes = "btn btn--ghost btn--sm") {
-                        type = ButtonType.button
-                        attributes["onclick"] = "this.closest('li').remove()"
-                        +"Remove"
+            mode.rates.entries
+                .sortedWith(compareByDescending<Map.Entry<String, Int?>> { it.value ?: -1 }.thenBy { it.key })
+                .forEach { (itemId, rate) ->
+                    li("item-req") {
+                        span { +if (rate == null) "$itemId — rate unmeasured" else "$itemId × $rate/h" }
+                        hiddenInput {
+                            name = "productionRate[$index][$itemId]"
+                            value = rate?.toString() ?: ""
+                        }
+                        button(classes = "btn btn--ghost btn--sm") {
+                            type = ButtonType.button
+                            attributes["onclick"] = "this.closest('li').remove()"
+                            +"Remove"
+                        }
                     }
                 }
-            }
         }
     }
 }
@@ -171,8 +175,10 @@ private fun productionScript() = """
         var itemInput = block.querySelector('.production-item-search');
         var rateInput = block.querySelector('.production-item-rate');
         var itemId = itemInput.value.trim();
-        var rate = parseInt(rateInput.value, 10);
-        if (!itemId || isNaN(rate) || rate < 0) return;
+        var rawRate = rateInput.value.trim();
+        var rate = rawRate === '' ? null : parseInt(rawRate, 10);
+        if (!itemId) return;
+        if (rate !== null && (isNaN(rate) || rate < 0)) return;
         if (itemId.indexOf(':') === -1) itemId = 'minecraft:' + itemId;
 
         var list = document.getElementById('production-rates-' + index);
@@ -182,8 +188,9 @@ private fun productionScript() = """
         var li = document.createElement('li');
         li.className = 'item-req';
         li.dataset.itemId = itemId;
-        li.innerHTML = '<span>' + itemId + ' × ' + rate + '/h</span>' +
-            '<input type="hidden" name="productionRate[' + index + '][' + itemId + ']" value="' + rate + '">' +
+        var label = rate === null ? itemId + ' — rate unmeasured' : itemId + ' × ' + rate + '/h';
+        li.innerHTML = '<span>' + label + '</span>' +
+            '<input type="hidden" name="productionRate[' + index + '][' + itemId + ']" value="' + (rate === null ? '' : rate) + '">' +
             '<button type="button" class="btn btn--ghost btn--sm" onclick="this.closest(\'li\').remove()">Remove</button>';
         list.appendChild(li);
         itemInput.value = '';

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
@@ -113,9 +113,13 @@ private fun FlowContent.productionModeBlock(index: Int, mode: DraftProductionMod
                 placeholder = "How it is run — \"Max speed\", \"Skeletons only\""
             }
         } else {
+            // Carries the existing name rather than blanking it. A mode can be named and then
+            // become the only one — delete the rates from "Slowed" and "Max speed" is alone — and
+            // writing "" here would rename it to Default on the next save, silently discarding a
+            // name the author chose.
             hiddenInput {
                 name = "productionMode[$index][name]"
-                value = ""
+                value = mode.name
             }
         }
 
@@ -144,6 +148,12 @@ private fun FlowContent.productionModeBlock(index: Int, mode: DraftProductionMod
                 .sortedWith(compareByDescending<Map.Entry<String, Int?>> { it.value ?: -1 }.thenBy { it.key })
                 .forEach { (itemId, rate) ->
                     li("item-req") {
+                        // The add-a-rate script de-duplicates on this attribute. Without it a row
+                        // that came back from a saved draft is invisible to that lookup, so re-adding
+                        // the item appends a second hidden input with the same name and the *old*
+                        // value wins on parse — the correction disappears with no feedback.
+                        // Scoped per mode by the enclosing <ul>, since one item can appear in several.
+                        attributes["data-item-id"] = itemId
                         span { +if (rate == null) "$itemId — rate unmeasured" else "$itemId × $rate/h" }
                         hiddenInput {
                             name = "productionRate[$index][$itemId]"
@@ -232,7 +242,9 @@ private fun productionScript() = """
                 named.type = 'text';
                 named.className = 'form-control production-mode__name';
                 named.name = hidden.name;
-                named.value = '';
+                // Keep whatever the hidden input held — a mode that already has a name keeps it
+                // when it grows a visible field.
+                named.value = hidden.value;
                 named.placeholder = 'How it is run — "Max speed", "Skeletons only"';
                 hidden.replaceWith(named);
             }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
@@ -1,5 +1,6 @@
 package app.mcorg.presentation.templated.idea.createwizard
 
+import app.mcorg.domain.model.idea.IdeaCategory
 import app.mcorg.domain.model.idea.IdeaDraft
 import app.mcorg.pipeline.idea.draft.DraftData
 import app.mcorg.pipeline.idea.draft.DraftProductionMode
@@ -7,6 +8,7 @@ import kotlinx.html.ButtonType
 import kotlinx.html.FlowContent
 import kotlinx.html.InputType
 import kotlinx.html.button
+import kotlinx.html.classes
 import kotlinx.html.div
 import kotlinx.html.hiddenInput
 import kotlinx.html.id
@@ -43,6 +45,9 @@ fun FlowContent.draftProductionFields(draft: IdeaDraft) {
         .getOrDefault(DraftData())
     val modes = data.productionModes.orEmpty().ifEmpty { listOf(DraftProductionMode()) }
 
+    val isFarm = data.category == IdeaCategory.FARM
+    val hasRates = modes.any { it.rates.isNotEmpty() }
+
     div("wizard-section") {
         id = "draft-productions"
         attributes["data-mode-count"] = modes.size.toString()
@@ -51,6 +56,24 @@ fun FlowContent.draftProductionFields(draft: IdeaDraft) {
         p("form-help") {
             +"What this design makes, per hour. Leave empty for anything that produces nothing — "
             +"a storage system, a base, a decorative build."
+        }
+
+        // Recommended, not required (MCO-412). Requiring it would undo MCO-310, whose whole point
+        // was making capture fast enough that the bank fills up — and an author who has watched a
+        // video but not built the farm honestly does not know the rate yet. A gate would either
+        // block that capture or teach people to type a number they made up, and an invented rate
+        // is worse than a missing one.
+        //
+        // So state the consequence instead of nagging. It is a real one and it is specific: farm
+        // suggestions match demand against produced items (MCO-294), so a farm with nothing here
+        // is invisible to exactly the moment it was worth capturing for.
+        div("callout callout--info production-recommendation") {
+            id = "production-recommendation"
+            if (!isFarm || hasRates) classes = classes + "production-recommendation--hidden"
+            span("callout__body") {
+                +"Worth filling in for a farm: Seam suggests farms by what they produce, so one "
+                +"with no output here will not come up when a world needs that item."
+            }
         }
 
         div {
@@ -165,7 +188,28 @@ private fun productionScript() = """
         list.appendChild(li);
         itemInput.value = '';
         rateInput.value = '';
+        refreshProductionRecommendation();
     }
+
+    function refreshProductionRecommendation() {
+        var note = document.getElementById('production-recommendation');
+        if (!note) return;
+        var farm = document.querySelector('.category-radio[value="FARM"]');
+        var isFarm = farm && farm.checked;
+        var hasRates = document.querySelectorAll('#production-modes input[name^="productionRate["]').length > 0;
+        note.classList.toggle('production-recommendation--hidden', !isFarm || hasRates);
+    }
+
+    document.addEventListener('change', function (event) {
+        if (event.target && event.target.classList.contains('category-radio')) {
+            refreshProductionRecommendation();
+        }
+    });
+
+    document.addEventListener('click', function (event) {
+        // Removing the last rate should bring the note back.
+        if (event.target && event.target.tagName === 'BUTTON') setTimeout(refreshProductionRecommendation, 0);
+    });
 
     function addProductionMode() {
         var container = document.getElementById('production-modes');

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
@@ -1,0 +1,203 @@
+package app.mcorg.presentation.templated.idea.createwizard
+
+import app.mcorg.domain.model.idea.IdeaDraft
+import app.mcorg.pipeline.idea.draft.DraftData
+import app.mcorg.pipeline.idea.draft.DraftProductionMode
+import kotlinx.html.ButtonType
+import kotlinx.html.FlowContent
+import kotlinx.html.InputType
+import kotlinx.html.button
+import kotlinx.html.div
+import kotlinx.html.hiddenInput
+import kotlinx.html.id
+import kotlinx.html.input
+import kotlinx.html.label
+import kotlinx.html.li
+import kotlinx.html.p
+import kotlinx.html.script
+import kotlinx.html.span
+import kotlinx.html.ul
+import kotlinx.html.unsafe
+import kotlinx.serialization.json.Json
+
+private val productionJson = Json { ignoreUnknownKeys = true; isLenient = true }
+
+/**
+ * What this idea produces (MCO-412).
+ *
+ * ## Why modes are almost invisible here
+ *
+ * Almost every farm has one mode with one set of items, and this exact field carried a
+ * Mode → (Item → Rate) nesting once before: MCO-204 tore it out as "the single most tedious thing
+ * in the form", and it "never got filled". The model needs modes back — an ice farm runs full
+ * speed or slowed, a nether fortress farm has six ways to run — but the form must not charge the
+ * common case for the rare one.
+ *
+ * So the first mode has no name field and is never called a mode. You add items and rates. Only
+ * when you press "This farm can be run another way" does a second block appear, and only then do
+ * names show up at all — including on the first block, which has to be nameable once there is
+ * something to distinguish it from.
+ */
+fun FlowContent.draftProductionFields(draft: IdeaDraft) {
+    val data = runCatching { productionJson.decodeFromString(DraftData.serializer(), draft.data) }
+        .getOrDefault(DraftData())
+    val modes = data.productionModes.orEmpty().ifEmpty { listOf(DraftProductionMode()) }
+
+    div("wizard-section") {
+        id = "draft-productions"
+        attributes["data-mode-count"] = modes.size.toString()
+
+        label { +"Produces" }
+        p("form-help") {
+            +"What this design makes, per hour. Leave empty for anything that produces nothing — "
+            +"a storage system, a base, a decorative build."
+        }
+
+        div {
+            id = "production-modes"
+            modes.forEachIndexed { index, mode ->
+                productionModeBlock(index, mode, showName = modes.size > 1)
+            }
+        }
+
+        button(classes = "btn btn--ghost btn--sm") {
+            type = ButtonType.button
+            id = "add-production-mode"
+            attributes["onclick"] = "addProductionMode()"
+            +"This farm can be run another way"
+        }
+
+        script {
+            unsafe { raw(productionScript()) }
+        }
+    }
+}
+
+/**
+ * One mode: an optional name and its item/rate rows.
+ *
+ * [showName] is false while there is only one mode — the name is stored as blank and becomes
+ * "Default" on save, because an author who was never asked about modes has not chosen one.
+ */
+private fun FlowContent.productionModeBlock(index: Int, mode: DraftProductionMode, showName: Boolean) {
+    div("production-mode") {
+        attributes["data-mode-index"] = index.toString()
+
+        if (showName) {
+            input(type = InputType.text, classes = "form-control production-mode__name") {
+                name = "productionMode[$index][name]"
+                value = mode.name
+                placeholder = "How it is run — \"Max speed\", \"Skeletons only\""
+            }
+        } else {
+            hiddenInput {
+                name = "productionMode[$index][name]"
+                value = ""
+            }
+        }
+
+        div("production-mode__add") {
+            input(type = InputType.text, classes = "form-control production-item-search") {
+                placeholder = "Item"
+                attributes["data-mode-index"] = index.toString()
+            }
+            input(type = InputType.number, classes = "form-control production-item-rate") {
+                placeholder = "Per hour"
+                min = "0"
+                attributes["data-mode-index"] = index.toString()
+            }
+            button(classes = "btn btn--secondary btn--sm") {
+                type = ButtonType.button
+                attributes["onclick"] = "addProductionRate(this)"
+                +"Add"
+            }
+        }
+
+        ul("wizard-item-list production-mode__rates") {
+            id = "production-rates-$index"
+            mode.rates.entries.sortedByDescending { it.value }.forEach { (itemId, rate) ->
+                li("item-req") {
+                    span { +"$itemId × $rate/h" }
+                    hiddenInput {
+                        name = "productionRate[$index][$itemId]"
+                        value = rate.toString()
+                    }
+                    button(classes = "btn btn--ghost btn--sm") {
+                        type = ButtonType.button
+                        attributes["onclick"] = "this.closest('li').remove()"
+                        +"Remove"
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Adding a rate row and adding a mode, client-side.
+ *
+ * The item field takes a raw id rather than reusing the requirement search: that search posts to a
+ * fragment endpoint and owns a single set of element ids, so it cannot be repeated per mode
+ * without reworking it. Deliberate V1 limit — noted on the issue, and the ids are validated on
+ * import against the world's catalog either way.
+ */
+private fun productionScript() = """
+    function addProductionRate(btn) {
+        var block = btn.closest('.production-mode');
+        var index = block.dataset.modeIndex;
+        var itemInput = block.querySelector('.production-item-search');
+        var rateInput = block.querySelector('.production-item-rate');
+        var itemId = itemInput.value.trim();
+        var rate = parseInt(rateInput.value, 10);
+        if (!itemId || isNaN(rate) || rate < 0) return;
+        if (itemId.indexOf(':') === -1) itemId = 'minecraft:' + itemId;
+
+        var list = document.getElementById('production-rates-' + index);
+        var existing = list.querySelector('[data-item-id="' + itemId + '"]');
+        if (existing) existing.remove();
+
+        var li = document.createElement('li');
+        li.className = 'item-req';
+        li.dataset.itemId = itemId;
+        li.innerHTML = '<span>' + itemId + ' × ' + rate + '/h</span>' +
+            '<input type="hidden" name="productionRate[' + index + '][' + itemId + ']" value="' + rate + '">' +
+            '<button type="button" class="btn btn--ghost btn--sm" onclick="this.closest(\'li\').remove()">Remove</button>';
+        list.appendChild(li);
+        itemInput.value = '';
+        rateInput.value = '';
+    }
+
+    function addProductionMode() {
+        var container = document.getElementById('production-modes');
+        var section = document.getElementById('draft-productions');
+        var index = parseInt(section.dataset.modeCount, 10);
+        section.dataset.modeCount = index + 1;
+
+        // The first mode only grows a name field once there is a second one to tell it apart from.
+        container.querySelectorAll('.production-mode').forEach(function (block) {
+            var hidden = block.querySelector('input[type=hidden][name$="][name]"]');
+            if (hidden) {
+                var named = document.createElement('input');
+                named.type = 'text';
+                named.className = 'form-control production-mode__name';
+                named.name = hidden.name;
+                named.value = '';
+                named.placeholder = 'How it is run — "Max speed", "Skeletons only"';
+                hidden.replaceWith(named);
+            }
+        });
+
+        var block = document.createElement('div');
+        block.className = 'production-mode';
+        block.dataset.modeIndex = index;
+        block.innerHTML =
+            '<input type="text" class="form-control production-mode__name" name="productionMode[' + index + '][name]" placeholder="How it is run — &quot;Max speed&quot;, &quot;Skeletons only&quot;">' +
+            '<div class="production-mode__add">' +
+            '<input type="text" class="form-control production-item-search" placeholder="Item" data-mode-index="' + index + '">' +
+            '<input type="number" class="form-control production-item-rate" placeholder="Per hour" min="0" data-mode-index="' + index + '">' +
+            '<button type="button" class="btn btn--secondary btn--sm" onclick="addProductionRate(this)">Add</button>' +
+            '</div>' +
+            '<ul class="wizard-item-list production-mode__rates" id="production-rates-' + index + '"></ul>';
+        container.appendChild(block);
+    }
+""".trimIndent()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftWizardStage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftWizardStage.kt
@@ -16,6 +16,7 @@ enum class DraftWizardStage(val displayName: String) {
     AUTHOR_INFO("Author"),
     VERSION_COMPATIBILITY("Version"),
     ITEM_REQUIREMENTS("Items"),
+    PRODUCTIONS("Produces"),
     CATEGORY_FIELDS("Category"),
     REVIEW("Review"),
 }

--- a/webapp/mc-web/src/main/resources/db/migration/V2_57_0__add_idea_production_modes.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_57_0__add_idea_production_modes.sql
@@ -1,0 +1,48 @@
+-- What an idea produces, relationally — modes and their rates.
+--
+-- Until now this lived in `ideas.category_data -> 'productionRate'` as untyped JSON on the FARM
+-- category. Three problems with that, and MCO-294 hits all of them: it cannot be joined against
+-- demand, it is category-gated (a mob farm inside a storage build produces nothing, as far as the
+-- schema is concerned), and its only reader has been broken since MCO-204 changed the shape under
+-- it — no idea import has ever written a production row (MCO-411). So there is no data to
+-- preserve here, only a shape to replace.
+--
+-- ## Modes
+--
+-- A farm can run in more than one way, and the ways produce different things at different rates:
+-- an ice farm at full speed or slowed for lag; a nether fortress farm with a wither-skeleton
+-- filter on or off, times three speeds. Modes are **flat**, deliberately — the fortress farm is
+-- six modes, not two axes multiplied. Axes would model that one case more elegantly and every
+-- other case worse, and the six-mode farm is rare.
+--
+-- Most farms have exactly one mode with one set of items. That case must stay free: the form
+-- creates a single mode without ever saying the word, and mode UI appears only on the second one.
+-- The nesting this replaces was removed once already (MCO-204) for being "the single most tedious
+-- thing in the form"; re-introducing it only works if the common case never pays for it.
+CREATE TABLE idea_production_modes
+(
+    id       SERIAL PRIMARY KEY,
+    idea_id  INT  NOT NULL REFERENCES ideas (id) ON DELETE CASCADE,
+    -- Names the way the farm is run ("Max speed", "Skeletons only, slow"). Unique per idea so a
+    -- mode can be referred to by name — a project records which one it was built to run.
+    name     TEXT NOT NULL,
+    -- Author's ordering. Not a ranking: which mode is *best* depends on the demand being matched,
+    -- so that is computed, never stored.
+    position INT  NOT NULL DEFAULT 0,
+    UNIQUE (idea_id, name)
+);
+
+CREATE INDEX idea_production_modes_idea_id_idx ON idea_production_modes (idea_id);
+
+CREATE TABLE idea_production_rates
+(
+    mode_id       INT  NOT NULL REFERENCES idea_production_modes (id) ON DELETE CASCADE,
+    item_id       TEXT NOT NULL,
+    -- Items per hour. Matches project_productions.rate_per_hour, which is what an import writes
+    -- into once a mode is chosen.
+    rate_per_hour INT  NOT NULL CHECK (rate_per_hour >= 0),
+    PRIMARY KEY (mode_id, item_id)
+);
+
+-- MCO-294's lookup direction: "which ideas produce this item, and how fast at best?"
+CREATE INDEX idea_production_rates_item_id_idx ON idea_production_rates (item_id);

--- a/webapp/mc-web/src/main/resources/db/migration/V2_57_0__add_idea_production_modes.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_57_0__add_idea_production_modes.sql
@@ -41,9 +41,18 @@ CREATE TABLE idea_production_rates
 (
     mode_id       INT  NOT NULL REFERENCES idea_production_modes (id) ON DELETE CASCADE,
     item_id       TEXT NOT NULL,
-    -- Items per hour. Matches project_productions.rate_per_hour, which is what an import writes
-    -- into once a mode is chosen.
-    rate_per_hour INT  NOT NULL CHECK (rate_per_hour >= 0),
+    -- Items per hour, or NULL for "produces this, rate unmeasured".
+    --
+    -- Knowing *what* a design makes is worth capturing on its own: someone sharing a small bamboo
+    -- farm knows it makes bamboo without ever having timed it, and demanding a number would either
+    -- lose the design or invite an invented one.
+    --
+    -- NULL rather than 0, even though project_productions already reads 0 as "rate unknown"
+    -- (ProductionPanel prints exactly that). Following that convention here would make zero mean
+    -- two things in one column, and this feature already has one bug whose entire symptom was
+    -- rates silently being 0 (MCO-411). The project side keeps its convention until MCO-413
+    -- unifies the two; the mapping between them is one place, in the import.
+    rate_per_hour INT  NULL CHECK (rate_per_hour IS NULL OR rate_per_hour >= 0),
     PRIMARY KEY (mode_id, item_id)
 );
 
@@ -81,6 +90,9 @@ WHERE m.name = 'Default'
   -- thing a farm can do — the column's CHECK would reject it and take the whole migration with it.
   AND jsonb_typeof(entry.payload -> 'value') = 'number'
   AND (entry.payload ->> 'value')::numeric >= 0;
+
+-- Every carried-over rate is a number: the old form required one. Unmeasured output only becomes
+-- expressible from here on.
 
 -- The JSON is left in place. It is unread from here on (the FARM schema's productionRate field
 -- goes with the form work), and leaving it costs nothing while making this migration reversible

--- a/webapp/mc-web/src/main/resources/db/migration/V2_57_0__add_idea_production_modes.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_57_0__add_idea_production_modes.sql
@@ -4,8 +4,11 @@
 -- category. Three problems with that, and MCO-294 hits all of them: it cannot be joined against
 -- demand, it is category-gated (a mob farm inside a storage build produces nothing, as far as the
 -- schema is concerned), and its only reader has been broken since MCO-204 changed the shape under
--- it — no idea import has ever written a production row (MCO-411). So there is no data to
--- preserve here, only a shape to replace.
+-- it — no idea import has ever written a production row (MCO-411).
+--
+-- The JSON *was* being written, though, even while nothing could read it: authors have entered
+-- real farms through the form. Those rates are carried over at the bottom of this file rather
+-- than asking anyone to type them again.
 --
 -- ## Modes
 --
@@ -46,3 +49,39 @@ CREATE TABLE idea_production_rates
 
 -- MCO-294's lookup direction: "which ideas produce this item, and how fast at best?"
 CREATE INDEX idea_production_rates_item_id_idx ON idea_production_rates (item_id);
+
+-- ---------------------------------------------------------------------------------------------
+-- Carry over what the form already captured.
+--
+-- The stored shape is a CategoryValue tree:
+--
+--   category_data -> 'productionRate' -> 'value' -> { "<item id>": { "type": ..., "value": 71000 } }
+--
+-- Every such idea becomes one mode. It is named "Default" because these authors were never asked
+-- about modes — there was no such concept when they filled the form in — and calling it anything
+-- else would attribute a choice to them that they did not make.
+INSERT INTO idea_production_modes (idea_id, name, position)
+SELECT i.id, 'Default', 0
+FROM ideas i
+WHERE jsonb_typeof(i.category_data -> 'productionRate' -> 'value') = 'object'
+  AND EXISTS (
+      SELECT 1
+      FROM jsonb_each(i.category_data -> 'productionRate' -> 'value') AS entry(item_id, payload)
+      WHERE jsonb_typeof(payload -> 'value') = 'number'
+  );
+
+INSERT INTO idea_production_rates (mode_id, item_id, rate_per_hour)
+SELECT m.id, entry.item_id, round((entry.payload ->> 'value')::numeric)::int
+FROM idea_production_modes m
+         JOIN ideas i ON i.id = m.idea_id
+         CROSS JOIN LATERAL jsonb_each(i.category_data -> 'productionRate' -> 'value') AS entry(item_id, payload)
+WHERE m.name = 'Default'
+  AND m.position = 0
+  -- Anything non-numeric is a form artefact rather than a rate, and a negative rate is not a
+  -- thing a farm can do — the column's CHECK would reject it and take the whole migration with it.
+  AND jsonb_typeof(entry.payload -> 'value') = 'number'
+  AND (entry.payload ->> 'value')::numeric >= 0;
+
+-- The JSON is left in place. It is unread from here on (the FARM schema's productionRate field
+-- goes with the form work), and leaving it costs nothing while making this migration reversible
+-- by hand if the carried-over rates turn out wrong.

--- a/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
@@ -491,3 +491,29 @@
         flex: 1;
     }
 }
+
+/* MCO-412 — production modes, and the recommendation for farms that declare none. */
+.production-mode {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-2) 0;
+}
+
+.production-mode + .production-mode {
+    border-top: 1px dashed var(--border);
+}
+
+.production-mode__add {
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+}
+
+.production-mode__name {
+    font-family: var(--font-mono);
+}
+
+.production-recommendation--hidden {
+    display: none;
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/GetIdeasByCategoryStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/GetIdeasByCategoryStepTest.kt
@@ -126,12 +126,12 @@ class GetIdeasByCategoryStepTest : WithUser() {
         createTestIdea(
             name = "AFK Iron Farm",
             category = IdeaCategory.FARM,
-            categoryData = """{"afkable": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.BooleanValue", "value": true}, "productionRate": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MapValue", "value": {"Normal": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MapValue", "value": {"item.minecraft.golden_carrot": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 5000}}}}}}"""
+            categoryData = """{"afkable": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.BooleanValue", "value": true}, "specs": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MapValue", "value": {"Normal": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MapValue", "value": {"item.minecraft.golden_carrot": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 5000}}}}}}"""
         )
         createTestIdea(
             name = "Manual Iron Farm",
             category = IdeaCategory.FARM,
-            categoryData = """{"afkable": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.BooleanValue", "value": false}, "productionRate": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MapValue", "value": {"Normal": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MapValue", "value": {"item.minecraft.golden_carrot": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 5000}}}}}}"""
+            categoryData = """{"afkable": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.BooleanValue", "value": false}, "specs": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MapValue", "value": {"Normal": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.MapValue", "value": {"item.minecraft.golden_carrot": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 5000}}}}}}"""
         )
 
         // When: Filtering for AFK-able farms
@@ -158,23 +158,23 @@ class GetIdeasByCategoryStepTest : WithUser() {
         createTestIdea(
             name = "Slow Farm",
             category = IdeaCategory.FARM,
-            categoryData = """{"productionRate": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 500} }"""
+            categoryData = """{"specs": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 500} }"""
         )
         createTestIdea(
             name = "Medium Farm",
             category = IdeaCategory.FARM,
-            categoryData = """{"productionRate": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 5000} }"""
+            categoryData = """{"specs": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 5000} }"""
         )
         createTestIdea(
             name = "Fast Farm",
             category = IdeaCategory.FARM,
-            categoryData = """{"productionRate": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 15000} }"""
+            categoryData = """{"specs": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 15000} }"""
         )
 
         // When: Filtering for production rate between 1000 and 10000
         val filters = IdeaSearchFilters(
             category = IdeaCategory.FARM,
-            categoryFilters = mapOf("productionRate" to FilterValue.NumberRange(1000.0, 10000.0))
+            categoryFilters = mapOf("specs" to FilterValue.NumberRange(1000.0, 10000.0))
         )
         val result = SearchIdeasStep.process(filters)
 
@@ -283,7 +283,7 @@ class GetIdeasByCategoryStepTest : WithUser() {
             difficulty = IdeaDifficulty.START_OF_GAME,
             ratingAverage = 4.8,
             // language=json
-            categoryData = """{"productionRate": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 50}}"""
+            categoryData = """{"specs": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 50}}"""
         )
         createTestIdea(
             name = "Better Carrot Farm",
@@ -291,7 +291,7 @@ class GetIdeasByCategoryStepTest : WithUser() {
             difficulty = IdeaDifficulty.START_OF_GAME,
             ratingAverage = 4.2,
             // language=json
-            categoryData =  """{"productionRate": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 500}}"""
+            categoryData =  """{"specs": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 500}}"""
         )
         createTestIdea(
             name = "Good Carrot Farm",
@@ -299,7 +299,7 @@ class GetIdeasByCategoryStepTest : WithUser() {
             difficulty = IdeaDifficulty.END_GAME,
             ratingAverage = 4.5,
             // language=json
-            categoryData =  """{"productionRate": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 5000}, "afkable": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.BooleanValue", "value": true}}"""
+            categoryData =  """{"specs": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.IntValue", "value": 5000}, "afkable": {"type": "app.mcorg.domain.model.idea.schema.CategoryValue.BooleanValue", "value": true}}"""
         )
 
         // When: Applying multiple filters
@@ -309,7 +309,7 @@ class GetIdeasByCategoryStepTest : WithUser() {
             minRating = 4.5,
             categoryFilters = mapOf(
                 "afkable" to FilterValue.BooleanValue(true),
-                "productionRate" to FilterValue.NumberRange(1000.0, null)
+                "specs" to FilterValue.NumberRange(1000.0, null)
             )
         )
         val result = SearchIdeasStep.process(filters)

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/commonsteps/IdeaProductionModeMergeTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/commonsteps/IdeaProductionModeMergeTest.kt
@@ -1,0 +1,95 @@
+package app.mcorg.pipeline.idea.commonsteps
+
+import app.mcorg.domain.model.idea.IdeaProductionMode
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * MCO-412 — the last line of defence before `UNIQUE (idea_id, name)`.
+ *
+ * The form rejects colliding mode names with a field-level message, but a bodyless publish
+ * re-publishes stored draft JSON without re-validating it, so the write path has to survive a
+ * collision rather than roll the whole publish back on a 23505.
+ */
+class IdeaProductionModeMergeTest {
+
+    private fun mode(name: String, vararg rates: Pair<String, Int?>) =
+        IdeaProductionModeInput(name, rates.toMap())
+
+    @Test
+    fun `a blank name resolves to Default`() {
+        val merged = listOf(mode("", "minecraft:ice" to 71000)).mergeByResolvedName()
+
+        assertEquals(IdeaProductionMode.DEFAULT_MODE_NAME, merged.single().name)
+    }
+
+    @Test
+    fun `two unnamed modes become one Default carrying both items`() {
+        val merged = listOf(
+            mode("", "minecraft:ice" to 71000),
+            mode("", "minecraft:bamboo" to 400),
+        ).mergeByResolvedName()
+
+        assertEquals(1, merged.size)
+        assertEquals(IdeaProductionMode.DEFAULT_MODE_NAME, merged.single().name)
+        assertEquals(mapOf("minecraft:ice" to 71000, "minecraft:bamboo" to 400), merged.single().rates)
+    }
+
+    @Test
+    fun `the faster rate wins when both name the same item`() {
+        // Consistent with bestRateFor, which already answers "how fast, at best".
+        val merged = listOf(
+            mode("Max speed", "minecraft:ice" to 62000),
+            mode("Max speed", "minecraft:ice" to 71000),
+        ).mergeByResolvedName()
+
+        assertEquals(mapOf("minecraft:ice" to 71000), merged.single().rates)
+    }
+
+    @Test
+    fun `a measured rate beats an unmeasured one regardless of order`() {
+        // null is "never timed", not zero — it must never displace a real number.
+        val nullFirst = listOf(
+            mode("Default", "minecraft:ice" to null),
+            mode("Default", "minecraft:ice" to 71000),
+        ).mergeByResolvedName()
+        val numberFirst = listOf(
+            mode("Default", "minecraft:ice" to 71000),
+            mode("Default", "minecraft:ice" to null),
+        ).mergeByResolvedName()
+
+        assertEquals(mapOf("minecraft:ice" to 71000), nullFirst.single().rates)
+        assertEquals(mapOf("minecraft:ice" to 71000), numberFirst.single().rates)
+    }
+
+    @Test
+    fun `an item unmeasured on both sides stays unmeasured rather than becoming zero`() {
+        val merged = listOf(
+            mode("Default", "minecraft:bamboo" to null),
+            mode("Default", "minecraft:bamboo" to null),
+        ).mergeByResolvedName()
+
+        assertEquals(mapOf("minecraft:bamboo" to null), merged.single().rates)
+    }
+
+    @Test
+    fun `distinct names are left alone and keep their order`() {
+        val merged = listOf(
+            mode("Max speed", "minecraft:ice" to 71000),
+            mode("Slowed", "minecraft:ice" to 20000),
+        ).mergeByResolvedName()
+
+        assertEquals(listOf("Max speed", "Slowed"), merged.map { it.name })
+    }
+
+    @Test
+    fun `a trailing space does not create a second mode`() {
+        val merged = listOf(
+            mode("Max speed", "minecraft:ice" to 71000),
+            mode("Max speed ", "minecraft:bamboo" to 400),
+        ).mergeByResolvedName()
+
+        assertEquals(1, merged.size)
+        assertEquals("Max speed", merged.single().name)
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/draft/ProductionStageParsingTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/draft/ProductionStageParsingTest.kt
@@ -1,0 +1,129 @@
+package app.mcorg.pipeline.idea.draft
+
+import app.mcorg.presentation.templated.idea.createwizard.DraftWizardStage
+import io.ktor.http.Parameters
+import io.ktor.http.parametersOf
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * MCO-412 — turning the productions form into draft JSON.
+ *
+ * The form names its fields `productionMode[i][name]` and `productionRate[i][<item id>]`, and the
+ * index only groups them: it is positional, re-assigned on every save, and referenced by nothing.
+ * These tests pin what survives that trip, because everything downstream — matching, import,
+ * the supply map — reads whatever this produces.
+ */
+class ProductionStageParsingTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    private fun parse(vararg pairs: Pair<String, String>): List<DraftProductionMode> {
+        val params: Parameters = parametersOf(*pairs.map { (k, v) -> k to listOf(v) }.toTypedArray())
+        val stageJson = buildStageJson(DraftWizardStage.PRODUCTIONS, params)
+        return json.decodeFromString(DraftData.serializer(), stageJson).productionModes.orEmpty()
+    }
+
+    @Test
+    fun `a single unnamed mode keeps its rates and no name`() {
+        // The common case: the author never saw the word "mode". The blank name becomes the
+        // implicit "Default" when it is stored, not here.
+        val modes = parse(
+            "productionMode[0][name]" to "",
+            "productionRate[0][minecraft:ice]" to "71000",
+        )
+
+        assertEquals(1, modes.size)
+        assertEquals("", modes.first().name)
+        assertEquals(mapOf("minecraft:ice" to 71000), modes.first().rates)
+    }
+
+    @Test
+    fun `several modes keep their names and their own rates`() {
+        val modes = parse(
+            "productionMode[0][name]" to "Max speed",
+            "productionRate[0][minecraft:ice]" to "62000",
+            "productionMode[1][name]" to "Slowed",
+            "productionRate[1][minecraft:ice]" to "18000",
+        )
+
+        assertEquals(listOf("Max speed", "Slowed"), modes.map { it.name })
+        assertEquals(mapOf("minecraft:ice" to 62000), modes[0].rates)
+        assertEquals(mapOf("minecraft:ice" to 18000), modes[1].rates)
+    }
+
+    @Test
+    fun `a mode carrying several items keeps all of them`() {
+        val modes = parse(
+            "productionMode[0][name]" to "Everything, fast",
+            "productionRate[0][minecraft:bone]" to "700",
+            "productionRate[0][minecraft:blaze_rod]" to "500",
+        )
+
+        assertEquals(
+            mapOf("minecraft:bone" to 700, "minecraft:blaze_rod" to 500),
+            modes.single().rates,
+        )
+    }
+
+    @Test
+    fun `a named mode with no rates does not survive`() {
+        // A named way of running a farm that produces nothing is a form artefact — someone pressed
+        // the button and changed their mind — not a fact about the farm.
+        val modes = parse(
+            "productionMode[0][name]" to "Max speed",
+            "productionRate[0][minecraft:ice]" to "62000",
+            "productionMode[1][name]" to "Abandoned",
+        )
+
+        assertEquals(listOf("Max speed"), modes.map { it.name })
+    }
+
+    @Test
+    fun `producing nothing is normal and yields no modes`() {
+        // A storage system, a base, a decorative build. Not an error.
+        assertTrue(parse("productionMode[0][name]" to "").isEmpty())
+    }
+
+    @Test
+    fun `a non-numeric rate is dropped rather than stored as zero`() {
+        val modes = parse(
+            "productionMode[0][name]" to "",
+            "productionRate[0][minecraft:ice]" to "fast",
+            "productionRate[0][minecraft:packed_ice]" to "900",
+        )
+
+        assertEquals(mapOf("minecraft:packed_ice" to 900), modes.single().rates)
+    }
+
+    @Test
+    fun `a negative rate is dropped`() {
+        // The column's CHECK would reject it; dropping it here means the form says "that did not
+        // stick" instead of the save failing wholesale.
+        val modes = parse(
+            "productionMode[0][name]" to "",
+            "productionRate[0][minecraft:ice]" to "-5",
+            "productionRate[0][minecraft:packed_ice]" to "900",
+        )
+
+        assertEquals(mapOf("minecraft:packed_ice" to 900), modes.single().rates)
+    }
+
+    @Test
+    fun `modes stay in the order the author added them`() {
+        // Position is the author's ordering and the form's grouping key; index 10 must not sort
+        // between 1 and 2.
+        val modes = parse(
+            "productionMode[0][name]" to "First",
+            "productionRate[0][minecraft:ice]" to "1",
+            "productionMode[10][name]" to "Eleventh",
+            "productionRate[10][minecraft:ice]" to "11",
+            "productionMode[2][name]" to "Third",
+            "productionRate[2][minecraft:ice]" to "3",
+        )
+
+        assertEquals(listOf("First", "Third", "Eleventh"), modes.map { it.name })
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/draft/ProductionStageParsingTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/draft/ProductionStageParsingTest.kt
@@ -88,6 +88,18 @@ class ProductionStageParsingTest {
     }
 
     @Test
+    fun `a blank rate keeps the item as unmeasured output`() {
+        // "I know it makes bamboo, I have never timed it" is information worth keeping. Requiring
+        // a number would either lose the design or invite an invented one.
+        val modes = parse(
+            "productionMode[0][name]" to "",
+            "productionRate[0][minecraft:bamboo]" to "",
+        )
+
+        assertEquals(mapOf("minecraft:bamboo" to null), modes.single().rates)
+    }
+
+    @Test
     fun `a non-numeric rate is dropped rather than stored as zero`() {
         val modes = parse(
             "productionMode[0][name]" to "",

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaCategoryDataStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaCategoryDataStepTest.kt
@@ -293,38 +293,6 @@ class ValidateIdeaCategoryDataStepTest {
     // --- Production rate: item -> rate, the one field the engine consumes ---
 
     @Test
-    fun `production rate maps items to rates`() {
-        val params = createParameters(
-            "categoryData.productionRate.key[]" to listOf("minecraft:iron_ingot", "minecraft:diamond"),
-            "categoryData.productionRate.value[]" to listOf("2000", "500")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertSuccess(step, params)
-
-        val rates = assertIs<CategoryValue.MapValue>(result["productionRate"]).value
-        assertEquals(CategoryValue.IntValue(2000), rates["minecraft:iron_ingot"])
-        assertEquals(CategoryValue.IntValue(500), rates["minecraft:diamond"])
-    }
-
-    @Test
-    fun `production rate with an unknown item returns failure`() {
-        val params = createParameters(
-            "categoryData.productionRate.key[]" to listOf("minecraft:unobtanium"),
-            "categoryData.productionRate.value[]" to listOf("2000")
-        )
-        val step = ValidateIdeaCategoryDataStep(IdeaCategory.FARM)
-
-        val result = TestUtils.executeAndAssertFailure(step, params)
-
-        assertTrue(result.any {
-            it is ValidationFailure.InvalidFormat && it.message?.contains("Invalid option") == true
-        })
-    }
-
-    // --- Reference links ---
-
-    @Test
     fun `references parse as a comma-separated list`() {
         val params = createParameters(
             "categoryData.references" to listOf("https://youtu.be/abc, https://example.com/schematic")
@@ -418,8 +386,6 @@ class ValidateIdeaCategoryDataStepTest {
             append("categoryData.size.x", "")
             append("categoryData.size.y", "")
             append("categoryData.size.z", "")
-            append("categoryData.productionRate.key[]", "")
-            append("categoryData.productionRate.value[]", "")
             append("categoryData.tileable", "")
             append("categoryData.directional", "")
             append("categoryData.afkable", "")
@@ -454,8 +420,6 @@ class ValidateIdeaCategoryDataStepTest {
             "categoryData.size.x" to listOf("10"),
             "categoryData.size.y" to listOf("20"),
             "categoryData.size.z" to listOf("30"),
-            "categoryData.productionRate.key[]" to listOf("minecraft:iron_ingot"),
-            "categoryData.productionRate.value[]" to listOf("2000"),
             "categoryData.tileable" to listOf("true"),
             "categoryData.afkable" to listOf("true"),
             "categoryData.specs.key[]" to listOf("Villagers"),
@@ -467,13 +431,12 @@ class ValidateIdeaCategoryDataStepTest {
         val result = TestUtils.executeAndAssertSuccess(step, params)
 
         assertEquals(
-            setOf("size", "productionRate", "tileable", "afkable", "specs", "references"),
+            // productionRate left the schema in MCO-412 — production is relational now.
+            setOf("size", "tileable", "afkable", "specs", "references"),
             result.keys
         )
         val size = assertIs<CategoryValue.MapValue>(result["size"]).value
         assertEquals(CategoryValue.IntValue(20), size["y"])
-        val rates = assertIs<CategoryValue.MapValue>(result["productionRate"]).value
-        assertEquals(CategoryValue.IntValue(2000), rates["minecraft:iron_ingot"])
         val specs = assertIs<CategoryValue.MapValue>(result["specs"]).value
         assertEquals(CategoryValue.TextValue("3"), specs["Villagers"])
     }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaProductionsStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaProductionsStepTest.kt
@@ -1,0 +1,139 @@
+package app.mcorg.pipeline.idea.validators
+
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.failure.ValidationFailure
+import io.ktor.http.Parameters
+import io.ktor.http.parametersOf
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * MCO-412 — what the productions stage rejects.
+ *
+ * Both cases here used to be silent in their own way: colliding mode names reached
+ * `UNIQUE (idea_id, name)` and rolled the publish back with no field-level message, and an item id
+ * outside the catalog stored happily and then never matched anything (MCO-294) while making the
+ * idea unimportable into every world.
+ */
+class ValidateIdeaProductionsStepTest {
+
+    private val catalog = setOf("minecraft:ice", "minecraft:blue_ice", "minecraft:bamboo")
+
+    private fun validate(vararg pairs: Pair<String, String>): List<ValidationFailure> {
+        val params: Parameters = parametersOf(*pairs.map { (k, v) -> k to listOf(v) }.toTypedArray())
+        val step = ValidateIdeaProductionsStep(knownItemIds = { catalog })
+        return runBlocking { (step.process(params) as Result.Success).value }
+    }
+
+    @Test
+    fun `the ordinary single unnamed mode passes`() {
+        val errors = validate(
+            "productionMode[0][name]" to "",
+            "productionRate[0][minecraft:ice]" to "71000",
+        )
+
+        assertTrue(errors.isEmpty(), "a farm with one mode and a known item is the common case")
+    }
+
+    @Test
+    fun `two unnamed modes are rejected before they collide on Default`() {
+        // Both resolve to "Default", which the unique index refuses. The author sees a name field
+        // on each block at this point, so asking them to fill one in is actionable.
+        val errors = validate(
+            "productionMode[0][name]" to "",
+            "productionRate[0][minecraft:ice]" to "71000",
+            "productionMode[1][name]" to "",
+            "productionRate[1][minecraft:ice]" to "62000",
+        )
+
+        assertEquals(1, errors.size)
+        val error = errors.single() as ValidationFailure.CustomValidation
+        assertTrue(error.parameterName.startsWith("productionMode["))
+        assertTrue(error.message.contains("unnamed"), "should say what is wrong: ${error.message}")
+    }
+
+    @Test
+    fun `two modes with the same name are rejected and the name is quoted back`() {
+        val errors = validate(
+            "productionMode[0][name]" to "Max speed",
+            "productionRate[0][minecraft:ice]" to "71000",
+            "productionMode[1][name]" to "Max speed",
+            "productionRate[1][minecraft:bamboo]" to "400",
+        )
+
+        val error = errors.single() as ValidationFailure.CustomValidation
+        assertTrue(error.message.contains("Max speed"), "the message names the collision: ${error.message}")
+    }
+
+    @Test
+    fun `names differing only by surrounding space still collide`() {
+        // They collide in the database, which trims nothing but receives the resolved name — so
+        // the check has to trim in the same place the write does.
+        val errors = validate(
+            "productionMode[0][name]" to "Max speed",
+            "productionRate[0][minecraft:ice]" to "71000",
+            "productionMode[1][name]" to "  Max speed  ",
+            "productionRate[1][minecraft:bamboo]" to "400",
+        )
+
+        assertEquals(1, errors.size)
+    }
+
+    @Test
+    fun `distinct names are fine`() {
+        val errors = validate(
+            "productionMode[0][name]" to "Max speed",
+            "productionRate[0][minecraft:ice]" to "71000",
+            "productionMode[1][name]" to "Slowed",
+            "productionRate[1][minecraft:ice]" to "20000",
+        )
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    fun `an item id outside the catalog is rejected and named`() {
+        // "Blue Ice" typed into the free-text field becomes minecraft:Blue Ice client-side.
+        val errors = validate(
+            "productionMode[0][name]" to "",
+            "productionRate[0][minecraft:Blue Ice]" to "3000",
+        )
+
+        val error = errors.single() as ValidationFailure.CustomValidation
+        assertEquals("productionRate[0][minecraft:Blue Ice]", error.parameterName)
+        assertTrue(error.message.contains("minecraft:Blue Ice"), "the message quotes the id: ${error.message}")
+    }
+
+    @Test
+    fun `an unmeasured rate is still checked for a real item`() {
+        // A blank rate is legitimate (MCO-412), but the item it names still has to exist.
+        val errors = validate(
+            "productionMode[0][name]" to "",
+            "productionRate[0][minecraft:bamboo]" to "",
+            "productionRate[0][minecraft:nonsense]" to "",
+        )
+
+        assertEquals(1, errors.size)
+        assertTrue((errors.single() as ValidationFailure.CustomValidation).message.contains("minecraft:nonsense"))
+    }
+
+    @Test
+    fun `an unreadable catalog rejects nothing`() {
+        // A database blip is not evidence the author is wrong, and blocking publish on it would
+        // lose the whole form.
+        val params = parametersOf("productionRate[0][minecraft:whatever]" to listOf("10"))
+        val step = ValidateIdeaProductionsStep(knownItemIds = { null })
+        val errors = runBlocking { (step.process(params) as Result.Success).value }
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
+    fun `an idea that produces nothing is not an error`() {
+        val errors = validate("productionMode[0][name]" to "")
+
+        assertTrue(errors.isEmpty(), "most builds produce nothing; that is the normal case")
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/IdeaProductionModeSelectionTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/IdeaProductionModeSelectionTest.kt
@@ -1,0 +1,101 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.domain.model.idea.IdeaProductionMode
+import app.mcorg.domain.model.idea.bestRateFor
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * MCO-412 — which mode's rates answer a question.
+ *
+ * Two different questions, two different answers, and they must not be confused:
+ *
+ * - *"Can this farm cover my demand?"* — [bestRateFor], the best any mode achieves, named.
+ * - *"What does the project I just imported produce?"* — [ratesForImport], one mode's whole set,
+ *   because a farm in a world runs one way at a time.
+ */
+class IdeaProductionModeSelectionTest {
+
+    private fun mode(name: String, position: Int, vararg rates: Pair<String, Int>) =
+        IdeaProductionMode(id = position + 1, name = name, position = position, rates = rates.toMap())
+
+    private val iceFarm = listOf(
+        mode("Max speed", 0, "minecraft:ice" to 62_000),
+        mode("Slowed", 1, "minecraft:ice" to 18_000),
+    )
+
+    // A nether fortress farm: a wither-skeleton filter crossed with three speeds, modelled flat
+    // as six modes rather than two axes.
+    private val fortressFarm = listOf(
+        mode("Skeletons only, fast", 0, "minecraft:bone" to 900, "minecraft:wither_skeleton_skull" to 40),
+        mode("Skeletons only, slow", 1, "minecraft:bone" to 300, "minecraft:wither_skeleton_skull" to 12),
+        mode("Everything, fast", 2, "minecraft:bone" to 700, "minecraft:blaze_rod" to 500, "minecraft:nether_wart" to 200),
+    )
+
+    @Test
+    fun `the best rate across modes is the one a suggestion should quote`() {
+        val (mode, rate) = iceFarm.bestRateFor("minecraft:ice")!!
+
+        assertEquals(62_000, rate)
+        assertEquals("Max speed", mode.name)
+    }
+
+    @Test
+    fun `the best rate names its own mode so the assumption is visible`() {
+        // The point of returning the mode alongside the number: "62,000/h in Max speed" states the
+        // best case as a best case, instead of quietly promising it.
+        val (mode, _) = fortressFarm.bestRateFor("minecraft:bone")!!
+
+        assertEquals("Skeletons only, fast", mode.name)
+    }
+
+    @Test
+    fun `an item no mode produces has no rate`() {
+        assertNull(iceFarm.bestRateFor("minecraft:diamond"))
+    }
+
+    @Test
+    fun `an idea with no modes has no rate`() {
+        assertNull(emptyList<IdeaProductionMode>().bestRateFor("minecraft:ice"))
+    }
+
+    @Test
+    fun `importing a single-mode farm takes that mode without asking`() {
+        val single = listOf(mode("Default", 0, "minecraft:cobblestone" to 12_000))
+
+        assertEquals(mapOf("minecraft:cobblestone" to 12_000), ratesForImport(single))
+    }
+
+    @Test
+    fun `importing with an explicit mode takes exactly that mode`() {
+        assertEquals(mapOf("minecraft:ice" to 18_000), ratesForImport(iceFarm, chosenModeName = "Slowed"))
+    }
+
+    @Test
+    fun `an unknown mode name falls back rather than importing nothing`() {
+        // A stale name from a form should not produce a farm that supplies nothing at all.
+        assertEquals(mapOf("minecraft:ice" to 62_000), ratesForImport(iceFarm, chosenModeName = "Turbo"))
+    }
+
+    @Test
+    fun `without a choice the most productive mode wins, across all its items`() {
+        // "Everything, fast" totals 1,400/h against "Skeletons only, fast" at 940 — the comparison
+        // is over the mode's whole output, not its best single item.
+        assertEquals(
+            mapOf("minecraft:bone" to 700, "minecraft:blaze_rod" to 500, "minecraft:nether_wart" to 200),
+            ratesForImport(fortressFarm),
+        )
+    }
+
+    @Test
+    fun `importing an idea with no modes produces nothing`() {
+        assertEquals(emptyMap(), ratesForImport(emptyList()))
+    }
+
+    @Test
+    fun `the implicit mode is recognisable`() {
+        assertEquals(true, mode(IdeaProductionMode.DEFAULT_MODE_NAME, 0, "minecraft:ice" to 1).isImplicit)
+        assertEquals(false, mode("Max speed", 0, "minecraft:ice" to 1).isImplicit)
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/IdeaProductionModeSelectionTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/IdeaProductionModeSelectionTest.kt
@@ -2,9 +2,11 @@ package app.mcorg.pipeline.project
 
 import app.mcorg.domain.model.idea.IdeaProductionMode
 import app.mcorg.domain.model.idea.bestRateFor
+import app.mcorg.domain.model.idea.produces
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * MCO-412 — which mode's rates answer a question.
@@ -17,7 +19,7 @@ import kotlin.test.assertNull
  */
 class IdeaProductionModeSelectionTest {
 
-    private fun mode(name: String, position: Int, vararg rates: Pair<String, Int>) =
+    private fun mode(name: String, position: Int, vararg rates: Pair<String, Int?>) =
         IdeaProductionMode(id = position + 1, name = name, position = position, rates = rates.toMap())
 
     private val iceFarm = listOf(
@@ -91,6 +93,43 @@ class IdeaProductionModeSelectionTest {
     @Test
     fun `importing an idea with no modes produces nothing`() {
         assertEquals(emptyMap(), ratesForImport(emptyList()))
+    }
+
+    @Test
+    fun `a farm that produces something it never measured still produces it`() {
+        // A small private bamboo farm: the author knows what it makes, not how fast. Ignoring it
+        // because nobody timed it would hide the design for the wrong reason.
+        val bambooFarm = listOf(mode("Default", 0, "minecraft:bamboo" to null))
+
+        assertTrue(bambooFarm.produces("minecraft:bamboo"))
+        assertNull(bambooFarm.bestRateFor("minecraft:bamboo"))
+    }
+
+    @Test
+    fun `an unmeasured rate never wins the best-rate comparison`() {
+        val mixed = listOf(
+            mode("Measured", 0, "minecraft:ice" to 1_000),
+            mode("Unmeasured", 1, "minecraft:ice" to null),
+        )
+
+        assertEquals("Measured", mixed.bestRateFor("minecraft:ice")!!.first.name)
+    }
+
+    @Test
+    fun `an unmeasured rate imports as zero, which the project already reads as unknown`() {
+        val bambooFarm = listOf(mode("Default", 0, "minecraft:bamboo" to null))
+
+        assertEquals(mapOf("minecraft:bamboo" to 0), ratesForImport(bambooFarm))
+    }
+
+    @Test
+    fun `an unmeasured mode does not beat a measured one when picking for import`() {
+        val modes = listOf(
+            mode("Unmeasured", 0, "minecraft:ice" to null, "minecraft:packed_ice" to null),
+            mode("Measured", 1, "minecraft:ice" to 500),
+        )
+
+        assertEquals(mapOf("minecraft:ice" to 500), ratesForImport(modes))
     }
 
     @Test

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/idea/DraftLifecycleIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/idea/DraftLifecycleIT.kt
@@ -7,6 +7,9 @@ import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.idea.draft.CreateDraftStep
+import app.mcorg.pipeline.idea.draft.DraftData
+import app.mcorg.pipeline.idea.draft.RevertIdeaToDraftInput
+import app.mcorg.pipeline.idea.draft.RevertIdeaToDraftStep
 import app.mcorg.pipeline.idea.draft.DeleteDraftInput
 import app.mcorg.pipeline.idea.draft.DeleteDraftStep
 import app.mcorg.pipeline.idea.draft.GetDraftInput
@@ -22,6 +25,9 @@ import app.mcorg.pipeline.idea.draft.handlePublishDraft
 import app.mcorg.pipeline.idea.draft.handleSaveDraftForm
 import app.mcorg.pipeline.idea.draft.handleRevertIdeaToDraft
 import app.mcorg.pipeline.idea.commonsteps.GetIdeaStep
+import app.mcorg.pipeline.idea.commonsteps.GetIdeaProductionModesStep
+import app.mcorg.pipeline.idea.draft.PublishDraftInput
+import app.mcorg.pipeline.idea.draft.PublishDraftStep
 import app.mcorg.presentation.plugins.AuthPlugin
 import app.mcorg.presentation.plugins.IdeaParamPlugin
 import app.mcorg.test.WithUser
@@ -53,6 +59,7 @@ import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @Tag("database")
@@ -570,7 +577,94 @@ class DraftLifecycleIT : WithUser() {
         assertEquals(HttpStatusCode.Found, response.status)
     }
 
+    @Test
+    fun `reverting an idea to a draft carries its production modes (MCO-412)`() = runBlocking {
+        // Publishing the draft replaces the idea wholesale — replaceIdeaProductionModes opens with
+        // an unconditional DELETE — so anything missing from the draft is not "left alone", it is
+        // deleted. Editing a description used to wipe every rate the farm had, with no warning and
+        // nothing in the form to show it had happened.
+        val ideaId = createIdea("Ice Farm", IdeaCategory.FARM)
+        addProductionMode(ideaId, "Max speed", 0, "minecraft:ice" to 71000)
+        addProductionMode(ideaId, "Slowed", 1, "minecraft:ice" to 18000, "minecraft:packed_ice" to null)
+
+        val draftId = (RevertIdeaToDraftStep().process(RevertIdeaToDraftInput(ideaId, user.id)) as Result.Success).value
+        val draft = GetDraftStep().process(GetDraftInput(draftId, user.id)).getOrNull()
+        assertNotNull(draft)
+
+        val modes = Json { ignoreUnknownKeys = true; isLenient = true }
+            .decodeFromString(DraftData.serializer(), draft.data).productionModes.orEmpty()
+
+        assertEquals(listOf("Max speed", "Slowed"), modes.map { it.name }, "modes come back in the author's order")
+        assertEquals(mapOf("minecraft:ice" to 71000), modes[0].rates)
+        // An unmeasured rate has to survive as null: 0 means "makes none of it", and the whole
+        // point of MCO-412's nullable column was that those are different facts.
+        assertEquals(mapOf("minecraft:ice" to 18000, "minecraft:packed_ice" to null), modes[1].rates)
+    }
+
+    @Test
+    fun `reverting an idea that produces nothing leaves productionModes out`() = runBlocking {
+        val ideaId = createIdea("Storage Hall", IdeaCategory.STORAGE)
+
+        val draftId = (RevertIdeaToDraftStep().process(RevertIdeaToDraftInput(ideaId, user.id)) as Result.Success).value
+        val draft = GetDraftStep().process(GetDraftInput(draftId, user.id)).getOrNull()
+        assertNotNull(draft)
+
+        val modes = Json { ignoreUnknownKeys = true; isLenient = true }
+            .decodeFromString(DraftData.serializer(), draft.data).productionModes
+
+        assertNull(modes, "most builds produce nothing; the key should simply be absent")
+    }
+
+    @Test
+    fun `editing a published idea and publishing it again keeps what it produces (MCO-412)`() = runBlocking {
+        // The whole round trip, because the two halves fail independently: revert has to copy the
+        // modes into the draft, and publish has to write back what the draft carries. Miss either
+        // and a farm loses its rates to an unrelated edit.
+        val ideaId = createIdea("Ice Farm", IdeaCategory.FARM)
+        addProductionMode(ideaId, "Max speed", 0, "minecraft:ice" to 71000)
+        addProductionMode(ideaId, "Slowed", 1, "minecraft:packed_ice" to null)
+
+        val draftId = (RevertIdeaToDraftStep().process(RevertIdeaToDraftInput(ideaId, user.id)) as Result.Success).value
+        val draft = GetDraftStep().process(GetDraftInput(draftId, user.id)).getOrNull()
+        assertNotNull(draft)
+        val publishedId = (PublishDraftStep().process(PublishDraftInput(draft, user.id)) as Result.Success).value
+
+        val modes = GetIdeaProductionModesStep(publishedId).process(Unit).getOrNull()
+        assertNotNull(modes)
+        assertEquals(listOf("Max speed", "Slowed"), modes.map { it.name })
+        assertEquals(mapOf("minecraft:ice" to 71000), modes[0].rates)
+        assertEquals(mapOf("minecraft:packed_ice" to null), modes[1].rates)
+    }
+
     // --- Helpers ---
+
+    private suspend fun addProductionMode(ideaId: Int, name: String, position: Int, vararg rates: Pair<String, Int?>) {
+        val modeId = (
+            DatabaseSteps.update<Unit>(
+                sql = SafeSQL.insert(
+                    "INSERT INTO idea_production_modes (idea_id, name, position) VALUES (?, ?, ?) RETURNING id"
+                ),
+                parameterSetter = { stmt, _ ->
+                    stmt.setInt(1, ideaId)
+                    stmt.setString(2, name)
+                    stmt.setInt(3, position)
+                }
+            ).process(Unit) as Result.Success
+            ).value
+
+        rates.forEach { (itemId, rate) ->
+            DatabaseSteps.update<Unit>(
+                sql = SafeSQL.insert(
+                    "INSERT INTO idea_production_rates (mode_id, item_id, rate_per_hour) VALUES (?, ?, ?)"
+                ),
+                parameterSetter = { stmt, _ ->
+                    stmt.setInt(1, modeId)
+                    stmt.setString(2, itemId)
+                    if (rate == null) stmt.setNull(3, java.sql.Types.INTEGER) else stmt.setInt(3, rate)
+                }
+            ).process(Unit)
+        }
+    }
 
     private fun createIdea(name: String, category: IdeaCategory, createdBy: Int = user.id): Int = runBlocking {
         val result = DatabaseSteps.update<Unit>(

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/IdeaDetailFieldsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/IdeaDetailFieldsTest.kt
@@ -18,7 +18,8 @@ import kotlin.test.assertTrue
 /**
  * Covers MCO-309: the detail page renders `categoryData` against the category schema.
  * The interesting behaviour is what gets *skipped* — unknown keys and empty values —
- * and the map-valued fields (`specs`, `productionRate`, `size`) that carry the detail.
+ * and the map-valued fields (`specs`, `size`) that carry the detail. Production moved out of
+ * category data entirely in MCO-412 — see IdeaProductionModesTest.
  */
 class IdeaDetailFieldsTest {
 
@@ -93,25 +94,6 @@ class IdeaDetailFieldsTest {
         }
 
         assertTrue(html.contains("gt per cycle"))
-    }
-
-    @Test
-    fun `production rate item ids are tidied and carry their unit`() {
-        val html = render {
-            ideaDetailFields(
-                idea(
-                    categoryData = mapOf(
-                        "productionRate" to CategoryValue.MapValue(
-                            mapOf("minecraft:iron_ingot" to CategoryValue.IntValue(1200))
-                        )
-                    )
-                )
-            )
-        }
-
-        assertTrue(html.contains("Iron Ingot"))
-        assertFalse(html.contains("minecraft:iron_ingot"))
-        assertTrue(html.contains("1200 items/hour"))
     }
 
     @Test

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/IdeaProductionModesTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/IdeaProductionModesTest.kt
@@ -1,0 +1,73 @@
+package app.mcorg.presentation.templated.idea
+
+import app.mcorg.domain.model.idea.IdeaProductionMode
+import kotlinx.html.div
+import kotlinx.html.stream.createHTML
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * MCO-412 — what an idea produces, on its detail page.
+ *
+ * Replaces the `productionRate` category-data rendering covered by IdeaDetailFieldsTest, which
+ * went when production stopped being a FARM schema field.
+ */
+class IdeaProductionModesTest {
+
+    private fun render(modes: List<IdeaProductionMode>) = createHTML().div { ideaProductionModes(modes) }
+
+    private fun mode(name: String, position: Int, vararg rates: Pair<String, Int>) =
+        IdeaProductionMode(id = position + 1, name = name, position = position, rates = rates.toMap())
+
+    @Test
+    fun `a single mode shows its rates without ever saying "mode"`() {
+        // The author was never asked about modes, so naming the implicit one back at them would
+        // attribute a choice they did not make.
+        val html = render(listOf(mode(IdeaProductionMode.DEFAULT_MODE_NAME, 0, "minecraft:ice" to 71_000)))
+
+        assertContains(html, "71,000")
+        assertContains(html, "ice")
+        assertFalse(html.contains(IdeaProductionMode.DEFAULT_MODE_NAME))
+    }
+
+    @Test
+    fun `several modes are named, because now there is something to tell apart`() {
+        val html = render(
+            listOf(
+                mode("Max speed", 0, "minecraft:ice" to 62_000),
+                mode("Slowed", 1, "minecraft:ice" to 18_000),
+            )
+        )
+
+        assertContains(html, "Max speed")
+        assertContains(html, "Slowed")
+        assertContains(html, "62,000")
+        assertContains(html, "18,000")
+    }
+
+    @Test
+    fun `item ids are tidied for reading`() {
+        val html = render(listOf(mode("Default", 0, "minecraft:wither_skeleton_skull" to 40)))
+
+        assertContains(html, "wither skeleton skull")
+        assertFalse(html.contains("minecraft:"))
+    }
+
+    @Test
+    fun `rates within a mode read largest first`() {
+        val html = render(
+            listOf(mode("Everything", 0, "minecraft:blaze_rod" to 500, "minecraft:bone" to 900))
+        )
+
+        assertTrue(html.indexOf("900") < html.indexOf("500"))
+    }
+
+    @Test
+    fun `an idea that produces nothing renders no section at all`() {
+        // Most builds produce nothing. An empty "Produces" heading would read as missing data.
+        assertFalse(render(emptyList()).contains("Produces"))
+        assertFalse(render(listOf(mode("Default", 0))).contains("Produces"))
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFieldsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFieldsTest.kt
@@ -1,0 +1,107 @@
+package app.mcorg.presentation.templated.idea.createwizard
+
+import app.mcorg.domain.model.idea.IdeaDraft
+import kotlinx.html.div
+import kotlinx.html.stream.createHTML
+import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
+import kotlin.test.assertContains
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * MCO-412 — the productions section of the idea form.
+ *
+ * Two behaviours worth pinning: modes stay out of sight until there are two, and the farm
+ * recommendation appears exactly when it is true.
+ */
+class DraftProductionFieldsTest {
+
+    private fun draft(data: String) = IdeaDraft(
+        id = 1,
+        userId = 1,
+        data = data,
+        currentStage = "PRODUCTIONS",
+        sourceIdeaId = null,
+        createdAt = ZonedDateTime.now(),
+        updatedAt = ZonedDateTime.now(),
+    )
+
+    private fun render(data: String) = createHTML().div { draftProductionFields(draft(data)) }
+
+    /**
+     * Markup only. The section carries its own inline script, which mentions every class it
+     * manipulates — asserting a class is absent from the whole document would match the script
+     * and never fail.
+     */
+    private fun markup(data: String) = render(data).substringBefore("<script")
+
+    private fun isRecommendationVisible(html: String): Boolean {
+        val marker = html.substringAfter("id=\"production-recommendation\"", "")
+        return html.contains("production-recommendation") &&
+            !html.substringBefore("id=\"production-recommendation\"").takeLast(120)
+                .contains("production-recommendation--hidden") &&
+            marker.isNotEmpty()
+    }
+
+    @Test
+    fun `one mode is never called a mode`() {
+        // The name is submitted blank and becomes "Default" on save; the author never sees either.
+        val html = markup("""{"productionModes":[{"name":"","rates":{"minecraft:ice":71000}}]}""")
+
+        assertContains(html, "productionMode[0][name]")
+        assertContains(html, "type=\"hidden\"")
+        assertFalse(html.contains("production-mode__name"))
+    }
+
+    @Test
+    fun `a second mode brings names to both`() {
+        val html = markup(
+            """{"productionModes":[
+                {"name":"Max speed","rates":{"minecraft:ice":62000}},
+                {"name":"Slowed","rates":{"minecraft:ice":18000}}
+            ]}"""
+        )
+
+        assertContains(html, "Max speed")
+        assertContains(html, "Slowed")
+        assertTrue(html.split("production-mode__name").size - 1 >= 2)
+    }
+
+    @Test
+    fun `existing rates come back as removable rows`() {
+        val html = render("""{"productionModes":[{"name":"","rates":{"minecraft:ice":71000}}]}""")
+
+        assertContains(html, "productionRate[0][minecraft:ice]")
+        assertContains(html, "71000")
+    }
+
+    @Test
+    fun `a farm with no output is told what it costs them`() {
+        // Recommended rather than required: an author who has seen a video but not built the farm
+        // does not know the rate, and an invented number is worse than a missing one. So the note
+        // states the consequence — MCO-294 matches farms by produced item.
+        val html = render("""{"category":"FARM"}""")
+
+        assertTrue(isRecommendationVisible(html))
+        assertContains(html, "will not come up when a world needs that item")
+    }
+
+    @Test
+    fun `the note goes once the farm declares output`() {
+        val html = render("""{"category":"FARM","productionModes":[{"name":"","rates":{"minecraft:ice":71000}}]}""")
+
+        assertFalse(isRecommendationVisible(html))
+    }
+
+    @Test
+    fun `a storage system is not nagged about producing nothing`() {
+        // Most builds produce nothing, and that is not a defect.
+        assertFalse(isRecommendationVisible(render("""{"category":"STORAGE"}""")))
+    }
+
+    @Test
+    fun `no category chosen yet means no advice about farms`() {
+        assertFalse(isRecommendationVisible(render("{}")))
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFieldsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFieldsTest.kt
@@ -77,6 +77,25 @@ class DraftProductionFieldsTest {
     }
 
     @Test
+    fun `a rate row carries the item id the add script de-duplicates on`() {
+        // Without it, re-adding an item that came back from a saved draft appends a second hidden
+        // input with the same name — and the parser takes the first, so the correction is lost.
+        val html = markup("""{"productionModes":[{"name":"","rates":{"minecraft:ice":71000}}]}""")
+
+        assertContains(html, "data-item-id=\"minecraft:ice\"")
+    }
+
+    @Test
+    fun `the only mode keeps a name it was given`() {
+        // Two modes, then the rates are deleted from one: the survivor is alone and loses its name
+        // field, but writing "" into the hidden input would rename it Default on the next save.
+        val html = markup("""{"productionModes":[{"name":"Max speed","rates":{"minecraft:ice":71000}}]}""")
+
+        assertFalse(html.contains("production-mode__name"), "one mode is still never called a mode")
+        assertContains(html, "value=\"Max speed\"")
+    }
+
+    @Test
     fun `a farm with no output is told what it costs them`() {
         // Recommended rather than required: an author who has seen a video but not built the farm
         // does not know the rate, and an invented number is worse than a missing one. So the note


### PR DESCRIPTION
Closes MCO-412 — https://linear.app/evegul/issue/MCO-412/move-idea-production-rates-out-of-json-into-relational-modes

**Draft: for adversarial review before merge.** Jump to "Where to attack this" at the bottom.

What an idea produces lived in `ideas.category_data -> 'productionRate'` as untyped JSON on the FARM category. MCO-294 needs to match bulk demand against it, and JSON fails that three ways: it cannot be joined, it is category-gated (a mob farm inside a storage build produces nothing as far as the schema is concerned), and its only reader has been broken since MCO-204 changed the shape underneath it — **no idea import has ever written a production row** (MCO-411).

## The model

```sql
idea_production_modes  (id, idea_id, name, position)   UNIQUE (idea_id, name)
idea_production_rates  (mode_id, item_id, rate_per_hour NULL)
```

A farm can be run more than one way, and the ways produce different things at different rates: an ice farm at full speed or slowed for lag; a nether fortress farm with a wither-skeleton filter crossed with three speeds.

**Modes are flat, not axes.** Six rows for the fortress farm rather than two dimensions multiplied — axes model that one case elegantly and every other case worse.

**The single-mode case is free.** Almost every farm has one mode with one set of items. This nesting existed once and MCO-204 removed it as *"the single most tedious thing in the form"*; it *"never got filled"*. So the first mode has no name field and is never called a mode; names appear only when you add a second.

**A rate is optional.** "This makes bamboo, I have never timed it" is real information from the most common contributor — someone sharing a small private farm, not a published design with a spreadsheet. Demanding a number would lose the design or invite an invented one, and an invented rate is worse than none because it gets matched against real demand and believed.

## Decisions, and one reversal

- **Matching quotes the best rate any mode achieves and names it** — "62,000/h in Max speed". The roadmap question is "can this cover it at all"; rejecting a farm because its *default* mode is slow would hide a farm that plainly covers the work. Naming the mode stops a best case reading as a promise.
- **`NULL` for unmeasured, deliberately not `0`** — even though `project_productions` already reads 0 as "rate unknown" and `ProductionPanel` prints exactly that. Copying it would make zero mean two things in one column, and this feature already carries a bug whose entire symptom was rates silently being 0. The two sides differ until MCO-413; the mapping is one commented line in the import.
- **Import flattens one mode's rates into the project — reversed, and left as an interim.** Which mode a farm runs in is a *runtime* choice, not a build-time one; flattening it means re-typing rates to switch. **MCO-413** carries it, and `ratesForImport`'s doc comment says it is known-wrong rather than pretending otherwise.

## Your two ice farms survive

The migration carries existing JSON over as one `Default` mode each. Verified against the real rows in the shared DB: **71,000** and **72,000** ice/hour, each matching the JSON it came from. The JSON is left in place, unread, so the conversion is reversible by hand.

## Removing the old field had consequences — all three are real losses

Verifying the form in the browser showed it offering production rates **twice**, in two different stores. Removing the schema field then cost:

1. **The detail page rendered productions through it.** Replaced with a section reading the new tables.
2. **Category validation checked production item ids against the catalog. That check is gone** and the new path does not replace it — ids are validated at import against the world's version, which is later but not silent.
3. **Ideas could be filtered by `productionRate` as a numeric field. Nothing has that today.** No schema has a filterable top-level number any more.

## Verified in the running app, not just compiled

- Form → draft JSON → publish → two named modes with their own rates.
- A farm with an empty rate publishes with a genuine NULL, distinguishable from a real zero.
- The farm recommendation across all four states: no category, farm without output, farm with output, non-farm.

## Where to attack this

- **`NULL` vs the existing `0` convention.** I chose divergence over conflation; the counter-argument — one convention, unified now rather than at MCO-413 — is reasonable and I did not take it.
- **Delete-then-insert for modes** discards surrogate ids on every save. Nothing references them today. If anything ever does, this is where it breaks.
- **The mode index is positional and re-assigned on save.** Two tabs editing one draft would interleave badly. Same exposure as the existing item-requirements form, but worth a second look.
- **`ratesForImport` picks the most productive mode by summed output** when no mode is chosen. Summing across different items is not obviously meaningful — 1,400 bones is not comparable to 1,400 diamonds.
- **The item field takes a raw id** rather than reusing the requirement search, which owns a single set of element ids and cannot be repeated per mode. It prepends `minecraft:` to a bare id without checking the catalog.
- **The recommendation is advisory.** If farms keep arriving with no output, the copy did not work and a harder gate is the fallback.

## Tests

**895 unit + 443 database, zero failures.** New: mode selection (14), form parsing (8), form rendering (7), detail rendering (5). Two tests deleted where the thing they tested no longer exists; two repointed where the behaviour survived in another form. One of my own assertions was matching a class name inside an inline script and would have passed on broken markup — fixed, and filed as **MCO-416**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Adversarial review, and what it changed

A `/code-review high` pass over this diff found eight things. Five were on the path an author walks while filling the bank by hand, which is the next thing that happens to this code, so they are fixed here (`4ecdfe6`). Three are filed.

### The one that lost data

**Editing any published idea silently deleted everything it produced.** `RevertIdeaToDraftStep` copied `categoryData` and `itemRequirements` into the edit draft but not `productionModes` — and publishing replaces the idea wholesale, since `replaceIdeaProductionModes` opens with an unconditional `DELETE`. A key missing from the draft was not "left alone", it was deleted.

Publish a farm at 71,000 ice/h → fix a typo in the description → publish. The farm now produces nothing, and the form never showed the rates, so there was nothing to notice. Both real ice farms in the shared DB were one description edit away from this.

### The trap it formed with the free-text item field

A mistyped id made the idea **unimportable into every world**. `ValidateItemIdsStep` now actually receives production ids — before this branch `extractProductionRates` always returned empty, so that branch was dead code — and it hard-fails the whole import, requirements included. `minecraft:Blue Ice` stored happily, matched nothing, and broke import permanently. The repair path was editing the idea, which is the bug above.

Ids are now validated against the world's catalog at the form, with a message naming the id. That is later than picking from a search but it is loud, and the real fix is filed as **MCO-417**.

### Also fixed

- **Two unnamed modes collided on `UNIQUE (idea_id, name)`** — both resolve to `Default` — and the button that adds a second mode leaves both names empty, so the natural path led to a 23505 and a rolled-back publish with no field-level message. Rejected at the form now; the write path merges same-named modes rather than inserting twice, because a bodyless publish re-publishes stored draft JSON without re-validating it.
- **Re-adding an item after a draft reload kept the old rate.** The add script de-duplicates on `[data-item-id]`, which only JS-created rows carried — so two hidden inputs posted under one name and the parser took the first. The correction vanished silently.
- **A mode that became the only one lost its name**, quietly renaming itself `Default`, because the hidden input was written with `value = ""`.

### Filed, not fixed

- **MCO-418** — removing every production row cannot be saved; the JSONB merge brings the old rows back. Pre-existing form shape (`itemRequirements` does the same), but production is what MCO-294 reads.
- **MCO-419** — the "Produces" section on the detail page is entirely unstyled; none of its eight class names appear in a stylesheet.
- **MCO-420** — `GetIdeaPipeline` swallows a load failure into "produces nothing".

### Tests

**913 unit + 446 database, zero failures.** The two round-trip tests were run against the *unfixed* code first and fail there with exactly the reported symptom — the modes come back empty — rather than passing on broken behaviour. That check exists because this branch already produced one assertion that could not fail (MCO-416).

Not re-verified in the browser since the original pass; the round-trip is covered by an integration test through revert → publish instead, which is the stronger check for this particular bug.
