### PR TITLE
MCO-417/418: a real item search per production mode, and let a row be removed

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
@@ -362,15 +362,17 @@ internal fun buildStageJson(stage: DraftWizardStage, params: Parameters): String
 
             // A mode with no rates says nothing about the farm, so it does not survive the form.
             val modes = ratesByMode.keys.sortedBy { it.toIntOrNull() ?: Int.MAX_VALUE }
-            if (modes.isNotEmpty()) {
-                putJsonArray("productionModes") {
-                    modes.forEach { index ->
-                        addJsonObject {
-                            put("name", names[index] ?: "")
-                            putJsonObject("rates") {
-                                ratesByMode[index].orEmpty().forEach { (itemId, rate) ->
-                                    if (rate == null) put(itemId, JsonNull) else put(itemId, rate)
-                                }
+            // Written even when empty (MCO-418). UpdateDraftStep merges with `data || ?::jsonb`, so
+            // an omitted key is not "no change", it is "keep what was there" — and clearing the last
+            // production row was therefore unsaveable: the rows came back on reload and published.
+            // An author correcting a rate they got wrong has to be able to remove it.
+            putJsonArray("productionModes") {
+                modes.forEach { index ->
+                    addJsonObject {
+                        put("name", names[index] ?: "")
+                        putJsonObject("rates") {
+                            ratesByMode[index].orEmpty().forEach { (itemId, rate) ->
+                                if (rate == null) put(itemId, JsonNull) else put(itemId, rate)
                             }
                         }
                     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftFormPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftFormPage.kt
@@ -25,9 +25,11 @@ import kotlinx.html.h2
 import kotlinx.html.id
 import kotlinx.html.main
 import kotlinx.html.p
+import kotlinx.html.script
 import kotlinx.html.span
 import kotlinx.html.stream.createHTML
 import kotlinx.html.summary
+import kotlinx.html.unsafe
 
 /**
  * The single-page create form (MCO-310).
@@ -144,6 +146,14 @@ private fun FlowContent.draftFormContent(
                 hxPost("/ideas/drafts/${draft.id}/save")
                 +"Save for later"
             }
+        }
+
+        // One definition for every item-search combo in this form — requirements and one per
+        // production mode. Emitted here rather than by either field group because `/items/search`
+        // hardcodes `selectSearchedItem` as a global, and whichever group rendered last would
+        // otherwise define the winner (MCO-417).
+        script {
+            unsafe { raw(draftItemSearchScript()) }
         }
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftItemRequirementFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftItemRequirementFields.kt
@@ -3,14 +3,12 @@ package app.mcorg.presentation.templated.idea.createwizard
 import app.mcorg.domain.model.idea.IdeaDraft
 import app.mcorg.domain.model.minecraft.MinecraftVersionRange
 import app.mcorg.pipeline.idea.draft.DraftData
-import app.mcorg.presentation.hxGet
 import app.mcorg.presentation.hxPost
 import app.mcorg.presentation.hxSwap
 import app.mcorg.presentation.hxTarget
 import app.mcorg.presentation.hxTrigger
 import kotlinx.html.ButtonType
 import kotlinx.html.FlowContent
-import kotlinx.html.FormEncType
 import kotlinx.html.InputType
 import kotlinx.html.button
 import kotlinx.html.div
@@ -21,10 +19,7 @@ import kotlinx.html.input
 import kotlinx.html.label
 import kotlinx.html.li
 import kotlinx.html.p
-import kotlinx.html.script
-import kotlinx.html.span
 import kotlinx.html.ul
-import kotlinx.html.unsafe
 import kotlinx.serialization.json.Json
 
 private val json = Json { ignoreUnknownKeys = true; isLenient = true }
@@ -33,49 +28,23 @@ fun FlowContent.draftItemRequirementFields(draft: IdeaDraft) {
     val data = runCatching { json.decodeFromString(DraftData.serializer(), draft.data) }.getOrDefault(DraftData())
     val versionRange = data.versionRange ?: MinecraftVersionRange.Unbounded
 
-    val versionRangeType = when (versionRange) {
-        is MinecraftVersionRange.Bounded -> "bounded"
-        is MinecraftVersionRange.LowerBounded -> "lowerBounded"
-        is MinecraftVersionRange.UpperBounded -> "upperBounded"
-        else -> "unbounded"
-    }
-    val versionFrom = when (versionRange) {
-        is MinecraftVersionRange.Bounded -> versionRange.from.toString()
-        is MinecraftVersionRange.LowerBounded -> versionRange.from.toString()
-        else -> ""
-    }
-    val versionTo = when (versionRange) {
-        is MinecraftVersionRange.Bounded -> versionRange.to.toString()
-        is MinecraftVersionRange.UpperBounded -> versionRange.to.toString()
-        else -> ""
-    }
-
     // --- Manual item search ---
     // Search, quantity and the action on one line: they are one gesture ("add 64 iron"), and
     // stacking them made a three-step ritual out of it.
     div("wizard-item-add item-add-line") {
-        div("item-search-combo item-add-line__search") {
-            label { htmlFor = "item-search"; +"Add Item" }
-            div("item-search-field") {
-                input(type = InputType.text, classes = "form-control") {
-                    id = "item-search"
-                    placeholder = "Search items by name..."
-                    autoComplete = "off"
-                    hxGet("/items/search")
-                    hxTrigger("input changed delay:300ms")
-                    hxTarget("#item-search-results")
-                    hxSwap("innerHTML")
-                    attributes["hx-vals"] = "js:{q: this.value, versionRangeType: '$versionRangeType', versionFrom: '$versionFrom', versionTo: '$versionTo'}"
-                }
-                div("item-search-results") {
-                    id = "item-search-results"
-                }
-            }
-            hiddenInput { id = "selected-item-id" }
-            span("item-selected-label") {
-                id = "selected-item-label"
-            }
-        }
+        // Ids kept because addItemScript() still addresses these three fields directly; the class
+        // hooks are what let the shared selectSearchedItem find them (MCO-417). The DOM is
+        // unchanged from before that change — both classes on one element, label inside — so the
+        // existing item-search CSS still applies.
+        draftItemSearchCombo(
+            scope = "requirements",
+            versionRange = versionRange,
+            inputId = "item-search",
+            selectedIdId = "selected-item-id",
+            selectedLabelId = "selected-item-label",
+            extraClasses = "item-add-line__search",
+            labelText = "Add Item",
+        )
 
         div("item-add-line__qty") {
             label { htmlFor = "item-amount"; +"Quantity" }
@@ -134,18 +103,9 @@ fun FlowContent.draftItemRequirementFields(draft: IdeaDraft) {
             }
     }
 
-    script {
-        unsafe {
-            raw("""
-                function selectSearchedItem(el) {
-                    document.getElementById('selected-item-id').value = el.dataset.itemId;
-                    document.getElementById('selected-item-label').textContent = el.dataset.itemName;
-                    document.getElementById('item-search').value = el.dataset.itemName;
-                    document.getElementById('item-search-results').innerHTML = '';
-                }
-            """.trimIndent())
-        }
-    }
+    // selectSearchedItem is no longer defined here — the productions section renders combos of its
+    // own into this same <form>, and two definitions of one global mean the later render wins.
+    // It now lives once in draftItemSearchScript(), emitted by the form (MCO-417).
 }
 
 private fun addItemScript() = """

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftItemSearchCombo.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftItemSearchCombo.kt
@@ -1,0 +1,129 @@
+package app.mcorg.presentation.templated.idea.createwizard
+
+import app.mcorg.domain.model.minecraft.MinecraftVersionRange
+import kotlinx.html.FlowContent
+import kotlinx.html.InputType
+import kotlinx.html.div
+import kotlinx.html.hiddenInput
+import kotlinx.html.id
+import kotlinx.html.input
+import kotlinx.html.label
+import kotlinx.html.span
+
+/**
+ * The item-search combo, scoped to its own container so a page can carry several (MCO-417).
+ *
+ * `/items/search` renders each option with a fixed `onclick="selectSearchedItem(this)"`, so every
+ * consumer of that endpoint has to supply a global of that name. The draft form has two consumers
+ * in one `<form>` — item requirements and, since MCO-412, one per production mode — and two globals
+ * of the same name means the later definition silently wins. That collision is why productions
+ * shipped with a raw text field instead of a search.
+ *
+ * The fix is one definition that works out *which* combo was used from the clicked option's
+ * position, rather than from element ids it has to know in advance. Every combo carries the same
+ * class hooks; ids remain only where other scripts already address a specific field by id.
+ *
+ * Other pages (`ProductionPanel`, `ResourceDetailPanel`, the project pages) keep their own
+ * `selectSearchedItem`; they render one combo each, on pages this file has nothing to do with.
+ */
+fun FlowContent.draftItemSearchCombo(
+    scope: String,
+    versionRange: MinecraftVersionRange,
+    placeholder: String = "Search items by name...",
+    inputId: String? = null,
+    selectedIdId: String? = null,
+    selectedLabelId: String? = null,
+    /** Extra classes on the combo root, so a caller can size it without adding a wrapper. */
+    extraClasses: String = "",
+    /** Rendered as the combo's first child, where `.item-search-combo`'s column gap applies to it. */
+    labelText: String? = null,
+) {
+    div(("item-search-combo $extraClasses").trim()) {
+        if (labelText != null) {
+            label {
+                inputId?.let { htmlFor = it }
+                +labelText
+            }
+        }
+
+        div("item-search-field") {
+            input(type = InputType.text, classes = "form-control item-search-input") {
+                inputId?.let { id = it }
+                this.placeholder = placeholder
+                autoComplete = "off"
+                attributes["hx-get"] = "/items/search"
+                attributes["hx-trigger"] = "input changed delay:300ms"
+                attributes["hx-target"] = "#item-search-results-$scope"
+                attributes["hx-swap"] = "innerHTML"
+                attributes["hx-vals"] = versionRange.toSearchVals()
+            }
+            div("item-search-results") {
+                id = "item-search-results-$scope"
+            }
+        }
+
+        hiddenInput(classes = "item-search-selected-id") {
+            selectedIdId?.let { id = it }
+        }
+        span("item-selected-label item-search-selected-label") {
+            selectedLabelId?.let { id = it }
+        }
+    }
+}
+
+/**
+ * `hx-vals` carrying the draft's version range, so results match the versions the idea claims.
+ *
+ * Mirrors what `handleSearchItems` feeds to `ValidateIdeaMinecraftVersionStep`.
+ */
+fun MinecraftVersionRange.toSearchVals(): String {
+    val type = when (this) {
+        is MinecraftVersionRange.Bounded -> "bounded"
+        is MinecraftVersionRange.LowerBounded -> "lowerBounded"
+        is MinecraftVersionRange.UpperBounded -> "upperBounded"
+        else -> "unbounded"
+    }
+    val from = when (this) {
+        is MinecraftVersionRange.Bounded -> from.toString()
+        is MinecraftVersionRange.LowerBounded -> from.toString()
+        else -> ""
+    }
+    val to = when (this) {
+        is MinecraftVersionRange.Bounded -> to.toString()
+        is MinecraftVersionRange.UpperBounded -> to.toString()
+        else -> ""
+    }
+    return "js:{q: this.value, versionRangeType: '$type', versionFrom: '$from', versionTo: '$to'}"
+}
+
+/**
+ * The single `selectSearchedItem` for the draft form.
+ *
+ * Resolves the fields to write from the clicked option's own container rather than by id, so it
+ * serves any number of combos on the page. Rendered once, by the page shell — not by either field
+ * group, since whichever rendered last would otherwise define the winner.
+ */
+fun draftItemSearchScript() = """
+    function selectSearchedItem(el) {
+        var results = el.closest('.item-search-results');
+        var combo = el.closest('.item-search-combo');
+        if (!combo) return;
+        combo.querySelector('.item-search-selected-id').value = el.dataset.itemId;
+        combo.querySelector('.item-search-selected-label').textContent = el.dataset.itemName;
+        combo.querySelector('.item-search-input').value = el.dataset.itemName;
+        if (results) results.innerHTML = '';
+    }
+
+    /** The id the combo currently holds, or '' — the only way anything should read a picked item. */
+    function selectedItemIn(combo) {
+        var field = combo && combo.querySelector('.item-search-selected-id');
+        return field ? field.value.trim() : '';
+    }
+
+    function clearSelectedItem(combo) {
+        if (!combo) return;
+        combo.querySelector('.item-search-selected-id').value = '';
+        combo.querySelector('.item-search-selected-label').textContent = '';
+        combo.querySelector('.item-search-input').value = '';
+    }
+""".trimIndent()

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
@@ -2,6 +2,7 @@ package app.mcorg.presentation.templated.idea.createwizard
 
 import app.mcorg.domain.model.idea.IdeaCategory
 import app.mcorg.domain.model.idea.IdeaDraft
+import app.mcorg.domain.model.minecraft.MinecraftVersionRange
 import app.mcorg.pipeline.idea.draft.DraftData
 import app.mcorg.pipeline.idea.draft.DraftProductionMode
 import kotlinx.html.ButtonType
@@ -18,11 +19,20 @@ import kotlinx.html.li
 import kotlinx.html.p
 import kotlinx.html.script
 import kotlinx.html.span
+import kotlinx.html.stream.createHTML
 import kotlinx.html.ul
 import kotlinx.html.unsafe
 import kotlinx.serialization.json.Json
 
 private val productionJson = Json { ignoreUnknownKeys = true; isLenient = true }
+
+/**
+ * Stands in for the mode index inside `#production-mode-template`, replaced when a mode is added.
+ *
+ * Chosen to survive HTML attribute escaping and to be findable — it appears in element ids, field
+ * names and the combo's scope, so a change here has to match [productionScript]'s substitution.
+ */
+private const val MODE_INDEX_TOKEN = "__MODE_INDEX__"
 
 /**
  * What this idea produces (MCO-412).
@@ -44,6 +54,7 @@ fun FlowContent.draftProductionFields(draft: IdeaDraft) {
     val data = runCatching { productionJson.decodeFromString(DraftData.serializer(), draft.data) }
         .getOrDefault(DraftData())
     val modes = data.productionModes.orEmpty().ifEmpty { listOf(DraftProductionMode()) }
+    val versionRange = data.versionRange ?: MinecraftVersionRange.Unbounded
 
     val isFarm = data.category == IdeaCategory.FARM
     val hasRates = modes.any { it.rates.isNotEmpty() }
@@ -79,8 +90,31 @@ fun FlowContent.draftProductionFields(draft: IdeaDraft) {
         div {
             id = "production-modes"
             modes.forEachIndexed { index, mode ->
-                productionModeBlock(index, mode, showName = modes.size > 1)
+                productionModeBlock(index.toString(), mode, showName = modes.size > 1, versionRange = versionRange)
             }
+        }
+
+        // The block a new mode is cloned from, rendered by the server so the search combo inside it
+        // is the real thing — same hx-vals, same version range. Building it in JS instead would mean
+        // maintaining the markup twice and interpolating server state into a string (MCO-417).
+        // MODE_INDEX_TOKEN is substituted for the real index on insert.
+        //
+        // Raw <template> because kotlinx.html only offers `template` on PhrasingContent, and this
+        // sits in flow content. The rendered fragment carries its own wrapping <div>, which is why
+        // the script picks the block out by class rather than taking firstElementChild.
+        unsafe {
+            raw(
+                "<template id=\"production-mode-template\">" +
+                    createHTML().div {
+                        productionModeBlock(
+                            index = MODE_INDEX_TOKEN,
+                            mode = DraftProductionMode(),
+                            showName = true,
+                            versionRange = versionRange,
+                        )
+                    } +
+                    "</template>"
+            )
         }
 
         button(classes = "btn btn--ghost btn--sm") {
@@ -102,9 +136,14 @@ fun FlowContent.draftProductionFields(draft: IdeaDraft) {
  * [showName] is false while there is only one mode — the name is stored as blank and becomes
  * "Default" on save, because an author who was never asked about modes has not chosen one.
  */
-private fun FlowContent.productionModeBlock(index: Int, mode: DraftProductionMode, showName: Boolean) {
+private fun FlowContent.productionModeBlock(
+    index: String,
+    mode: DraftProductionMode,
+    showName: Boolean,
+    versionRange: MinecraftVersionRange,
+) {
     div("production-mode") {
-        attributes["data-mode-index"] = index.toString()
+        attributes["data-mode-index"] = index
 
         if (showName) {
             input(type = InputType.text, classes = "form-control production-mode__name") {
@@ -124,10 +163,15 @@ private fun FlowContent.productionModeBlock(index: Int, mode: DraftProductionMod
         }
 
         div("production-mode__add") {
-            input(type = InputType.text, classes = "form-control production-item-search") {
-                placeholder = "Item"
-                attributes["data-mode-index"] = index.toString()
-            }
+            // A real catalog search, one per mode, scoped by the mode index (MCO-417). Before this
+            // the field took a raw id and the script prepended "minecraft:" to it, so "Blue Ice"
+            // became minecraft:Blue Ice — accepted here, matched nothing in MCO-294, and failed the
+            // whole import of the idea into every world.
+            draftItemSearchCombo(
+                scope = "production-$index",
+                versionRange = versionRange,
+                placeholder = "Search items by name...",
+            )
             input(type = InputType.number, classes = "form-control production-item-rate") {
                 // Optional on purpose: knowing a farm makes bamboo is worth recording even when
                 // nobody has timed it, and an invented rate would be worse than none.
@@ -173,23 +217,22 @@ private fun FlowContent.productionModeBlock(index: Int, mode: DraftProductionMod
 /**
  * Adding a rate row and adding a mode, client-side.
  *
- * The item field takes a raw id rather than reusing the requirement search: that search posts to a
- * fragment endpoint and owns a single set of element ids, so it cannot be repeated per mode
- * without reworking it. Deliberate V1 limit — noted on the issue, and the ids are validated on
- * import against the world's catalog either way.
+ * The item comes from a real catalog search now (MCO-417), one combo per mode, so an id that is not
+ * an item cannot be entered rather than being caught at publish. `ValidateIdeaProductionsStep`
+ * still checks ids server-side — drafts saved before this could carry anything.
  */
 private fun productionScript() = """
     function addProductionRate(btn) {
         var block = btn.closest('.production-mode');
         var index = block.dataset.modeIndex;
-        var itemInput = block.querySelector('.production-item-search');
+        var combo = block.querySelector('.item-search-combo');
         var rateInput = block.querySelector('.production-item-rate');
-        var itemId = itemInput.value.trim();
+        var itemId = selectedItemIn(combo);
         var rawRate = rateInput.value.trim();
         var rate = rawRate === '' ? null : parseInt(rawRate, 10);
+        // Nothing picked from the results yet — typing a name into the box is not a choice.
         if (!itemId) return;
         if (rate !== null && (isNaN(rate) || rate < 0)) return;
-        if (itemId.indexOf(':') === -1) itemId = 'minecraft:' + itemId;
 
         var list = document.getElementById('production-rates-' + index);
         var existing = list.querySelector('[data-item-id="' + itemId + '"]');
@@ -203,7 +246,7 @@ private fun productionScript() = """
             '<input type="hidden" name="productionRate[' + index + '][' + itemId + ']" value="' + (rate === null ? '' : rate) + '">' +
             '<button type="button" class="btn btn--ghost btn--sm" onclick="this.closest(\'li\').remove()">Remove</button>';
         list.appendChild(li);
-        itemInput.value = '';
+        clearSelectedItem(combo);
         rateInput.value = '';
         refreshProductionRecommendation();
     }
@@ -250,17 +293,17 @@ private fun productionScript() = """
             }
         });
 
-        var block = document.createElement('div');
-        block.className = 'production-mode';
-        block.dataset.modeIndex = index;
-        block.innerHTML =
-            '<input type="text" class="form-control production-mode__name" name="productionMode[' + index + '][name]" placeholder="How it is run — &quot;Max speed&quot;, &quot;Skeletons only&quot;">' +
-            '<div class="production-mode__add">' +
-            '<input type="text" class="form-control production-item-search" placeholder="Item" data-mode-index="' + index + '">' +
-            '<input type="number" class="form-control production-item-rate" placeholder="Per hour" min="0" data-mode-index="' + index + '">' +
-            '<button type="button" class="btn btn--secondary btn--sm" onclick="addProductionRate(this)">Add</button>' +
-            '</div>' +
-            '<ul class="wizard-item-list production-mode__rates" id="production-rates-' + index + '"></ul>';
+        // Cloned from the server-rendered template so the new mode's search combo is identical to
+        // the existing ones — including the hx-vals carrying this draft's version range.
+        var template = document.getElementById('production-mode-template');
+        var markup = template.innerHTML.split('$MODE_INDEX_TOKEN').join(index);
+        var holder = document.createElement('div');
+        holder.innerHTML = markup;
+        var block = holder.querySelector('.production-mode');
+        if (!block) return;
         container.appendChild(block);
+
+        // The combo's hx-get is inert until htmx is told about the new nodes.
+        if (window.htmx) htmx.process(block);
     }
 """.trimIndent()

--- a/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
@@ -507,7 +507,21 @@
 .production-mode__add {
     display: flex;
     gap: var(--space-2);
-    align-items: center;
+    align-items: flex-end;
+    /* Wraps like the requirements add-line: since MCO-417 the first control is a search combo with
+       a results dropdown, and holding all three on one row squeezed it to about 90px at 375. */
+    flex-wrap: wrap;
+}
+
+.production-mode__add .item-search-combo {
+    flex: 1 1 220px;
+    min-width: 0;
+}
+
+.production-mode__add .production-item-rate {
+    /* Wide enough for the "Per hour (optional)" placeholder — the word "optional" is the point of
+       it, and clipping it back to "Per hour (op" loses that. */
+    flex: 0 0 165px;
 }
 
 .production-mode__name {

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/draft/ProductionStageParsingTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/draft/ProductionStageParsingTest.kt
@@ -138,4 +138,37 @@ class ProductionStageParsingTest {
 
         assertEquals(listOf("First", "Third", "Eleventh"), modes.map { it.name })
     }
+
+    @Test
+    fun `removing every row emits an empty array, not an absent key (MCO-418)`() {
+        // UpdateDraftStep merges with `data || ?::jsonb`, so an absent key means "keep what was
+        // there". Omitting it made clearing the last production row unsaveable: the rows came back
+        // on reload and published anyway. An author correcting a rate they got wrong has to be able
+        // to remove it.
+        val stageJson = buildStageJson(
+            DraftWizardStage.PRODUCTIONS,
+            parametersOf("productionMode[0][name]" to listOf("")),
+        )
+
+        assertTrue(
+            stageJson.contains("\"productionModes\""),
+            "the key has to be present for the merge to overwrite: $stageJson",
+        )
+        assertEquals(
+            emptyList(),
+            json.decodeFromString(DraftData.serializer(), stageJson).productionModes,
+        )
+    }
+
+    @Test
+    fun `a submission with no production fields at all still clears`() {
+        // The productions section always posts at least its mode-name inputs, but a form that
+        // somehow posts none must not be read as "leave the old rows alone" either.
+        val stageJson = buildStageJson(DraftWizardStage.PRODUCTIONS, Parameters.Empty)
+
+        assertEquals(
+            emptyList(),
+            json.decodeFromString(DraftData.serializer(), stageJson).productionModes,
+        )
+    }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFieldsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFieldsTest.kt
@@ -6,6 +6,7 @@ import kotlinx.html.stream.createHTML
 import org.junit.jupiter.api.Test
 import java.time.ZonedDateTime
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -30,11 +31,17 @@ class DraftProductionFieldsTest {
     private fun render(data: String) = createHTML().div { draftProductionFields(draft(data)) }
 
     /**
-     * Markup only. The section carries its own inline script, which mentions every class it
-     * manipulates — asserting a class is absent from the whole document would match the script
-     * and never fail.
+     * The markup a reader actually sees, with two things cut out.
+     *
+     * The inline script mentions every class it manipulates, so asserting a class is *absent* from
+     * the whole document would match the script and never fail. Since MCO-417 the section also
+     * carries a `<template>` holding the block a new mode is cloned from — inert markup that always
+     * has a name field, because a second mode always gets one. Leaving it in makes
+     * "one mode is never called a mode" unfalsifiable in the same way.
      */
-    private fun markup(data: String) = render(data).substringBefore("<script")
+    private fun markup(data: String) = render(data)
+        .substringBefore("<script")
+        .replace(Regex("<template[\\s\\S]*?</template>"), "")
 
     private fun isRecommendationVisible(html: String): Boolean {
         val marker = html.substringAfter("id=\"production-recommendation\"", "")
@@ -93,6 +100,58 @@ class DraftProductionFieldsTest {
 
         assertFalse(html.contains("production-mode__name"), "one mode is still never called a mode")
         assertContains(html, "value=\"Max speed\"")
+    }
+
+    @Test
+    fun `each mode gets its own catalog search, scoped so they cannot collide (MCO-417)`() {
+        // The whole reason productions shipped with a raw text field: /items/search hardcodes a
+        // global selectSearchedItem, and one set of element ids cannot serve two modes at once.
+        val html = markup(
+            """{"productionModes":[
+                {"name":"Max speed","rates":{"minecraft:ice":62000}},
+                {"name":"Slowed","rates":{"minecraft:ice":18000}}
+            ]}"""
+        )
+
+        assertContains(html, "item-search-results-production-0")
+        assertContains(html, "item-search-results-production-1")
+        assertEquals(2, html.split("hx-get=\"/items/search\"").size - 1, "one search per mode")
+    }
+
+    @Test
+    fun `the search respects the draft's version range`() {
+        // Otherwise it offers items the idea claims not to work with.
+        val html = markup(
+            """{"versionRange":{
+                    "type":"app.mcorg.domain.model.minecraft.MinecraftVersionRange.LowerBounded",
+                    "from":{"type":"app.mcorg.domain.model.minecraft.MinecraftVersion.Release","major":1,"minor":21,"patch":0}
+                },
+                "productionModes":[{"name":"","rates":{}}]}"""
+        )
+
+        assertContains(html, "versionRangeType: 'lowerBounded'")
+        assertContains(html, "versionFrom: '1.21.0'")
+    }
+
+    @Test
+    fun `a new mode is cloned from a server-rendered template, not built in JS`() {
+        // The template carries a real combo — same hx-vals, same version range — so a mode added
+        // client-side searches exactly like the ones rendered with the page.
+        val html = render("""{"productionModes":[{"name":"","rates":{}}]}""")
+
+        assertContains(html, "id=\"production-mode-template\"")
+        assertContains(html, "__MODE_INDEX__")
+        assertContains(html, "htmx.process(block)")
+    }
+
+    @Test
+    fun `the free-text item field and its minecraft prefix are gone`() {
+        // "Blue Ice" used to become minecraft:Blue Ice — accepted, matched nothing, and broke
+        // import of the idea into every world.
+        val html = render("""{"productionModes":[{"name":"","rates":{}}]}""")
+
+        assertFalse(html.contains("production-item-search"), "the raw id field should be gone")
+        assertFalse(html.contains("'minecraft:' +"), "nothing should be guessing a namespace")
     }
 
     @Test


### PR DESCRIPTION
Closes MCO-417 — https://linear.app/evegul/issue/MCO-417/per-mode-item-search-in-the-productions-form-instead-of-a-raw-item-id
Closes MCO-418 — https://linear.app/evegul/issue/MCO-418/removing-every-production-row-from-a-draft-cannot-be-saved-the-old

Both fix ways the productions form loses or corrupts what you typed. They ship together because filling the idea bank by hand is the next thing that happens, and both are on that path.

## MCO-417 — a real item search per mode

The item field was free text and the client prepended `minecraft:` to anything without a colon. **"Blue Ice" became `minecraft:Blue Ice`**: stored happily, matched nothing in MCO-294, and failed the *entire* import of that idea into every world. MCO-412 added a catalog check at publish, which names the bad id — but only after the whole form is filled.

### Why it shipped without a search

`/items/search` renders every option with a fixed `onclick="selectSearchedItem(this)"`, so each consumer must supply a global of that name. Requirements and productions render into the **same `<form>`**, so two definitions of one global means the later render silently wins — and one set of element ids cannot serve several modes at once.

`selectSearchedItem` now resolves the fields to write from the clicked option's **own container** rather than by id, and is emitted once by the form rather than by either field group. The requirements combo keeps its exact DOM — both classes on one element, label inside — so the existing `item-search.css` still applies to it unchanged.

### The cloned mode

A mode added client-side is cloned from a server-rendered `<template>` rather than built by string concatenation, so its combo is the real thing — including the `hx-vals` carrying this draft's version range — and `htmx.process` wires the new nodes, since an `hx-get` on unprocessed DOM is inert. Building it in JS would have meant maintaining the markup twice and interpolating server state into a string.

`ValidateIdeaProductionsStep`'s catalog check stays as the backstop; drafts saved before this can carry anything.

## MCO-418 — clearing a production row

`buildStageJson` omitted the `productionModes` key when nothing was submitted, and `UpdateDraftStep` merges with `data = data || ?::jsonb`, where an absent key means *keep what was there*. Removing the last row and saving did nothing: the rows came back on reload and published.

That is a normal correction, not an edge case — you type 71,000, measure 62,000, and remove the row. It matters more here than on `itemRequirements` (same shape, still omits its key) because MCO-294 matches farm supply against these rates: a stale one is wrong in the roadmap, not just on the page.

## Verified in the running app

Driven end to end at 1440 and 375, with the draft JSON checked in the database afterwards:

- Requirements search unchanged — typing returns results, clicking fills the field, Add creates a row.
- Each mode searches its own catalog independently.
- "This farm can be run another way" clones a second mode **whose search also works** — the `htmx.process` path.
- Picking "Blue Ice" stores **`minecraft:blue_ice`**, not `minecraft:Blue Ice`.
- Re-adding an item **replaces** the earlier row rather than appending a second (the MCO-412 de-dupe fix, now exercised against a reloaded draft).
- Removing every production row and saving wrote **`"productionModes": []`** to the draft, with `itemRequirements` untouched — confirmed by querying the row.

Zero JS console errors, zero server errors.

**Known cosmetic limit:** "Per hour (optional)" is clipped by a character or two at 375. Widening further pushes the Add button to a third line.

## Tests

**919 unit + 446 database, zero failures.** New: per-mode scoping, version-range propagation, the template and its token, and the absence of the raw-id field; two for MCO-418's empty array.

One helper changed: `DraftProductionFieldsTest.markup()` now strips the `<template>` as well as the script. The template always contains a name field, so leaving it in would make "one mode is never called a mode" unfalsifiable — the same trap as MCO-416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
