### PR TITLE
MCO-414: a build that spans dimensions imports as several files

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/createfragments/ParseLitematicaToIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/createfragments/ParseLitematicaToIdeaPipeline.kt
@@ -7,6 +7,7 @@ import app.mcorg.domain.pipeline.Step
 import app.mcorg.nbt.util.LitematicaReader
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.idea.commonsteps.GetItemsInVersionRangeStep
+import app.mcorg.pipeline.project.ReceiveSchematicStep
 import app.mcorg.presentation.handler.handlePipeline
 import app.mcorg.presentation.utils.respondHtml
 import io.ktor.http.content.MultiPartData
@@ -60,34 +61,87 @@ suspend fun ApplicationCall.handleParseLitematica() {
     }
 }
 
-private object GetContentStep : Step<MultiPartData, AppFailure, Pair<String?, ByteArray>> {
-    override suspend fun process(input: MultiPartData): Result<AppFailure, Pair<String?, ByteArray>> {
-        var content: ByteArray? = null
-        var name: String? = null
+/**
+ * Every `.litematic` in the upload (MCO-414).
+ *
+ * Several, for the same reason the project import takes several: Litematica saves a selection
+ * from one world, so a design with a nether side is more than one file and capturing only one of
+ * them would record a material list for part of the build.
+ */
+private object GetContentStep : Step<MultiPartData, AppFailure, List<Pair<String?, ByteArray>>> {
+    override suspend fun process(input: MultiPartData): Result<AppFailure, List<Pair<String?, ByteArray>>> {
+        val files = mutableListOf<Pair<String?, ByteArray>>()
+        var tooMany = false
+
         input.forEachPart { part ->
             if (part is PartData.FileItem && part.originalFileName?.endsWith(".litematic") == true) {
-                content = part.provider().readRemaining().readByteArray()
-                name = part.originalFileName
+                if (files.size >= ReceiveSchematicStep.MAX_FILES) {
+                    tooMany = true
+                    part.release()
+                } else {
+                    files.add(part.originalFileName to part.provider().readRemaining().readByteArray())
+                }
             } else {
                 part.release()
             }
         }
-        return if (content != null) {
-            if (content.isEmpty()) {
-                Result.failure(AppFailure.customValidationError("litematicFile", "Litematica file is empty"))
-            }
-            Result.success(name to content)
-        } else {
-            Result.failure(AppFailure.customValidationError("litematicFile", "Litematica file not provided"))
+
+        return when {
+            tooMany -> Result.failure(
+                AppFailure.customValidationError(
+                    "litematicFile",
+                    "Import at most ${ReceiveSchematicStep.MAX_FILES} files at once",
+                )
+            )
+            files.isEmpty() -> Result.failure(
+                AppFailure.customValidationError("litematicFile", "Litematica file not provided")
+            )
+            // This used to build the failure and then fall through to success, so an empty file
+            // was read as a schematic with no materials rather than rejected.
+            files.any { it.second.isEmpty() } -> Result.failure(
+                AppFailure.customValidationError("litematicFile", "Litematica file is empty")
+            )
+            else -> Result.success(files)
         }
     }
 }
 
-private object ParseLitematicaStep : Step<Pair<String?, ByteArray>, AppFailure, Pair<String?, Litematica>> {
-    override suspend fun process(input: Pair<String?, ByteArray>): Result<AppFailure, Pair<String?, Litematica>> {
-        return when (val compound = LitematicaReader.readLitematica(input.second)) {
-            is Result.Failure -> compound.mapError { AppFailure.customValidationError("litematicFile", "Could not read Litematica file") }
-            is Result.Success -> compound.mapSuccess { input.first to it }
+/**
+ * Parses each file and presents them as one material list.
+ *
+ * Summed per item, not concatenated: the caller renders one `<li>` per id carrying the quantity
+ * in a hidden field, and the draft parser keys those by id — so two rows for the same item would
+ * mean the second silently replacing the first rather than adding to it.
+ */
+private object ParseLitematicaStep :
+    Step<List<Pair<String?, ByteArray>>, AppFailure, Pair<String?, Litematica>> {
+
+    override suspend fun process(
+        input: List<Pair<String?, ByteArray>>,
+    ): Result<AppFailure, Pair<String?, Litematica>> {
+        val parsed = input.map { (name, bytes) ->
+            when (val compound = LitematicaReader.readLitematica(bytes)) {
+                is Result.Failure -> return Result.failure(
+                    AppFailure.customValidationError(
+                        "litematicFile",
+                        "Could not read ${name ?: "Litematica file"}",
+                    )
+                )
+                is Result.Success -> compound.value
+            }
         }
+
+        val first = parsed.first()
+        if (parsed.size == 1) return Result.success(input.first().first to first)
+
+        val items = LinkedHashMap<String, Int>()
+        parsed.forEach { file -> file.items.forEach { (id, count) -> items[id] = (items[id] ?: 0) + count } }
+
+        return Result.success(
+            input.first().first to first.copy(
+                items = items,
+                regions = parsed.flatMap { it.regions },
+            )
+        )
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
@@ -39,11 +39,28 @@ import kotlinx.io.readByteArray
  * .schem/.nbt parsing is not yet supported by mc-nbt.
  */
 
-data class SchematicUpload(
+/** One uploaded `.litematic`. */
+data class SchematicFile(
     val fileName: String?,
-    val providedName: String?,
     val content: ByteArray,
-)
+) {
+    /** The name a group is qualified with: the file without its extension. */
+    val stem: String get() = fileName?.removeSuffix(".litematic").orEmpty()
+}
+
+/**
+ * What arrived from the upload control — one or more files, and an optional name for the project.
+ *
+ * Several files, because Litematica saves a selection from **one** world: a build with a nether
+ * side cannot be a single file, and Seam used to model it as either several unrelated projects or
+ * one project missing part of its materials (MCO-414).
+ */
+data class SchematicUpload(
+    val files: List<SchematicFile>,
+    val providedName: String?,
+) {
+    val fileName: String? get() = files.firstOrNull()?.fileName
+}
 
 data class SchematicProject(
     val name: String,
@@ -77,6 +94,14 @@ data class ResolvedRegion(
     val name: String,
     val requirements: List<Pair<Item, Int>>,
     val placedCounts: Map<String, Int> = emptyMap(),
+    /**
+     * The file this region came from, or null when the import was a single file (MCO-414).
+     *
+     * Null rather than "the only file" so a one-file import renders exactly as it did before
+     * multi-file existed: the review screen qualifies a group by its file only when there is
+     * another file to tell it apart from.
+     */
+    val sourceFile: String? = null,
 )
 
 /**
@@ -208,16 +233,32 @@ internal data class ValidateReviewedMaterialsStep(val availableItems: List<Item>
 }
 
 object ReceiveSchematicStep : Step<MultiPartData, AppFailure, SchematicUpload> {
+
+    /**
+     * A sanity bound, not a product limit. The case this exists for is a build split by dimension,
+     * which is two or three files; the cap is well above that and only stops a hand-rolled post
+     * asking the server to parse an unbounded number of schematics. Related: MCO-421.
+     */
+    const val MAX_FILES = 12
+
     override suspend fun process(input: MultiPartData): Result<AppFailure, SchematicUpload> {
-        var content: ByteArray? = null
-        var fileName: String? = null
+        val files = mutableListOf<SchematicFile>()
         var providedName: String? = null
+        var tooMany = false
 
         input.forEachPart { part ->
             when {
                 part is PartData.FileItem && part.originalFileName?.endsWith(".litematic") == true -> {
-                    content = part.provider().readRemaining().readByteArray()
-                    fileName = part.originalFileName
+                    // Every matching part, not the last one: the control is `multiple` now, so a
+                    // build that spans dimensions arrives as several parts under one field name
+                    // (MCO-414). Overwriting here was the old single-file behaviour and would
+                    // silently import only the final file.
+                    if (files.size >= MAX_FILES) {
+                        tooMany = true
+                        part.release()
+                    } else {
+                        files.add(SchematicFile(part.originalFileName, part.provider().readRemaining().readByteArray()))
+                    }
                 }
                 part is PartData.FormItem && part.name == "name" -> {
                     providedName = part.value.takeIf { it.isNotBlank() }
@@ -227,27 +268,121 @@ object ReceiveSchematicStep : Step<MultiPartData, AppFailure, SchematicUpload> {
             }
         }
 
-        val bytes = content
         return when {
-            bytes == null -> Result.failure(
+            tooMany -> Result.failure(
+                AppFailure.customValidationError("schematicFile", "Import at most $MAX_FILES files at once")
+            )
+            files.isEmpty() -> Result.failure(
                 AppFailure.customValidationError("schematicFile", "Provide a .litematic file")
             )
-            bytes.isEmpty() -> Result.failure(
-                AppFailure.customValidationError("schematicFile", "Schematic file is empty")
+            // Named, because with several files "one of them is empty" is not actionable.
+            files.any { it.content.isEmpty() } -> Result.failure(
+                AppFailure.customValidationError(
+                    "schematicFile",
+                    files.filter { it.content.isEmpty() }
+                        .joinToString(prefix = "Empty schematic file: ") { it.fileName ?: "unnamed" },
+                )
             )
-            else -> Result.success(SchematicUpload(fileName, providedName, bytes))
+            else -> Result.success(SchematicUpload(files, providedName))
         }
     }
 }
 
-object ParseSchematicStep : Step<SchematicUpload, AppFailure, Litematica> {
-    override suspend fun process(input: SchematicUpload): Result<AppFailure, Litematica> {
-        return when (val parsed = LitematicaReader.readLitematica(input.content)) {
-            is Result.Failure -> Result.failure(
-                AppFailure.customValidationError("schematicFile", "Could not read the schematic file")
+/** A file and what was read out of it. */
+data class ParsedSchematic(val fileName: String?, val litematica: Litematica) {
+    val stem: String get() = fileName?.removeSuffix(".litematic").orEmpty()
+}
+
+private fun sumRequirementLists(lists: List<List<Pair<Item, Int>>>): List<Pair<Item, Int>> {
+    val byItem = LinkedHashMap<Item, Int>()
+    lists.forEach { list -> list.forEach { (item, amount) -> byItem[item] = (byItem[item] ?: 0) + amount } }
+    return byItem.map { (item, amount) -> item to amount }
+}
+
+private fun sumPlacedCounts(maps: List<Map<String, Int>>): Map<String, Int> {
+    val total = LinkedHashMap<String, Int>()
+    maps.forEach { map -> map.forEach { (id, count) -> total[id] = (total[id] ?: 0) + count } }
+    return total
+}
+
+/**
+ * Resolves every uploaded file and presents them as one material list (MCO-414).
+ *
+ * A build that spans dimensions is several files, and the review screen already has the concept
+ * that fits them: MCO-398's region groups. So a file contributes its regions as groups, tagged
+ * with the file they came from, and the flat list is the sum across all of them. Two files are
+ * more groups — not a new idea for the screen to explain.
+ *
+ * A file with no regions at all (test-constructed data; real Litematica files always have at
+ * least one) becomes a single group named after the file, so it is still strikeable rather than
+ * dissolving into the flat list.
+ *
+ * Fluids keep the "one bucket per section" reading from MCO-398: each region caps its own water
+ * at one bucket and the sum runs over regions, so a pond spanning the overworld and nether halves
+ * of a build asks for one bucket per half — one per section you actually go and build.
+ */
+data class MapSchematicFilesToMaterialsStep(
+    val availableItems: List<Item>,
+) : Step<List<ParsedSchematic>, AppFailure, SchematicMaterials> {
+
+    override suspend fun process(input: List<ParsedSchematic>): Result<AppFailure, SchematicMaterials> {
+        if (input.isEmpty()) {
+            return Result.failure(
+                AppFailure.customValidationError("schematicFile", "Provide a .litematic file")
             )
-            is Result.Success -> Result.success(parsed.value)
         }
+
+        val single = input.size == 1
+        val perFile = input.map { parsed ->
+            when (val mapped = MapSchematicToMaterialsStep(availableItems).process(parsed.litematica)) {
+                is Result.Failure -> return Result.Failure(mapped.error)
+                is Result.Success -> parsed to mapped.value
+            }
+        }
+
+        val regions = perFile.flatMap { (parsed, materials) ->
+            when {
+                // One file: leave the tag off entirely, so the screen renders exactly as it did
+                // before multi-file existed rather than qualifying groups against nothing.
+                single -> materials.regions
+                materials.regions.isEmpty() -> listOf(
+                    ResolvedRegion(
+                        name = parsed.stem,
+                        requirements = materials.requirements,
+                        placedCounts = materials.placedCounts,
+                        sourceFile = parsed.stem,
+                    )
+                )
+                else -> materials.regions.map { it.copy(sourceFile = parsed.stem) }
+            }
+        }
+
+        return Result.success(
+            SchematicMaterials(
+                requirements = sumRequirementLists(perFile.map { it.second.requirements }),
+                placedCounts = sumPlacedCounts(perFile.map { it.second.placedCounts }),
+                regions = regions,
+            )
+        )
+    }
+}
+
+object ParseSchematicStep : Step<SchematicUpload, AppFailure, List<ParsedSchematic>> {
+    override suspend fun process(input: SchematicUpload): Result<AppFailure, List<ParsedSchematic>> {
+        val parsed = input.files.map { file ->
+            when (val read = LitematicaReader.readLitematica(file.content)) {
+                // Named, since with several files "could not read the schematic file" leaves the
+                // user guessing which one to re-export.
+                is Result.Failure -> return Result.failure(
+                    AppFailure.customValidationError(
+                        "schematicFile",
+                        "Could not read ${file.fileName ?: "the schematic file"}",
+                    )
+                )
+                is Result.Success -> ParsedSchematic(file.fileName, read.value)
+            }
+        }
+        return Result.success(parsed)
     }
 }
 
@@ -352,11 +487,8 @@ data class MapSchematicToMaterialsStep(
         )
     }
 
-    private fun sumRequirements(lists: List<List<Pair<Item, Int>>>): List<Pair<Item, Int>> {
-        val byItem = LinkedHashMap<Item, Int>()
-        lists.forEach { list -> list.forEach { (item, amount) -> byItem[item] = (byItem[item] ?: 0) + amount } }
-        return byItem.map { (item, amount) -> item to amount }
-    }
+    private fun sumRequirements(lists: List<List<Pair<Item, Int>>>): List<Pair<Item, Int>> =
+        sumRequirementLists(lists)
 
     private data class ResolvedMaterials(
         val requirements: List<Pair<Item, Int>>,
@@ -452,16 +584,21 @@ data class MapSchematicToMaterialsStep(
 private data class MapSchematicToProjectStep(
     val availableItems: List<Item>,
     val upload: SchematicUpload,
-) : Step<Litematica, AppFailure, SchematicProject> {
-    override suspend fun process(input: Litematica): Result<AppFailure, SchematicProject> {
-        val materials = when (val mapped = MapSchematicToMaterialsStep(availableItems).process(input)) {
+) : Step<List<ParsedSchematic>, AppFailure, SchematicProject> {
+    override suspend fun process(input: List<ParsedSchematic>): Result<AppFailure, SchematicProject> {
+        val materials = when (val mapped = MapSchematicFilesToMaterialsStep(availableItems).process(input)) {
             is Result.Failure -> return Result.Failure(mapped.error)
             is Result.Success -> mapped.value
         }
 
+        // The first file names the project. With several files their internal names are things
+        // like "Sorter (nether)" — a fragment of the build, not the build — so the name is a
+        // starting point the user edits on the review screen, and picking the first is at least
+        // predictable. Whatever they typed still wins.
+        val first = input.first()
         val name = upload.providedName
-            ?: input.name.takeIf { it.isNotBlank() && it != "Unnamed" }
-            ?: upload.fileName?.removeSuffix(".litematic")
+            ?: first.litematica.name.takeIf { it.isNotBlank() && it != "Unnamed" }
+            ?: first.stem.takeIf { it.isNotBlank() }
             ?: "Imported build"
 
         return Result.success(

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/resources/AddResourcesFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/resources/AddResourcesFromSchematicPipeline.kt
@@ -8,7 +8,7 @@ import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.failure.AppFailure
-import app.mcorg.pipeline.project.MapSchematicToMaterialsStep
+import app.mcorg.pipeline.project.MapSchematicFilesToMaterialsStep
 import app.mcorg.pipeline.project.ParseSchematicStep
 import app.mcorg.pipeline.project.ReceiveSchematicStep
 import app.mcorg.pipeline.project.SchematicUpload
@@ -56,8 +56,11 @@ suspend fun ApplicationCall.handleAddResourcesFromSchematic() {
     ) {
         val upload = ReceiveSchematicStep.run(multipart)
         ValidateWorldMemberRole<SchematicUpload>(user, Role.ADMIN, worldId).run(upload)
-        val litematica = ParseSchematicStep.run(upload)
-        val materials = MapSchematicToMaterialsStep(items).run(litematica)
+        val parsed = ParseSchematicStep.run(upload)
+        // Multi-file here too (MCO-414): replacing a project's resource list from its schematics
+        // has the same problem as creating it from them — a build with a nether side would
+        // otherwise replace the whole list with only one dimension's worth of materials.
+        val materials = MapSchematicFilesToMaterialsStep(items).run(parsed)
         ReplaceProjectResourcesStep(projectId).run(materials.requirements)
 
         previousIds.forEach { CacheManager.onResourceGatheringDeleted(projectId, it) }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -177,7 +177,7 @@ private fun FlowContent.materialsSection(
         materialsField(allRows, excluded)
         warningStrip(warnings)
         materialsSummary(groups, allRows)
-        sectionsLead(groups)
+        sectionsLead(groups, regions.mapNotNull { it.sourceFile }.distinct().size)
         groups.forEachIndexed { index, group ->
             if (group.name == null) {
                 materialsTable(index, group.rows, excluded, placedCounts, warnings)
@@ -201,11 +201,18 @@ private fun FlowContent.materialsSection(
  * neither what they are nor that they open. One line costs nothing and removes both questions;
  * without it the sections read as an unexplained grouping the screen invented.
  */
-private fun FlowContent.sectionsLead(groups: List<MaterialGroup>) {
+private fun FlowContent.sectionsLead(groups: List<MaterialGroup>, fileCount: Int) {
     if (groups.size < 2) return
 
     p("import-review__sections-lead") {
-        +"This schematic is built from ${groups.size} sections. "
+        // Naming the files matters when there are several: it is the confirmation that both
+        // halves of a build that spans dimensions actually arrived (MCO-414). "3 sections" alone
+        // would look identical whether the nether file was read or silently dropped.
+        if (fileCount > 1) {
+            +"These $fileCount files are being imported as one project, in ${groups.size} sections. "
+        } else {
+            +"This schematic is built from ${groups.size} sections. "
+        }
         +"Untick one to leave it out of the import, or open it to choose materials one at a time."
     }
 }
@@ -232,8 +239,35 @@ private fun groupsFor(requirements: Map<Item, Int>, regions: List<ResolvedRegion
     // Largest section first: on a build whose decorative shell is the thing you want to strike,
     // the section worth a decision is usually the big one.
     return populated
-        .map { MaterialGroup(it.name.ifBlank { "Unnamed section" }, it.requirements.sortedWith(byQuantity)) }
+        .map { MaterialGroup(groupName(it, populated), it.requirements.sortedWith(byQuantity)) }
         .sortedByDescending { group -> group.rows.sumOf { it.second.toLong() } }
+}
+
+/**
+ * What a section is called once several files can contribute them (MCO-414).
+ *
+ * The file is the part the user recognises — they named it, and for a build split by dimension
+ * the name usually says which half it is. The region name inside is Litematica's, and for a
+ * single-region file it merely repeats the schematic, so showing both would read as
+ * "Sorter (nether) — Sorter (nether)".
+ *
+ * So: the file alone when it contributed one section, and `file — region` when it contributed
+ * several and the region name actually adds something. Regions from a single-file import carry
+ * no file at all and keep their own names, exactly as before.
+ */
+private fun groupName(region: ResolvedRegion, all: List<ResolvedRegion>): String {
+    val fallback = region.name.ifBlank { "Unnamed section" }
+    val file = region.sourceFile?.takeIf { it.isNotBlank() } ?: return fallback
+
+    val siblings = all.count { it.sourceFile == region.sourceFile }
+    if (siblings < 2) return file
+
+    val regionName = region.name.trim()
+    val addsNothing = regionName.isBlank() ||
+        regionName.equals("Unnamed", ignoreCase = true) ||
+        regionName.equals(file, ignoreCase = true)
+
+    return if (addsNothing) file else "$file — $regionName"
 }
 
 private const val MATERIALS_FIELD_ID = "import-review-materials-field"

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -1252,7 +1252,7 @@ fun FlowContent.resourceSchematicModal(worldId: Int, projectId: Int, existingRes
 
                     label {
                         htmlFor = "resource-schematic-file"
-                        +"Schematic file"
+                        +"Schematic files"
                         span("required-indicator") { +"*" }
                     }
                     input(classes = "form-control") {
@@ -1261,6 +1261,9 @@ fun FlowContent.resourceSchematicModal(worldId: Int, projectId: Int, existingRes
                         name = "schematicFile"
                         accept = ".litematic"
                         required = true
+                        // A build that spans dimensions is several files (MCO-414); replacing the
+                        // list from only one of them would drop the rest of the build.
+                        multiple = true
                     }
                     p("form-error") {
                         id = "validation-error-schematicFile"

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectListPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectListPage.kt
@@ -307,7 +307,7 @@ private fun kotlinx.html.FlowContent.schematicProjectModal(worldId: Int) {
 
                         label {
                             htmlFor = "schematic-project-file"
-                            +"Schematic file"
+                            +"Schematic files"
                             span("required-indicator") { +"*" }
                         }
                         input(classes = "form-control") {
@@ -316,6 +316,12 @@ private fun kotlinx.html.FlowContent.schematicProjectModal(worldId: Int) {
                             name = "schematicFile"
                             accept = ".litematic"
                             required = true
+                            // Litematica saves a selection from one world, so a build with a
+                            // nether side is two files (MCO-414). They import as one project.
+                            multiple = true
+                        }
+                        p("form-help-text") {
+                            +"Pick several if the build spans dimensions — they become one project."
                         }
                         p("form-error") {
                             id = "validation-error-schematicFile"

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftItemRequirementFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftItemRequirementFields.kt
@@ -72,6 +72,9 @@ fun FlowContent.draftItemRequirementFields(draft: IdeaDraft) {
         input(type = InputType.file, classes = "form-control") {
             name = "litematicFile"
             accept = ".litematic"
+            // A design that spans dimensions is several files (MCO-414); their material lists
+            // are summed into one list here.
+            multiple = true
             hxPost("/ideas/create/litematic")
             hxTarget("#draft-item-list")
             hxSwap("beforeend")

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/MapSchematicFilesToMaterialsStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/MapSchematicFilesToMaterialsStepTest.kt
@@ -1,0 +1,145 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.Litematica
+import app.mcorg.domain.model.minecraft.LitematicaRegion
+import app.mcorg.pipeline.Result
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * MCO-414 — several files resolved as one build.
+ *
+ * Litematica saves a selection from one world, so a build with a nether side cannot be one file.
+ * The screen already had the concept that fits them — MCO-398's region groups — so a file
+ * contributes its regions as groups tagged with the file, and the flat list sums across all of
+ * them. What is pinned here is that nothing is lost or double-counted in that sum, and that a
+ * single-file import comes out byte-identical to the pre-MCO-414 shape.
+ */
+class MapSchematicFilesToMaterialsStepTest {
+
+    private val catalog = listOf(
+        "minecraft:oak_planks",
+        "minecraft:stone",
+        "minecraft:netherrack",
+        "minecraft:redstone",
+        "minecraft:water",
+        "minecraft:water_bucket",
+    ).map { Item(it, it.substringAfterLast(':')) }
+
+    private fun file(name: String, vararg regions: Pair<String, Map<String, Int>>): ParsedSchematic {
+        val regionList = regions.map { (regionName, items) -> LitematicaRegion(regionName, items) }
+        val flat = LinkedHashMap<String, Int>()
+        regionList.forEach { r -> r.items.forEach { (id, n) -> flat[id] = (flat[id] ?: 0) + n } }
+        return ParsedSchematic(name, Litematica(name.removeSuffix(".litematic"), "", "", Triple(1, 1, 1), flat, regionList))
+    }
+
+    private fun resolve(vararg files: ParsedSchematic): SchematicMaterials = runBlocking {
+        val result = MapSchematicFilesToMaterialsStep(catalog).process(files.toList())
+        assertIs<Result.Success<SchematicMaterials>>(result)
+        result.value
+    }
+
+    private fun SchematicMaterials.amountOf(id: String) =
+        requirements.firstOrNull { it.first.id == id }?.second
+
+    @Test
+    fun `a material in both files is summed, not replaced`() {
+        // The failure this guards is the one the issue describes from the other side: a build
+        // arriving with only part of its materials. Overwriting instead of summing would show
+        // the nether half's 200 planks as the whole build's requirement.
+        val materials = resolve(
+            file("Sorter.litematic", "Main" to mapOf("minecraft:oak_planks" to 500)),
+            file("Sorter (nether).litematic", "Main" to mapOf("minecraft:oak_planks" to 200)),
+        )
+
+        assertEquals(700, materials.amountOf("minecraft:oak_planks"))
+    }
+
+    @Test
+    fun `each file's regions become groups tagged with that file`() {
+        val materials = resolve(
+            file("Overworld.litematic", "Frame" to mapOf("minecraft:stone" to 100)),
+            file("Nether.litematic", "Frame" to mapOf("minecraft:netherrack" to 60)),
+        )
+
+        assertEquals(2, materials.regions.size)
+        assertEquals(listOf("Overworld", "Nether"), materials.regions.map { it.sourceFile })
+    }
+
+    @Test
+    fun `several regions in several files all survive`() {
+        val materials = resolve(
+            file(
+                "Overworld.litematic",
+                "Frame" to mapOf("minecraft:stone" to 100),
+                "Shell" to mapOf("minecraft:oak_planks" to 40),
+            ),
+            file("Nether.litematic", "Portal" to mapOf("minecraft:netherrack" to 60)),
+        )
+
+        assertEquals(3, materials.regions.size)
+        assertEquals(100, materials.amountOf("minecraft:stone"))
+        assertEquals(40, materials.amountOf("minecraft:oak_planks"))
+        assertEquals(60, materials.amountOf("minecraft:netherrack"))
+    }
+
+    @Test
+    fun `a single file carries no source tag at all`() {
+        // Null rather than "the only file", so the review screen renders a one-file import
+        // exactly as it did before multi-file existed rather than qualifying against nothing.
+        val materials = resolve(
+            file(
+                "Sorter.litematic",
+                "Frame" to mapOf("minecraft:stone" to 100),
+                "Shell" to mapOf("minecraft:oak_planks" to 40),
+            ),
+        )
+
+        assertTrue(materials.regions.isNotEmpty())
+        materials.regions.forEach { assertNull(it.sourceFile) }
+    }
+
+    @Test
+    fun `a file with no regions becomes one group named after itself`() {
+        // Real Litematica files always have a region; test-constructed ones need not. Letting it
+        // dissolve into the flat list would make that file's contribution unstrikeable.
+        val regionless = ParsedSchematic(
+            "Nether.litematic",
+            Litematica("Nether", "", "", Triple(1, 1, 1), mapOf("minecraft:netherrack" to 60)),
+        )
+        val materials = resolve(
+            file("Overworld.litematic", "Frame" to mapOf("minecraft:stone" to 100)),
+            regionless,
+        )
+
+        val nether = materials.regions.single { it.sourceFile == "Nether" }
+        assertEquals("Nether", nether.name)
+        assertEquals(60, nether.requirements.single().second)
+    }
+
+    @Test
+    fun `fluids stay one bucket per section across files`() {
+        // MCO-398's reading, carried across the file boundary: a pond spanning both halves of a
+        // build asks for one bucket per half — one per section you actually go and build — rather
+        // than collapsing to a single bucket for the whole import.
+        val materials = resolve(
+            file("Overworld.litematic", "Pond" to mapOf("minecraft:water" to 4000)),
+            file("Nether.litematic", "Pond" to mapOf("minecraft:water" to 900)),
+        )
+
+        assertEquals(2, materials.amountOf("minecraft:water_bucket"))
+        assertEquals(4900, materials.placedCounts["minecraft:water_bucket"])
+    }
+
+    @Test
+    fun `no files at all is a validation failure rather than an empty project`() {
+        val result = runBlocking { MapSchematicFilesToMaterialsStep(catalog).process(emptyList()) }
+
+        assertIs<Result.Failure<*>>(result)
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/CreateProjectFromSchematicIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/CreateProjectFromSchematicIT.kt
@@ -168,6 +168,21 @@ class CreateProjectFromSchematicIT : WithUser() {
 
     // -------------------------------------------------------------------------
 
+    /** Several files under the one field name, as a `multiple` file input posts them (MCO-414). */
+    private fun multipart(files: List<Pair<String, ByteArray>>, name: String? = null) =
+        MultiPartFormDataContent(formData {
+            if (name != null) append("name", name)
+            files.forEach { (fileName, bytes) ->
+                append("schematicFile", bytes, Headers.build {
+                    append(
+                        HttpHeaders.ContentDisposition,
+                        "form-data; name=\"schematicFile\"; filename=\"$fileName\"",
+                    )
+                    append(HttpHeaders.ContentType, "application/octet-stream")
+                })
+            }
+        })
+
     private fun multipart(fileName: String, bytes: ByteArray, name: String? = null) =
         MultiPartFormDataContent(formData {
             if (name != null) append("name", name)
@@ -263,6 +278,112 @@ class CreateProjectFromSchematicIT : WithUser() {
         )
         assertFalse(body.contains("qty["), "and never as one parameter per row again")
         assertEquals(before, countProjects(worldId), "review must not create anything")
+    }
+
+    // -------------------------------------------------------------------------
+    // Several files as one import (MCO-414)
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `two files review as one import and every material is counted`() = testApplication {
+        // The bug this replaces: the receive step overwrote its buffer per part, so uploading a
+        // build's overworld and nether halves imported only whichever arrived last — a project
+        // silently missing a third of its materials.
+        setupRoutes()
+        val before = countProjects(worldId)
+
+        val response = client.post("/worlds/$worldId/projects/from-schematic/review") {
+            addAuthCookie(this)
+            setBody(
+                multipart(
+                    files = listOf(
+                        "Sorter.litematic" to litematicBytes,
+                        "Sorter (nether).litematic" to litematicBytes,
+                    ),
+                    name = "Split Build",
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        val body = response.bodyAsText()
+        assertTrue(body.contains("These 2 files are being imported as one project"), "the lead names both files")
+        assertTrue(body.contains("Sorter (nether)"), "the second file is a section of its own")
+        assertEquals(before, countProjects(worldId), "review must not create anything")
+    }
+
+    @Test
+    fun `the same file twice doubles the quantities rather than replacing them`() = testApplication {
+        // Uploading one file as both halves is not a real workflow, but it makes the sum
+        // checkable: every amount must be exactly twice the single-file import's.
+        setupRoutes()
+
+        val single = client.post("/worlds/$worldId/projects/from-schematic/review") {
+            addAuthCookie(this)
+            setBody(multipart(fileName = "Sorter.litematic", bytes = litematicBytes))
+        }
+        val double = client.post("/worlds/$worldId/projects/from-schematic/review") {
+            addAuthCookie(this)
+            setBody(
+                multipart(
+                    files = listOf("A.litematic" to litematicBytes, "B.litematic" to litematicBytes),
+                )
+            )
+        }
+
+        val singleRows = materialRowsOf(single.bodyAsText())
+        val doubleRows = materialRowsOf(double.bodyAsText())
+
+        assertTrue(singleRows.isNotEmpty(), "expected a parsed material list")
+        assertEquals(singleRows.keys, doubleRows.keys, "the same items, from the same file twice")
+        singleRows.forEach { (itemId, amount) ->
+            assertEquals(amount * 2, doubleRows[itemId], "$itemId should be doubled")
+        }
+    }
+
+    @Test
+    fun `an unreadable file names itself rather than failing anonymously`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/from-schematic/review") {
+            addAuthCookie(this)
+            setBody(
+                multipart(
+                    files = listOf(
+                        "Sorter.litematic" to litematicBytes,
+                        "Sorter (nether).litematic" to byteArrayOf(1, 2, 3, 4),
+                    )
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.UnprocessableEntity, response.status)
+        assertTrue(
+            response.bodyAsText().contains("Sorter (nether).litematic"),
+            "with several files, the user has to be told which one to re-export",
+        )
+    }
+
+    /**
+     * Item id -> total amount, read back out of the review page's single `materials` field.
+     *
+     * Summed rather than keyed, because the payload carries one row **per section**: an item in
+     * three groups is three rows, and the server sums them the same way
+     * ([ValidateReviewedMaterialsStep]). Keying by id would keep only the last and read a
+     * correctly-doubled import as unchanged.
+     */
+    private fun materialRowsOf(html: String): Map<String, Int> {
+        val payload = Regex("""name="materials" value="([^"]*)"""").find(html)?.groupValues?.get(1)
+            ?: return emptyMap()
+        val totals = mutableMapOf<String, Int>()
+        payload.split(";")
+            .drop(2) // version marker and declared row count
+            .filter { it.isNotBlank() && !it.startsWith("!") }
+            .forEach { row ->
+                val id = row.substringBeforeLast('=')
+                totals[id] = (totals[id] ?: 0) + row.substringAfterLast('=').toInt()
+            }
+        return totals
     }
 
     @Test

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPageTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPageTest.kt
@@ -184,4 +184,70 @@ class ImportReviewPageTest {
 
         assertFalse(html.contains("Air pocket"))
     }
+
+    // --- Several files as one import (MCO-414) ---
+
+    @Test
+    fun `a file contributing one section is named by the file, not its region`() {
+        // Litematica names a lone region after the schematic, so showing both would read as
+        // "Sorter (nether) — Sorter (nether)". The file name is the part the user chose.
+        val html = render(
+            requirements = mapOf(item("oak_planks") to 700),
+            regions = listOf(
+                ResolvedRegion("Sorter", listOf(item("oak_planks") to 500), sourceFile = "Sorter"),
+                ResolvedRegion("Sorter (nether)", listOf(item("oak_planks") to 200), sourceFile = "Sorter (nether)"),
+            ),
+        )
+
+        assertContains(html, "Sorter (nether)")
+        assertFalse(
+            html.contains("Sorter (nether) — Sorter (nether)"),
+            "the file should not be printed twice",
+        )
+    }
+
+    @Test
+    fun `regions sharing a name across files are told apart by their file`() {
+        // The collision the issue calls out: two files can each hold a region called Main, and
+        // "Main" twice in the section list is unreadable.
+        val html = render(
+            requirements = mapOf(item("oak_planks") to 300, item("glass") to 90),
+            regions = listOf(
+                ResolvedRegion("Main", listOf(item("oak_planks") to 200), sourceFile = "Overworld"),
+                ResolvedRegion("Shell", listOf(item("oak_planks") to 100), sourceFile = "Overworld"),
+                ResolvedRegion("Main", listOf(item("glass") to 90), sourceFile = "Nether"),
+            ),
+        )
+
+        assertContains(html, "Overworld — Main")
+        assertContains(html, "Overworld — Shell")
+        // Nether contributed one section, so it is named by the file alone.
+        assertContains(html, "Nether")
+    }
+
+    @Test
+    fun `the lead says how many files were imported`() {
+        // "3 sections" alone reads the same whether the nether file arrived or was silently
+        // dropped; naming the file count is the confirmation that both halves are here.
+        val html = render(
+            requirements = mapOf(item("oak_planks") to 700),
+            regions = listOf(
+                ResolvedRegion("Sorter", listOf(item("oak_planks") to 500), sourceFile = "Overworld"),
+                ResolvedRegion("Sorter", listOf(item("oak_planks") to 200), sourceFile = "Nether"),
+            ),
+        )
+
+        assertContains(html, "These 2 files are being imported as one project")
+    }
+
+    @Test
+    fun `a single-file import still says schematic, not files`() {
+        val html = render(
+            requirements = mapOf(item("glass") to 4000, item("oak_planks") to 700, item("hopper") to 40),
+            regions = listOf(frame, shell),
+        )
+
+        assertContains(html, "This schematic is built from 2 sections")
+        assertFalse(html.contains("are being imported as one project"))
+    }
 }


### PR DESCRIPTION
Closes MCO-414 — https://linear.app/evegul/issue/MCO-414/a-build-can-span-dimensions-so-an-import-can-be-several-litematic

Litematica saves a selection from **one** world, so a design with a nether side cannot be one file. Seam modelled an import as exactly one, which left such a build as either several unrelated projects or one project missing part of its materials.

Worse than that, actually: `ReceiveSchematicStep` overwrote its buffer per multipart part, so if you *did* select two files, it imported only whichever arrived last — with no error.

## The shape

The review screen already had the concept that fits: **MCO-398's region groups.** A file contributes its regions as groups tagged with the file they came from, and the flat list sums across all of them.

Two files are more groups, not a new idea for the screen to explain. The group header, the include-everything checkbox, and the server-side summing of an item appearing in several groups all already existed and needed no change — `ValidateReviewedMaterialsStep` has summed duplicate rows since MCO-398, for exactly this reason.

## Dimension is not modelled

Per Even, 2026-08-17: it is *"just a filename that often contains a dimension"*. So the spike the issue asked for is dropped rather than run, and groups are qualified by **file name** — the part the author chose and recognises. Nothing infers or stores a dimension.

**Naming:** the file alone when it contributed one section — Litematica names a lone region after the schematic, so the alternative reads `Sorter (nether) — Sorter (nether)` — and `file — region` when it contributed several and the region name adds something.

A single-file import carries no file tag at all and renders byte-identically to before. That is what `ResolvedRegion.sourceFile` being **null** rather than *"the only file"* is for.

## Every litematic path, not just project creation

- `POST /worlds/{w}/projects/from-schematic` — create a project
- `POST .../resources/from-schematic` — replace an existing project's resources
- The idea capture path — summed per item

Leaving one of them single-file would mean a build importing correctly and then being replaced by half of itself.

## Found on the way

The idea path's empty-file check **built a failure and then fell through to success**, so an empty upload was read as a schematic with no materials rather than rejected. Fixed.

Errors now name the file: with one file "could not read the schematic file" is complete; with three it leaves you guessing which to re-export.

## Caps

**MCO-315's parameter cap is unaffected** — the list still rides in one `materials` field, and files add rows to that field rather than parameters. Uploads are capped at 12 files, well above the two or three this exists for (see MCO-421).

## Verified in the running app

On a fresh world, with two real fixture schematics uploaded as one import:

- The review screen said **"These 2 files are being imported as one project, in 2 sections"**, with a section per file — `Sorter` (33 materials, 1,141 blocks) and `Sorter (nether)` (19 materials, 620 blocks), each with its own include-everything checkbox.
- The created project holds **33 resource rows** — the union. The two files share 19 materials, and those were summed rather than duplicated or dropped.
- No exceptions in the server log.

## Tests

**930 unit + 449 database, zero failures.**

New: seven over the multi-file merge (summing, per-file tagging, single-file staying untagged, a region-less file becoming its own group, fluids staying one bucket per section across files), four over group naming and the lead copy, and three ITs through the real multipart path — which is where the "only the last file" bug lived and where a unit test could not reach.

One of those ITs caught a bug in my own test helper rather than the product: the review payload carries one row *per section*, so keying it by item id kept only the last and read a correctly-doubled import as unchanged. It sums now, the way the server does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
