### PR TITLE
MCO-419: style the idea "Produces" section like the material list beside it

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaProductionModes.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaProductionModes.kt
@@ -4,6 +4,7 @@ import app.mcorg.domain.model.idea.IdeaProductionMode
 import kotlinx.html.FlowContent
 import kotlinx.html.div
 import kotlinx.html.h2
+import kotlinx.html.h3
 import kotlinx.html.li
 import kotlinx.html.section
 import kotlinx.html.span
@@ -15,6 +16,10 @@ import kotlinx.html.ul
  * A mode name only appears when there is more than one. An author who never mentioned modes gets
  * the implicit "Default", and printing that word back at them would name a choice they did not
  * make — the list is just items and rates until the design actually has alternatives.
+ *
+ * Laid out as item-then-number like [ideaMaterialList] right below it (MCO-419): the two sections
+ * are the same kind of content — an item and a count — and giving them one shape means the reader
+ * learns to scan the right-hand column once.
  */
 fun FlowContent.ideaProductionModes(modes: List<IdeaProductionMode>) {
     val populated = modes.filter { it.rates.isNotEmpty() }
@@ -22,12 +27,12 @@ fun FlowContent.ideaProductionModes(modes: List<IdeaProductionMode>) {
 
     val named = populated.size > 1
 
-    section("idea-productions") {
+    section("idea-detail__productions") {
         h2("idea-detail__section-title") { +"Produces" }
         populated.forEach { mode ->
             div("idea-productions__mode") {
                 if (named) {
-                    span("idea-productions__mode-name") { +mode.name }
+                    h3("idea-productions__mode-name") { +mode.name }
                 }
                 ul("idea-productions__rates") {
                     // Measured output first; an unmeasured item is still output and still listed,
@@ -35,14 +40,15 @@ fun FlowContent.ideaProductionModes(modes: List<IdeaProductionMode>) {
                     mode.rates.entries
                         .sortedWith(compareByDescending<Map.Entry<String, Int?>> { it.value ?: -1 }.thenBy { it.key })
                         .forEach { (itemId, rate) ->
-                            li("idea-productions__rate") {
+                            val unmeasured = rate == null
+                            li("idea-productions__rate" + if (unmeasured) " idea-productions__rate--unmeasured" else "") {
+                                span("idea-productions__item") { +itemId.prettifyId() }
                                 if (rate != null) {
-                                    span("idea-productions__quantity") { +"%,d".format(rate) }
-                                    +" / hour "
-                                }
-                                span("idea-productions__item") { +itemId.removePrefix("minecraft:").replace('_', ' ') }
-                                if (rate == null) {
-                                    span("idea-productions__unmeasured") { +" — rate unmeasured" }
+                                    span("idea-productions__quantity") {
+                                        +"${rate.toLong().formatWithSeparators()} / hour"
+                                    }
+                                } else {
+                                    span("idea-productions__unmeasured") { +"rate unmeasured" }
                                 }
                             }
                         }

--- a/webapp/mc-web/src/main/resources/static/styles/pages/idea-hub.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/idea-hub.css
@@ -389,6 +389,71 @@ a.ideas-pagination__page:hover {
     white-space: nowrap;
 }
 
+/* Production rates — same row shape as the material list above it */
+.idea-productions__mode + .idea-productions__mode {
+    margin-top: var(--space-4);
+}
+
+.idea-productions__mode-name {
+    font-family: var(--font-ui);
+    font-size: var(--text-label);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-muted);
+    margin: 0 0 var(--space-2) 0;
+}
+
+.idea-productions__rates {
+    display: flex;
+    flex-direction: column;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.idea-productions__rate {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: var(--space-4);
+    padding: var(--space-2) 0;
+    border-bottom: 1px dotted var(--border);
+    max-width: 420px;
+}
+
+.idea-productions__rate:last-child {
+    border-bottom: none;
+}
+
+.idea-productions__item {
+    font-family: var(--font-body);
+    font-size: var(--text-base);
+    color: var(--text-primary);
+    overflow-wrap: anywhere;
+}
+
+.idea-productions__quantity {
+    font-family: var(--font-ui);
+    font-size: var(--text-ui);
+    color: var(--text-muted);
+    white-space: nowrap;
+}
+
+/* An unmeasured rate is still output, so it keeps its row — but it is greyed and italic so the
+   column reads as "has a number / has no number" before a word of it is read. */
+.idea-productions__rate--unmeasured .idea-productions__item {
+    color: var(--text-muted);
+}
+
+.idea-productions__unmeasured {
+    font-family: var(--font-body);
+    font-style: italic;
+    font-size: var(--text-sm);
+    color: var(--text-disabled);
+    white-space: nowrap;
+}
+
 /* Design details */
 .idea-fields {
     display: flex;

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/IdeaProductionModesTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/IdeaProductionModesTest.kt
@@ -18,7 +18,7 @@ class IdeaProductionModesTest {
 
     private fun render(modes: List<IdeaProductionMode>) = createHTML().div { ideaProductionModes(modes) }
 
-    private fun mode(name: String, position: Int, vararg rates: Pair<String, Int>) =
+    private fun mode(name: String, position: Int, vararg rates: Pair<String, Int?>) =
         IdeaProductionMode(id = position + 1, name = name, position = position, rates = rates.toMap())
 
     @Test
@@ -27,8 +27,8 @@ class IdeaProductionModesTest {
         // attribute a choice they did not make.
         val html = render(listOf(mode(IdeaProductionMode.DEFAULT_MODE_NAME, 0, "minecraft:ice" to 71_000)))
 
-        assertContains(html, "71,000")
-        assertContains(html, "ice")
+        assertContains(html, "71${DIGIT_GROUP_SEPARATOR}000")
+        assertContains(html, "Ice")
         assertFalse(html.contains(IdeaProductionMode.DEFAULT_MODE_NAME))
     }
 
@@ -43,15 +43,29 @@ class IdeaProductionModesTest {
 
         assertContains(html, "Max speed")
         assertContains(html, "Slowed")
-        assertContains(html, "62,000")
-        assertContains(html, "18,000")
+        assertContains(html, "62${DIGIT_GROUP_SEPARATOR}000")
+        assertContains(html, "18${DIGIT_GROUP_SEPARATOR}000")
+    }
+
+    @Test
+    fun `a named mode is a heading, not a run of styled text`() {
+        // MCO-419: two modes are two sub-sections of "Produces", and a screen reader jumping by
+        // heading should land on each one.
+        val html = render(
+            listOf(
+                mode("Max speed", 0, "minecraft:ice" to 62_000),
+                mode("Slowed", 1, "minecraft:ice" to 18_000),
+            )
+        )
+
+        assertContains(html, "<h3 class=\"idea-productions__mode-name\">Max speed</h3>")
     }
 
     @Test
     fun `item ids are tidied for reading`() {
         val html = render(listOf(mode("Default", 0, "minecraft:wither_skeleton_skull" to 40)))
 
-        assertContains(html, "wither skeleton skull")
+        assertContains(html, "Wither Skeleton Skull")
         assertFalse(html.contains("minecraft:"))
     }
 
@@ -62,6 +76,17 @@ class IdeaProductionModesTest {
         )
 
         assertTrue(html.indexOf("900") < html.indexOf("500"))
+    }
+
+    @Test
+    fun `an unmeasured item keeps its row and is marked as such`() {
+        // MCO-419: the row carries a modifier class so "has a number" and "has no number" are
+        // distinguishable by sight, not only by reading the words.
+        val html = render(listOf(mode("Default", 0, "minecraft:bamboo" to null)))
+
+        assertContains(html, "idea-productions__rate--unmeasured")
+        assertContains(html, "Bamboo")
+        assertContains(html, "rate unmeasured")
     }
 
     @Test


### PR DESCRIPTION
Closes MCO-419.

The eight class names MCO-412 rendered (`idea-productions`, `__mode`, `__mode-name`, `__rates`, `__rate`, `__quantity`, `__item`, `__unmeasured`) appeared in no stylesheet, so "Produces" came out as a browser-default bulleted list directly above a fully styled Materials section.

Rather than invent a second visual language for the same kind of content — an item and a count — this gives the production rows the material row's shape: item left, number right, dotted rule, same 420px column, same fonts and colors. That extends to the details that made the two look unrelated:

- **Number formatting** — `formatWithSeparators()` (narrow no-break space) instead of `"%,d"` commas, so one page has one number format.
- **Item names** — `prettifyId()`, so "Packed Ice" rather than "packed ice", matching the material list's catalog names.

**Unmeasured rates** keep their row and are greyed + italic against the mono figures, so the right column reads as has-a-number / has-no-number before a word of it is read.

**Mode names** become `h3` rather than a styled `span` — with two modes they are sub-sections of "Produces", and heading navigation should land on each. They stay absent entirely when there is only one mode (unchanged behaviour).

## Verification

- `mvn clean compile` clean; 932 unit tests pass via `webapp/scripts/test.sh`.
- Test file updated for the new formatting, plus two new cases: the `h3` heading, and the unmeasured row carrying its modifier class.
- Drove the running app at 1440 and 375 widths against a seeded multi-mode idea (three modes, one unmeasured rate) and a single-mode idea. Multi-mode shows named sub-headings; single-mode shows none; rows align with the Materials rows below. No errors in the app log.

CSS/template-only otherwise — no migration, no restricted-area (`mc-engine` / `SelectionScorer`) changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
