### PR TITLE
MCO-411: prove idea import writes the productions the idea declares

### DIFF
--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
@@ -55,6 +55,7 @@ class ImportIdeaReviewIT : WithUser() {
     private var airyIdeaId: Int = 0
     private var expensiveIdeaId: Int = 0
     private var wideIdeaId: Int = 0
+    private var multiModeIdeaId: Int = 0
 
     @BeforeAll
     fun setup() {
@@ -88,6 +89,24 @@ class ImportIdeaReviewIT : WithUser() {
         wideIdeaId = createIdea("Very Wide Idea")
         seedItems((1..BULK_ROWS).map { "minecraft:bulk_item_$it" to "Bulk Item $it" })
         addRequirements(wideIdeaId, (1..BULK_ROWS).map { "minecraft:bulk_item_$it" to it })
+
+        // MCO-411: what the idea produces has to survive the import, or the farm the user just
+        // imported supplies nothing and the roadmap draws no edge from it (MCO-287's model).
+        addProductionMode(ideaId, "Default", listOf("minecraft:iron_ingot" to 620))
+
+        // Two modes, no choice recorded anywhere yet: the import takes the highest-yield one
+        // (ratesForImport). An unmeasured rate arrives as project_productions' own 0.
+        seedItem("minecraft:bone", "Bone")
+        seedItem("minecraft:blaze_rod", "Blaze Rod")
+        seedItem("minecraft:blaze_powder", "Blaze Powder")
+        multiModeIdeaId = createIdea("Fortress Farm")
+        addRequirement(multiModeIdeaId, "minecraft:oak_planks", 10)
+        addProductionMode(multiModeIdeaId, "Skeletons only", listOf("minecraft:bone" to 700))
+        addProductionMode(
+            multiModeIdeaId,
+            "Everything on",
+            listOf("minecraft:bone" to 500, "minecraft:blaze_rod" to 400, "minecraft:blaze_powder" to null),
+        )
     }
 
     // ---- review ------------------------------------------------------------------
@@ -235,6 +254,50 @@ class ImportIdeaReviewIT : WithUser() {
             "oak planks were excluded on the review screen",
         )
         assertEquals(ideaId, getProjectIdeaId(projectId), "the idea link survives the review step")
+    }
+
+    @Test
+    fun `import records what the idea produces`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        val response = client.post("/ideas/$ideaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("worldId=$worldId&" + materials("minecraft:iron_ingot" to 64))
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val projectId = response.headers["Location"]!!.substringAfterLast("/").toInt()
+
+        // The whole of MCO-411: this list was empty for every import ever made, so no imported
+        // farm has ever supplied anything.
+        assertEquals(listOf("minecraft:iron_ingot" to 620), readProductions(projectId))
+    }
+
+    @Test
+    fun `an idea with several modes imports the highest-yield one`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        val response = client.post("/ideas/$multiModeIdeaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("worldId=$worldId&" + materials("minecraft:oak_planks" to 10))
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val projectId = response.headers["Location"]!!.substringAfterLast("/").toInt()
+
+        assertEquals(
+            listOf(
+                "minecraft:blaze_powder" to 0,
+                "minecraft:blaze_rod" to 400,
+                "minecraft:bone" to 500,
+            ),
+            readProductions(projectId),
+            "900/h across three items beats the skeletons-only mode's 700",
+        )
     }
 
     @Test
@@ -501,6 +564,45 @@ class ImportIdeaReviewIT : WithUser() {
             resultMapper = { rs ->
                 val rows = mutableListOf<Pair<String, Int>>()
                 while (rs.next()) rows.add(rs.getString("item_id") to rs.getInt("required"))
+                rows
+            }
+        ).process(projectId)
+        (result as Result.Success).value
+    }
+
+    private fun addProductionMode(ideaId: Int, name: String, rates: List<Pair<String, Int?>>) = runBlocking {
+        val modeId = DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                "INSERT INTO idea_production_modes (idea_id, name, position) " +
+                    "VALUES (?, ?, (SELECT COALESCE(MAX(position) + 1, 0) FROM idea_production_modes WHERE idea_id = ?)) " +
+                    "RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, ideaId)
+                stmt.setString(2, name)
+                stmt.setInt(3, ideaId)
+            }
+        ).process(Unit).let { (it as Result.Success).value }
+
+        DatabaseSteps.batchUpdate<Pair<String, Int?>>(
+            SafeSQL.insert("INSERT INTO idea_production_rates (mode_id, item_id, rate_per_hour) VALUES (?, ?, ?)"),
+            parameterSetter = { stmt, (itemId, rate) ->
+                stmt.setInt(1, modeId)
+                stmt.setString(2, itemId)
+                if (rate == null) stmt.setNull(3, java.sql.Types.INTEGER) else stmt.setInt(3, rate)
+            }
+        ).process(rates)
+    }
+
+    private fun readProductions(projectId: Int): List<Pair<String, Int>> = runBlocking {
+        val result = DatabaseSteps.query<Int, List<Pair<String, Int>>>(
+            sql = SafeSQL.select(
+                "SELECT item_id, rate_per_hour FROM project_productions WHERE project_id = ? ORDER BY item_id"
+            ),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) },
+            resultMapper = { rs ->
+                val rows = mutableListOf<Pair<String, Int>>()
+                while (rs.next()) rows.add(rs.getString("item_id") to rs.getInt("rate_per_hour"))
                 rows
             }
         ).process(projectId)


### PR DESCRIPTION
The extractor MCO-411 was filed against no longer exists — MCO-412 replaced `extractProductionRates` with `ratesForImport` reading the relational modes, and `IdeaProductionModeSelectionTest` covers the mode choice.

What was never covered is the fact the bug was actually about: whether an import ends with `project_productions` rows at all. That path runs through the review handler, `GetIdeaProductionModesStep`, `ValidateItemIdsStep` and a batch insert — none of which the unit test touches, and `ImportIdeaReviewIT` had no production assertions.

Two ITs through the real import door:

- a single-mode idea's rate lands on the project — empty for every import ever made before MCO-412, which is why no imported farm has ever supplied anything
- a two-mode idea imports the higher-yield mode, with an unmeasured rate arriving as `project_productions`' own `0`

Test-only. `test.sh --database -Dtest=ImportIdeaReviewIT` → 17/17; unit tier green.

Closes MCO-411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)