### PR TITLE
MCO-456: an unknown production id no longer kills the whole idea import

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -43,7 +43,12 @@ data class IdeaForImport(
     val description: String,
     val category: IdeaCategory,
     val requirements: Map<Item, Int>,
-    val production: Map<Item, Int>
+    val production: Map<Item, Int>,
+    /**
+     * Produced item ids this world's version does not have (MCO-456). Dropped from
+     * [production] and reported, never fatal — see [ValidateItemIdsStep].
+     */
+    val unrecordableProductions: List<String> = emptyList(),
 )
 
 /**
@@ -85,6 +90,7 @@ suspend fun ApplicationCall.handleReviewIdeaImport() {
                     requirements = requirements,
                     placedCounts = materials.placedCounts,
                     warnings = computeImportWarnings(worldId, requirements),
+                    unrecordableProductions = idea.unrecordableProductions,
                     action = Link.Ideas.single(ideaId) + "/import",
                     hiddenFields = buildMap {
                         put("worldId", worldId.toString())
@@ -344,11 +350,12 @@ internal fun ratesForImport(modes: List<IdeaProductionMode>, chosenModeName: Str
 }
 
 
-private data class ValidateItemIdsStep(val availableIds: List<Item>) : Step<Pair<BasicIdeaInfo, Map<String, Int>>, AppFailure, IdeaForImport> {
+internal data class ValidateItemIdsStep(val availableIds: List<Item>) : Step<Pair<BasicIdeaInfo, Map<String, Int>>, AppFailure, IdeaForImport> {
     override suspend fun process(input: Pair<BasicIdeaInfo, Map<String, Int>>): Result<AppFailure, IdeaForImport> {
         val (ideaInfo, requirements) = input
         val mappedRequirements = mutableMapOf<Item, Int>()
         val mappedProduction = mutableMapOf<Item, Int>()
+        val unrecordable = mutableListOf<String>()
         val errors = mutableListOf<ValidationFailure>()
 
         for ((itemId, amount) in requirements) {
@@ -365,12 +372,17 @@ private data class ValidateItemIdsStep(val availableIds: List<Item>) : Step<Pair
             }
         }
 
-        // TODO: Support multiple production entries?
+        // An unknown *production* id is reported, not refused (MCO-456). It used to be a
+        // validation error, which failed the whole import — and the review GET with it — over a
+        // field that screen does not have, so there was nothing the user could do but give up on
+        // the idea. What it produces is the author's claim about their farm, not work this world
+        // is agreeing to do: the honest handling is to record what this version knows about, say
+        // what was left out, and let the import through.
         for ((itemId, amount) in ideaInfo.productionRate) {
             val item = availableIds.find { it.id == itemId }
 
             if (item == null) {
-                errors.add(ValidationFailure.CustomValidation("productionRate", "Item ID $itemId is not available in the world version"))
+                unrecordable.add(itemId)
             } else {
                 mappedProduction[item] = amount
             }
@@ -384,7 +396,8 @@ private data class ValidateItemIdsStep(val availableIds: List<Item>) : Step<Pair
                     description = ideaInfo.description,
                     category = ideaInfo.category,
                     requirements = mappedRequirements,
-                    production = mappedProduction
+                    production = mappedProduction,
+                    unrecordableProductions = unrecordable.sorted(),
                 )
             )
         } else {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -79,6 +79,7 @@ fun importReviewPage(
     placedCounts: Map<String, Int> = emptyMap(),
     regions: List<ResolvedRegion> = emptyList(),
     warnings: ImportWarnings = ImportWarnings(),
+    unrecordableProductions: List<String> = emptyList(),
 ): String = pageShell(
     pageTitle = "Seam — review import",
     user = user,
@@ -135,6 +136,8 @@ fun importReviewPage(
                         required = true
                     }
                 }
+
+                productionNotice(unrecordableProductions)
 
                 materialsSection(requirements, emptySet(), placedCounts, regions, warnings)
 
@@ -325,6 +328,54 @@ private fun FlowContent.warningStrip(warnings: ImportWarnings) {
             }
         }
     }
+}
+
+/**
+ * What the idea claims to produce that this world cannot record (MCO-456).
+ *
+ * Productions are not reviewable — they are the author's statement about their farm, not work
+ * this world is agreeing to do (MCO-306) — so this is a notice and not a control. It exists
+ * because the alternative is silence: the import succeeds, the farm supplies less than the idea
+ * page said it would, and nothing anywhere connects the two.
+ *
+ * Info rather than warning. Nothing is wrong with the import and nothing is lost that this
+ * version could have used; a full-weight warning here would outrank the creative-only strip,
+ * which is about materials the user is about to go and gather.
+ */
+private fun FlowContent.productionNotice(unrecordable: List<String>) {
+    if (unrecordable.isEmpty()) return
+
+    div("callout callout--info import-review__warnings") {
+        span("callout__icon") {
+            attributes["aria-hidden"] = "true"
+            +"i"
+        }
+        div("callout__body") {
+            p("import-review__warning") {
+                span("import-review__warning-heading") { +"Not recorded as production: " }
+                +itemNamesFromIds(unrecordable)
+                +". This idea says it produces these, but this world's Minecraft version has no "
+                +"such item — the project is created without them."
+            }
+        }
+    }
+}
+
+/**
+ * A readable name for an id the catalog cannot name.
+ *
+ * These ids resolve to nothing in this world's version, so there is no stored display name to
+ * look up — `minecraft:sculk_shrieker` becomes `Sculk Shrieker` here rather than being shown
+ * raw. Same four-then-a-count cutoff as [namesOf].
+ */
+private fun itemNamesFromIds(ids: List<String>): String {
+    val shown = ids.take(4).joinToString(", ") { id ->
+        id.substringAfter(':').split('_').joinToString(" ") { word ->
+            word.replaceFirstChar { it.uppercase() }
+        }
+    }
+    val rest = ids.size - 4
+    return if (rest > 0) "$shown and $rest more" else shown
 }
 
 /** Up to four names, then a count — a strip that lists thirty items is a wall, not a warning. */

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
@@ -56,6 +56,7 @@ class ImportIdeaReviewIT : WithUser() {
     private var expensiveIdeaId: Int = 0
     private var wideIdeaId: Int = 0
     private var multiModeIdeaId: Int = 0
+    private var unknownProductionIdeaId: Int = 0
 
     @BeforeAll
     fun setup() {
@@ -106,6 +107,18 @@ class ImportIdeaReviewIT : WithUser() {
             multiModeIdeaId,
             "Everything on",
             listOf("minecraft:bone" to 500, "minecraft:blaze_rod" to 400, "minecraft:blaze_powder" to null),
+        )
+
+        // MCO-456: an idea claiming to produce something this world's version has no item for.
+        // Never seeded into minecraft_items by any IT class — the container is shared, so an id
+        // used here has to stay unseeded suite-wide to keep meaning "this version has no such
+        // item".
+        unknownProductionIdeaId = createIdea("Shrieker Farm")
+        addRequirement(unknownProductionIdeaId, "minecraft:oak_planks", 12)
+        addProductionMode(
+            unknownProductionIdeaId,
+            "Default",
+            listOf("minecraft:iron_ingot" to 90, "minecraft:sculk_shrieker" to 30),
         )
     }
 
@@ -297,6 +310,41 @@ class ImportIdeaReviewIT : WithUser() {
             ),
             readProductions(projectId),
             "900/h across three items beats the skeletons-only mode's 700",
+        )
+    }
+
+    @Test
+    fun `a production this version has no item for is reported, not fatal`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        val review = client.get("/ideas/$unknownProductionIdeaId/import/review?worldId=$worldId") {
+            addAuthCookie(this)
+        }
+
+        // The whole of MCO-456: this GET used to fail outright, so the material list — the part
+        // the user was asked to review — was unreachable over a field this screen does not have.
+        assertEquals(HttpStatusCode.OK, review.status)
+        val body = review.bodyAsText()
+        assertContains(body, "Not recorded as production")
+        assertContains(body, "Sculk Shrieker")
+        // Ids, not display names: the container is shared across IT classes, so whichever class
+        // seeds an id first owns its name (MCO-361).
+        assertContains(body, "minecraft:oak_planks=12")
+
+        val response = client.post("/ideas/$unknownProductionIdeaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("worldId=$worldId&" + materials("minecraft:oak_planks" to 12))
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val projectId = response.headers["Location"]!!.substringAfterLast("/").toInt()
+
+        assertEquals(
+            listOf("minecraft:iron_ingot" to 90),
+            readProductions(projectId),
+            "the production this version does know about still supplies the world",
         )
     }
 


### PR DESCRIPTION
`ValidateItemIdsStep` checked the idea's productions against the world version's item catalog and made a miss a validation error. Errors are fatal for the step, and the step runs on **both** halves of the door — so one unrecognised produced id failed the review GET as well as the import, naming the field `productionRate` on a screen that has no such field. The material list, the part the user was actually asked to review, was unreachable.

Productions are not the user's to review (MCO-306): they are the author's claim about their farm, not work this world agreed to do. So the unresolvable ones are dropped and reported — the project records what this version knows about, and the review screen says what was left out, as an info callout next to the creative-only strip rather than above it. The name is humanised from the id, since an id the catalog cannot resolve has no stored display name.

IT through the real door: the review renders, the import succeeds, and the production this version *does* know about still reaches `project_productions`.

## Verified in the app

Real reproduction on the worktree DB — a 26.2.0-authored idea producing `minecraft:cinnabar` imported into a 26.1.2 world, which is the reachable version-skew case (MCO-449, MCO-444):

- review page renders, notice reads "Not recorded as production: Cinnabar…", checked at 1440 and 375
- import succeeds; `project_productions` has the `ghast_tear` row and no cinnabar row; 39 requirement rows intact
- no errors or stack traces in the app log during the flow

`test.sh --database` green (452 + 932).

Closes MCO-456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)