### PR TITLE
MCO-404: invalidate stored demand when a world's supply changes

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/DeleteProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/DeleteProjectPipeline.kt
@@ -3,6 +3,7 @@ package app.mcorg.pipeline.project
 import app.mcorg.config.CacheManager
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.resources.invalidateDemandSuppliedBy
 import app.mcorg.presentation.handler.handlePipeline
 import app.mcorg.presentation.templated.dsl.Link
 import app.mcorg.presentation.utils.clientRedirect
@@ -20,6 +21,11 @@ suspend fun ApplicationCall.handleDeleteProject() {
     handlePipeline(
         onSuccess = { clientRedirect(Link.Worlds.world(worldId).projects().to) }
     ) {
+        // Before the delete, not after: the productions this reads are about to cascade away
+        // with the project, and after that nothing can tell which items stopped being supplied
+        // (MCO-404). Unconditional on state — a farm that was never DONE invalidates nothing,
+        // because its items were never in anyone's supply.
+        invalidateDemandSuppliedBy(worldId, projectId)
         handleDeleteProjectStep.run(projectId)
         CacheManager.onProjectDeleted(worldId, projectId)
     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/RecordExistingFarmPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/RecordExistingFarmPipeline.kt
@@ -1,6 +1,7 @@
 package app.mcorg.pipeline.project
 
 import app.mcorg.config.CacheManager
+import app.mcorg.pipeline.resources.invalidateDemandSuppliedBy
 import app.mcorg.domain.model.minecraft.Dimension
 import app.mcorg.domain.model.minecraft.Item
 import app.mcorg.domain.model.minecraft.MinecraftLocation
@@ -80,6 +81,9 @@ suspend fun ApplicationCall.handleRecordExistingFarm() {
         val input = ValidateRecordExistingFarmInputStep(validItems).run(parameters)
         ValidateWorldMemberRole<RecordExistingFarmInput>(user, Role.ADMIN, worldId).run(input)
         val projectId = CreateExistingFarmStep(worldId).run(input)
+        // A farm recorded straight into DONE is new world supply the moment it exists, so every
+        // stored plan that gathers what it makes is now wrong (MCO-404).
+        invalidateDemandSuppliedBy(worldId, projectId)
         CacheManager.onProjectCreated(worldId, projectId)
         bus.publish(
             ProjectCreated(

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/UpdateProjectMetaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/UpdateProjectMetaPipeline.kt
@@ -8,6 +8,7 @@ import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.ValidationSteps
+import app.mcorg.pipeline.resources.invalidateDemandOnStateChange
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.failure.ValidationFailure
 import app.mcorg.pipeline.project.commonsteps.GetProjectByIdStep
@@ -118,7 +119,10 @@ suspend fun ApplicationCall.handleUpdateProjectStateInline() {
         ValidateWorldMemberRole<ProjectState>(user, Role.ADMIN, worldId).run(target)
         val current = GetProjectStateStep.run(projectId)
         ValidateStateTransitionStep(current).run(target)
-        UpdateProjectStateStep(projectId).run(target)
+        val newState = UpdateProjectStateStep(projectId).run(target)
+        // Same rule as the Field Log's badge — this is the project page's door to the same
+        // transition, and a farm reaching DONE here supplies the world just as much (MCO-404).
+        invalidateDemandOnStateChange(worldId, projectId, current, newState)
         GetProjectByIdStep.run(projectId)
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/UpdateProjectStatePipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/UpdateProjectStatePipeline.kt
@@ -3,6 +3,7 @@ package app.mcorg.pipeline.project
 import app.mcorg.domain.model.project.ProjectState
 import app.mcorg.domain.model.user.Role
 import app.mcorg.event.ProjectStatusChanged
+import app.mcorg.pipeline.resources.invalidateDemandOnStateChange
 import app.mcorg.event.actorDisplayName
 import app.mcorg.event.eventBus
 import java.time.Instant
@@ -42,6 +43,9 @@ suspend fun ApplicationCall.handleUpdateProjectState() {
         val current = GetProjectStateStep.run(projectId)
         ValidateStateTransitionStep(current).run(target)
         val newState = UpdateProjectStateStep(projectId).run(target)
+        // Crossing DONE is what adds or removes this project's output as world supply, so every
+        // other project's stored plan may now be wrong (MCO-404).
+        invalidateDemandOnStateChange(worldId, projectId, current, newState)
         val project = GetProjectByIdStep.run(projectId)
         bus.publish(
             ProjectStatusChanged(

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/resources/ProjectProductionPipelines.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/resources/ProjectProductionPipelines.kt
@@ -4,6 +4,9 @@ import app.mcorg.domain.model.minecraft.Item
 import app.mcorg.domain.model.project.ProjectProduction
 import app.mcorg.domain.model.user.Role
 import app.mcorg.domain.pipeline.Step
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.pipeline.project.GetProjectStateStep
+import app.mcorg.pipeline.resources.invalidateDemandSuppliedBy
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
@@ -138,6 +141,11 @@ suspend fun ApplicationCall.handleUpsertProjectProduction() {
     ) {
         val input = ValidateProjectProductionInputStep(validItems).run(parameters)
         UpsertProjectProductionStep(projectId).run(input)
+        // A new produced item on an operational farm is new world supply (MCO-404). Editing a
+        // rate is not — V1 supply is unbounded (MCO-287), so the rate never reached the plan —
+        // but telling the two apart costs a read of what was there before, and the invalidation
+        // is a single DELETE against an action taken by hand.
+        invalidateDemandIfOperational(worldId, projectId)
         GetResourceProductionStep.run(projectId)
     }
 }
@@ -155,7 +163,22 @@ suspend fun ApplicationCall.handleDeleteProjectProduction() {
             )
         }
     ) {
+        // Before the delete: afterwards the row that says which item stopped being supplied is
+        // gone (MCO-404).
+        invalidateDemandIfOperational(worldId, projectId)
         DeleteProjectProductionStep(projectId).run(productionId)
         GetResourceProductionStep.run(projectId)
+    }
+}
+
+/**
+ * Invalidates stored demand for a production change, but only on a farm that is actually
+ * supplying — a project that is not DONE contributes nothing to anyone's plan
+ * (`GetWorldFarmSuppliesStep`), so editing its productions cannot have made a stored plan wrong.
+ */
+private suspend fun invalidateDemandIfOperational(worldId: Int, projectId: Int) {
+    val state = GetProjectStateStep.process(projectId)
+    if (state is Result.Success && state.value == ProjectState.DONE) {
+        invalidateDemandSuppliedBy(worldId, projectId)
     }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/DemandInvalidation.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/DemandInvalidation.kt
@@ -1,0 +1,159 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+import org.slf4j.LoggerFactory
+
+/**
+ * Invalidation of materialised demand when a world's **supply** changes (MCO-404).
+ *
+ * [DemandFingerprint] hashes every input a derivation reads, including the world's farm supply —
+ * but it is only ever *checked* where demand is written (`GenerateGatheringPlanStep`, on the
+ * project page). The roadmap reads the stored rows and derives only for projects that have none
+ * at all ([GetWorldDemandCoverageStep]), so a project with **stale** rows served them forever.
+ *
+ * That gap is not hypothetical, because supply is world-scoped: marking one farm DONE changes
+ * what every other project in the world has to gather. Their roadmap numbers stayed pre-farm
+ * until somebody happened to open each project page.
+ *
+ * ## Why invalidate rather than revalidate on read
+ *
+ * Of the three approaches on MCO-404, this is the first: delete the fingerprint at the moment
+ * supply changes and let the roadmap's existing fill-on-read path re-derive. It wins on
+ * measurement, not on taste — against the real ingested `Forever world` (29 projects, 2 with
+ * gathering rows, one of them the 555-target YAMS storage system):
+ *
+ * | Path                                            | Measured        |
+ * | ----------------------------------------------- | --------------- |
+ * | Warm roadmap load (all fingerprints present)     | 0.15 – 0.21 s   |
+ * | Cold roadmap load (2 projects to derive)         | 1.50 s          |
+ * | One 555-target derivation, cold                  | 0.63 – 0.83 s   |
+ *
+ * Revalidating on read (option 3) means one derivation per project per roadmap load — 0.7 s each
+ * on this data, so a world where 29 projects have plans would spend ~20 s rendering a table. The
+ * measured cost of *this* approach is one DELETE on an action nobody takes often, and the
+ * re-derivation is paid lazily, once, by the next roadmap load — which is the cost fill-on-read
+ * already permits and which the numbers above price at 0.7 s per affected project.
+ *
+ * ## Targeted by item, not by world
+ *
+ * Invalidating the whole world would be simpler and much more expensive: every planned project
+ * would re-derive because one farm changed. A project's plan can only have changed if it touches
+ * an item the producer produces, and `project_demand` already records exactly which items each
+ * project's plan touched — so the invalidation is a join, and flipping the iron farm invalidates
+ * the projects that gather iron and nobody else.
+ *
+ * ## What is deliberately *not* invalidated here
+ *
+ * Only the supplied **item set** matters. `DemandFingerprint` also hashes the producer's display
+ * name (via `SupplySource.Farm`'s label), so renaming a farm changes the fingerprint — but the
+ * derived demand rows are identical, so serving them is not stale in any way a reader could
+ * observe. Rates are not in the fingerprint at all: V1 supply is unbounded (MCO-287), so a rate
+ * is information rather than a constraint on the plan.
+ *
+ * The other input classes — a project's own targets, its collected counts, its plan overrides —
+ * are **not** covered by this. They change on the project page, which re-derives and rewrites on
+ * the spot; their staleness window is the roadmap between such a change and the next visit to
+ * that project, and invalidating on every progress tick would re-derive so often that the
+ * materialised table would stop paying for itself. That trade wants its own measurement.
+ */
+private val logger = LoggerFactory.getLogger("app.mcorg.pipeline.resources.DemandInvalidation")
+
+/**
+ * Drops the stored demand fingerprint of every project in [worldId] whose plan touches an item
+ * that [producerProjectId] produces, so the next roadmap load re-derives them.
+ *
+ * The producer itself is excluded: a farm's own plan never sees its own output as supply
+ * (`WorldFarmSuppliesInput.excludeProjectId`), so its demand cannot have changed.
+ *
+ * Only `project_demand_state` is deleted, never `project_demand`. The rows stay readable until
+ * the re-derivation replaces them, so a roadmap load that races an invalidation shows the old
+ * numbers rather than an empty graph — the same "one load behind" the fill-on-read path has
+ * always had, and strictly better than a project blinking out of the table.
+ *
+ * Call it **before** the change when the change removes what it reads (deleting a production
+ * row, deleting the project), and after when it does not (a state transition).
+ *
+ * @return the number of projects invalidated.
+ */
+data class InvalidateDemandSuppliedByStep(
+    val worldId: Int,
+    val producerProjectId: Int,
+) : Step<Unit, AppFailure.DatabaseError, Int> {
+
+    override suspend fun process(input: Unit): Result<AppFailure.DatabaseError, Int> =
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.delete(
+                """
+                DELETE FROM project_demand_state s
+                WHERE s.project_id IN (
+                    SELECT DISTINCT d.project_id
+                    FROM project_demand d
+                    JOIN projects c ON c.id = d.project_id
+                    WHERE c.world_id = ?
+                      AND d.project_id <> ?
+                      AND d.item_id IN (
+                          SELECT pp.item_id FROM project_productions pp WHERE pp.project_id = ?
+                      )
+                )
+                """.trimIndent()
+            ),
+            parameterSetter = { statement, _ ->
+                statement.setInt(1, worldId)
+                statement.setInt(2, producerProjectId)
+                statement.setInt(3, producerProjectId)
+            },
+        ).process(Unit)
+}
+
+/**
+ * Fire-and-forget wrapper for the handlers.
+ *
+ * Invalidation runs after the mutation it follows has already committed, on a request whose
+ * result is a rendered fragment. Failing that request because a cache invalidation failed would
+ * turn a stale number into a visible error, so a failure is logged and swallowed — the same
+ * posture as the write-through in `GenerateGatheringPlanStep`. The cost of the swallowed case is
+ * one world's roadmap staying one derivation behind until the next supply change or project
+ * visit.
+ */
+suspend fun invalidateDemandSuppliedBy(worldId: Int, producerProjectId: Int) {
+    when (val result = InvalidateDemandSuppliedByStep(worldId, producerProjectId).process(Unit)) {
+        is Result.Success ->
+            if (result.value > 0) {
+                logger.debug(
+                    "Demand: invalidated {} project(s) in world {} after a supply change in project {}",
+                    result.value, worldId, producerProjectId,
+                )
+            }
+        // No exception and no row data in the message: a PostgreSQL error appends
+        // `DETAIL: Key (col)=(value)`, which is user content. See documentation/logging.md.
+        is Result.Failure ->
+            logger.warn(
+                "Demand: could not invalidate stored demand in world {} after a supply change in project {}",
+                worldId, producerProjectId,
+            )
+    }
+}
+
+/**
+ * The state half of the rule, shared by the two doors that move a project's state — the Field Log
+ * badge and the project page's inline editor.
+ *
+ * DONE is the producing condition (MCO-287): crossing it in either direction is what adds or
+ * removes world supply. Every other transition leaves the supplied item set alone, so it costs
+ * nothing here.
+ */
+suspend fun invalidateDemandOnStateChange(
+    worldId: Int,
+    projectId: Int,
+    from: ProjectState,
+    to: ProjectState,
+) {
+    if (from == ProjectState.DONE || to == ProjectState.DONE) {
+        invalidateDemandSuppliedBy(worldId, projectId)
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/DemandInvalidationIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/DemandInvalidationIT.kt
@@ -1,0 +1,349 @@
+package app.mcorg.presentation.handler.project
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.minecraft.ServerData
+import app.mcorg.domain.model.resources.ResourceQuantity
+import app.mcorg.domain.model.resources.ResourceSource
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.minecraft.StoreMinecraftDataStep
+import app.mcorg.pipeline.project.handleDeleteProject
+import app.mcorg.pipeline.project.handleUpdateProjectState
+import app.mcorg.pipeline.project.resources.handleDeleteProjectProduction
+import app.mcorg.pipeline.project.resources.handleUpsertProjectProduction
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.ProjectParamPlugin
+import app.mcorg.presentation.plugins.ProjectProductionItemParamPlugin
+import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
+import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.delete
+import io.ktor.client.request.patch
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.patch
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Stored demand is invalidated when world supply changes (MCO-404).
+ *
+ * The bug these cover: `DemandFingerprint` is checked only where demand is *written* — the project
+ * page. The roadmap reads the stored rows and derives only for projects that have none, so a farm
+ * reaching DONE left every other project in the world serving pre-farm numbers until somebody
+ * happened to open each project page.
+ *
+ * Assertions are on `project_demand_state`, not on the roadmap's HTML: a missing fingerprint is
+ * exactly what makes the roadmap's existing fill-on-read path re-derive, and it is the thing this
+ * change controls. `WorldRoadmapIT` covers what the page does with the result.
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class DemandInvalidationIT : WithUser() {
+
+    private val version = MinecraftVersion.Release(1, 98, 0)
+    private val ironIngot = Item("minecraft:iron_ingot", "Iron Ingot")
+    private val poppy = Item("minecraft:poppy", "Poppy")
+
+    private var worldId: Int = 0
+
+    /** A farm producing iron, recorded DONE — the supply everything here turns on. */
+    private var farmId: Int = 0
+
+    /** Gathers iron: its stored plan changes when the farm's supply does. */
+    private var consumerId: Int = 0
+
+    /** Gathers poppies: nothing the farm does can change its plan. */
+    private var unrelatedId: Int = 0
+
+    @BeforeAll
+    fun setup() {
+        val serverData = ServerData(
+            version = version,
+            items = listOf(ironIngot, poppy),
+            sources = listOf(
+                ResourceSource(
+                    type = ResourceSource.SourceType.LootTypes.BLOCK,
+                    filename = "blocks/iron_ore.json",
+                    producedItems = listOf(ironIngot to ResourceQuantity.ItemQuantity(1))
+                )
+            )
+        )
+        assertIs<Result.Success<*>>(runBlocking { StoreMinecraftDataStep.process(serverData) })
+
+        worldId = createWorld("Demand Invalidation IT World")
+        farmId = createProject("Iron Farm")
+        consumerId = createProject("Iron-hungry Build")
+        unrelatedId = createProject("Flower Garden")
+
+        insertProduction(farmId, ironIngot.id, ironIngot.name, 3810)
+        insertDemand(consumerId, ironIngot)
+        insertDemand(unrelatedId, poppy)
+    }
+
+    @BeforeEach
+    fun resetState() {
+        setProjectState(farmId, "DONE")
+        stampFingerprint(consumerId)
+        stampFingerprint(unrelatedId)
+        stampFingerprint(farmId)
+    }
+
+    @Test
+    fun `a farm leaving DONE invalidates only the projects that gather what it makes`() = testApplication {
+        setupRoutes()
+
+        val response = client.patch("/worlds/$worldId/projects/$farmId/state") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("state=ACTIVE")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        assertFalse(hasFingerprint(consumerId), "the iron gatherer's stored plan is now wrong")
+        assertTrue(hasFingerprint(unrelatedId), "poppies have nothing to do with the iron farm")
+        assertTrue(hasFingerprint(farmId), "a farm's own plan never sees its own output as supply")
+    }
+
+    @Test
+    fun `a farm reaching DONE invalidates them too`() = testApplication {
+        setupRoutes()
+        setProjectState(farmId, "ACTIVE")
+        stampFingerprint(consumerId)
+
+        val response = client.patch("/worlds/$worldId/projects/$farmId/state") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("state=DONE")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        assertFalse(hasFingerprint(consumerId), "iron now comes from the farm, so the plan shrank")
+    }
+
+    @Test
+    fun `a transition that does not cross DONE leaves stored demand alone`() = testApplication {
+        setupRoutes()
+        setProjectState(farmId, "ACTIVE")
+        stampFingerprint(consumerId)
+
+        val response = client.patch("/worlds/$worldId/projects/$farmId/state") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("state=PAUSED")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        assertTrue(
+            hasFingerprint(consumerId),
+            "ACTIVE to PAUSED changes nothing about what the world supplies",
+        )
+    }
+
+    @Test
+    fun `removing a produced item from an operational farm invalidates its consumers`() = testApplication {
+        setupRoutes()
+        val productionId = productionIdOf(farmId, ironIngot.id)
+
+        val response = client.delete("/worlds/$worldId/projects/$farmId/productions/$productionId") {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        assertFalse(hasFingerprint(consumerId), "the world stopped supplying iron")
+        assertTrue(hasFingerprint(unrelatedId))
+
+        insertProduction(farmId, ironIngot.id, ironIngot.name, 3810)
+    }
+
+    @Test
+    fun `adding a produced item to a farm that is not operational invalidates nothing`() = testApplication {
+        setupRoutes()
+        setProjectState(farmId, "ACTIVE")
+        stampFingerprint(consumerId)
+
+        val response = client.post("/worlds/$worldId/projects/$farmId/productions") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("itemId=${poppy.id}&ratePerHour=12")
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        assertTrue(
+            hasFingerprint(consumerId),
+            "a farm that is not DONE supplies nothing, so its productions cannot make a plan wrong",
+        )
+
+        deleteProduction(farmId, poppy.id)
+    }
+
+    @Test
+    fun `deleting an operational farm invalidates its consumers`() = testApplication {
+        setupRoutes()
+        val doomedFarmId = createProject("Second Iron Farm")
+        setProjectState(doomedFarmId, "DONE")
+        insertProduction(doomedFarmId, ironIngot.id, ironIngot.name, 1000)
+
+        val response = client.delete("/worlds/$worldId/projects/$doomedFarmId") { addAuthCookie(this) }
+
+        assertEquals(HttpStatusCode.OK, response.status, response.bodyAsText())
+        // Read before the cascade, not after: once the project is gone so are its productions,
+        // and nothing could tell which items stopped being supplied.
+        assertFalse(hasFingerprint(consumerId), "iron stopped being supplied when the farm went")
+        assertTrue(hasFingerprint(unrelatedId))
+    }
+
+    // ---- routing — mirrors WorldHandler ---------------------------------------------
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
+                install(UpdateActiveWorldPlugin)
+                route("/projects/{projectId}") {
+                    install(ProjectParamPlugin)
+                    delete { call.handleDeleteProject() }
+                    patch("/state") { call.handleUpdateProjectState() }
+                    route("/productions") {
+                        post { call.handleUpsertProjectProduction() }
+                        route("/{productionId}") {
+                            install(ProjectProductionItemParamPlugin)
+                            delete { call.handleDeleteProjectProduction() }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- fixtures -------------------------------------------------------------------
+
+    private fun createWorld(name: String): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(name = name, description = "test", version = version)
+        )
+        (result as Result.Success).value
+    }
+
+    private fun createProject(name: String): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, location_x, location_y, location_z, location_dimension) " +
+                    "VALUES (?, ?, '', 'FARMING', 'PLANNING', 0, 0, 0, 'OVERWORLD') RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, name)
+                stmt.setInt(2, worldId)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun setProjectState(projectId: Int, state: String) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.update("UPDATE projects SET state = ? WHERE id = ?"),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, state)
+                stmt.setInt(2, projectId)
+            }
+        ).process(Unit)
+    }
+
+    private fun insertProduction(projectId: Int, itemId: String, name: String, rate: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO project_productions (project_id, item_id, name, rate_per_hour) VALUES (?, ?, ?, ?) " +
+                    "ON CONFLICT (project_id, item_id) DO UPDATE SET rate_per_hour = EXCLUDED.rate_per_hour"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+                stmt.setString(3, name)
+                stmt.setInt(4, rate)
+            }
+        ).process(Unit)
+    }
+
+    private fun deleteProduction(projectId: Int, itemId: String) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.delete("DELETE FROM project_productions WHERE project_id = ? AND item_id = ?"),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+            }
+        ).process(Unit)
+    }
+
+    private fun productionIdOf(projectId: Int, itemId: String): Int = runBlocking {
+        val result = DatabaseSteps.query<Unit, Int>(
+            sql = SafeSQL.select("SELECT id FROM project_productions WHERE project_id = ? AND item_id = ?"),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+            },
+            resultMapper = { rs -> rs.next(); rs.getInt("id") }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    /** One demand row, standing in for "this project's plan touches this item". */
+    private fun insertDemand(projectId: Int, item: Item) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO project_demand (project_id, item_id, item_name, quantity, activity_group, node_status) " +
+                    "VALUES (?, ?, ?, 64, 'GATHER', 'RESOLVED')"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, item.id)
+                stmt.setString(3, item.name)
+            }
+        ).process(Unit)
+    }
+
+    private fun stampFingerprint(projectId: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO project_demand_state (project_id, fingerprint, derived_at) VALUES (?, 'fp-test', now()) " +
+                    "ON CONFLICT (project_id) DO UPDATE SET fingerprint = EXCLUDED.fingerprint"
+            ),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, projectId) }
+        ).process(Unit)
+    }
+
+    private fun hasFingerprint(projectId: Int): Boolean = runBlocking {
+        val result = DatabaseSteps.query<Unit, Boolean>(
+            sql = SafeSQL.select("SELECT 1 FROM project_demand_state WHERE project_id = ?"),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, projectId) },
+            resultMapper = { rs -> rs.next() }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+}


### PR DESCRIPTION
`DemandFingerprint` hashes every input a derivation reads, world farm supply included — but it is only ever *checked* where demand is written, on the project page. `GetWorldRoadMapStep` reads the stored rows and derives only for projects that have **none**, so a project with *stale* rows served them indefinitely. Supply being world-scoped, marking one farm DONE made every other project in the world wrong until somebody happened to open each project page.

## Approach: invalidate on change, targeted by item

Option 1 of the three on the issue, chosen on measurement (below). Two refinements over what the issue sketched:

- **Targeted by item, not by world.** A project's plan can only have changed if it touches something the producer produces, and `project_demand` already records which items each plan touched — so the invalidation is a join. Flipping the iron farm invalidates the projects that gather iron and nobody else.
- **Only `project_demand_state` is deleted, never `project_demand`.** A roadmap load that races an invalidation shows the previous numbers rather than an empty graph — the same "one load behind" fill-on-read has always had.

Four doors change supply: the DONE boundary (both state editors — the Field Log badge and the project page's inline one), a production added or removed on an operational farm, recording an existing farm, and deleting a project. The last two read what is about to vanish, so they invalidate *before* the change.

## Measurements

Against the worktree's fork of production — `Forever world`, 29 projects, 2 with gathering rows, one of them the 555-target YAMS storage system:

| Path | Measured |
| --- | --- |
| Warm roadmap load (all fingerprints present) | 0.15 – 0.21 s |
| Cold roadmap load (2 projects to derive) | 1.50 s |
| One 555-target derivation, cold | 0.63 – 0.83 s (median 0.70) |
| Roadmap load right after an invalidation | 1.31 s |
| `PATCH /state` including the invalidation | 0.16 s |
| Any single statement against this Neon branch | ~29.4 ms (round-trip floor) |

Pricing option 3 (revalidate on read) honestly: a fingerprint-only check still has to re-read targets, supply and overrides per project — three round-trips, ~88 ms per project of pure latency here, *before* the derivation that a failed check then triggers at ~0.7 s. A world where 29 projects have plans would spend ~2.5 s of latency and up to ~20 s of planning to render a table. This approach costs one DELETE (~30 ms) on an action taken by hand.

Suggested p95 for a roadmap load: **500 ms**, from the warm measurement (0.15–0.21 s) plus headroom for one uncovered project. That is my number, not a measured requirement — worth confirming.

## Verified end to end

On real data, before and after:

- with `Cobble farm` DONE, project 41 carried **74,557 cobblestone as COLLECT_SUPPLIED**
- flipping it off DONE dropped the fingerprints of exactly the two affected projects in that world, and left the two projects in other worlds alone
- the next roadmap load re-derived that row as **74,557 cobblestone to GATHER** — 74k blocks of real work the roadmap used to hide
- flipping it back to DONE restored `COLLECT_SUPPLIED`; no errors in the app log throughout

`DemandInvalidationIT` covers the cross-project case both directions, the non-DONE transition that must *not* invalidate, production removal, a production change on a non-operational farm, and project deletion. `test.sh --database` green.

## Deliberately out of scope

A project's own targets, collected counts and plan overrides. They change on the page that re-derives them on the spot; invalidating on every progress tick would re-derive so often the materialised table would stop paying for itself. Wants its own measurement.

Closes MCO-404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)