### PR TITLE
MCO-403: print the demand on "Collect from farms" rows

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -691,12 +691,34 @@ internal fun FlowContent.feedsLine(label: FeedsLabel?) {
 }
 
 /**
- * SUPPLIED row: badge + supply label, no counter.
+ * SUPPLIED row: quantity + badge + supply label, no counter.
  *
  * Farm supply and linked-project supply share the group but are not the same promise
  * (MCO-299): a farm keeps producing, a linked project hands over once. The badge says
  * which, and a linked project's name is a link to it — the farm's name is not, because
  * the supply is ambient (any operational producer of the item, resolved at plan time).
+ *
+ * ## The quantity shows; the counter does not (MCO-403)
+ *
+ * This row used to print no number at all, on the reasoning that a supplied item is handled.
+ * That drops the one fact the row exists to deliver: "Cobblestone — from Cobble farm" reads as
+ * solved, and **74,557** cobblestone is what tells you whether that farm is anywhere near
+ * adequate. It is also the number the roadmap prints on the same farm's edge (MCO-316), in the
+ * same `%,d` format — two surfaces disagreeing about whether a quantity is worth showing was
+ * never a decision anyone made.
+ *
+ * A **counter and progress bar** stay off, for both supply kinds:
+ *
+ * - The plan does not schedule this work. A supplied item terminates its chain — nothing
+ *   downstream re-derives as you haul it in — so a "collected" number here would count toward a
+ *   finish line the planner does not have, and would never mark the row complete.
+ * - Farm supply is unbounded in V1 (MCO-287): the farm *solves* the item. Progress against a
+ *   solved item is a number nothing reads and nothing updates.
+ * - Linked-project supply is a one-time handover, where a counter reads more naturally — but the
+ *   handover is the *producer's* completion, which its own project already tracks. A second
+ *   counter here would be a second place to record the same thing, and they would drift.
+ *
+ * If that changes, the two kinds diverge and this branch splits; today they agree, so it does not.
  */
 private fun FlowContent.suppliedActivityRow(
     worldId: Int,
@@ -710,6 +732,9 @@ private fun FlowContent.suppliedActivityRow(
         id = "plan-activity-${activity.item.id.replace(":", "-")}"
         div("resource-row__desktop") {
             div("resource-row__name") { +activity.item.name }
+            // Same position as the counter row's count, so the numbers line up down the page
+            // however a row is sourced, and the same format as the roadmap's edge.
+            span("resource-row__count") { +"%,d".format(activity.quantity) }
             when (supply) {
                 is SupplySource.Farm -> {
                     span("badge badge--accent") { +"Farm" }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSupplySurfacingIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSupplySurfacingIT.kt
@@ -112,6 +112,25 @@ class FarmSupplySurfacingIT : WithUser() {
     }
 
     @Test
+    fun `a supplied row prints the demand but no counter`() = testApplication {
+        setupRoutes()
+        setProjectState(farmId, ProjectState.DONE)
+
+        val body = client.get("/worlds/$worldId/projects/$consumerId") { addAuthCookie(this) }.bodyAsText()
+
+        // MCO-403: the row used to be name + badge + "from Iron Farm", which reads as solved.
+        // The quantity is the fact that says whether the farm is anywhere near adequate, and it
+        // is the same number the roadmap prints on that farm's edge.
+        assertContains(body, """<span class="resource-row__count">32</span>""")
+        assertFalse(
+            body.contains("plan-count-minecraft-iron_ingot"),
+            "supplied work is not scheduled by the plan, so it gets no collected/required counter",
+        )
+
+        setProjectState(farmId, ProjectState.ACTIVE)
+    }
+
+    @Test
     fun `a producing farm is listed as producing, not shelved with finished builds`() = testApplication {
         setupRoutes()
         setProjectState(farmId, ProjectState.DONE)

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/FarmScaleRollUpTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/FarmScaleRollUpTest.kt
@@ -122,7 +122,10 @@ class FarmScaleRollUpTest {
         )
 
         assertContains(html, "1 raw material needs")
-        assertFalse(html.contains("32,967"))
+        // Scoped to the roll-up's own cell. A bare `contains("32,967")` used to stand in for
+        // this and stopped meaning it in MCO-403, which prints the demand on the supplied row
+        // itself — the number is now on the page on purpose, just not in the roll-up.
+        assertFalse(html.contains("""<span class="plan-farm-scale__quantity">32,967</span>"""))
     }
 
     @Test


### PR DESCRIPTION
A supplied row was name + `Farm` + "from Cobble farm", which reads as *solved*. The number it dropped is the one that answers the actual question — **74,557** cobblestone is what tells you whether that farm is anywhere near adequate, and it is the same figure the roadmap already prints on that farm's edge (MCO-316). `activity.quantity` was already on the row; this was a display decision, and the two surfaces disagreeing about it was never a decision anyone made.

Rendered in the same position as the counter row's count, so numbers line up down the page however a row is sourced, and in the same `%,d` format as the roadmap edge.

## The open question, decided and written down

**Farm and linked-project supply both get the quantity and neither gets a counter or progress bar.** The reasoning now lives on `suppliedActivityRow`:

- the plan does not schedule this work — a supplied item terminates its chain, nothing downstream re-derives as you haul it in — so a "collected" number here counts toward a finish line the planner does not have, and the row would never complete
- farm supply is unbounded in V1 (MCO-287): the farm *solves* the item, so progress against it is a number nothing reads and nothing updates
- for a linked project the handover *is* the producer's completion, which its own project already tracks; a second counter here would be a second place recording the same thing, and they would drift

If that stops being true the two kinds diverge and the branch splits. Today they agree, so it does not.

## Verified in the app

Real data — the YAMS storage system in `Forever world`, the same import the issue's table came from:

| Item | Farm | Row now reads |
| --- | --- | --- |
| Cobblestone | Cobble farm | 74,557 |
| Redstone Dust | Witch hut farm | 63,213 |
| Glass | First trading setup | 47,051 |
| Iron Ingot | Earlygame iron farm | 32,967 |

Checked at 1440 and 375; the section is already quantity-sorted, so it now reads as a ranked list. IT asserts both halves — the quantity is rendered, and no `plan-count-*` counter is.

Unrelated observation while looking at 375: the `Farm` badge stretches to full width on mobile. Pre-existing, and MCO-307's territory.

Closes MCO-403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)