### PR TITLE
MCO-405: sort unfinished work above finished on the roadmap

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/RoadmapPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/RoadmapPage.kt
@@ -110,10 +110,20 @@ private fun FlowContent.roadmapTable(roadmap: Roadmap) {
     val upstreamByConsumer = roadmap.edges.groupBy { it.fromNodeId }
     val downstreamByProducer = roadmap.edges.groupBy { it.toNodeId }
 
-    // Depth first — that is the sequence. Blocked projects sink within their layer, and
-    // names break the remaining ties so the order is stable between renders.
+    // Unfinished work first, then depth (MCO-405).
+    //
+    // Depth alone was the sequence, and it is the right sequence — but ascending depth answers
+    // "what came first", and the question at the top of a roadmap is "what do I do next". On the
+    // dev world that put 20-odd DONE farms above the one active build, alphabetically, because a
+    // finished prerequisite genuinely has depth 0.
+    //
+    // Terminal rather than DONE: cancelled and archived projects are not what to do next either,
+    // and they are not blocking anything downstream. Within each band the old rule is untouched —
+    // depth, then blocked sinks, then name for a stable order between renders — so the layer
+    // column still reads as the sequence it always did, and the Layer cell still prints it.
     val rows = roadmap.nodes.sortedWith(
-        compareBy<RoadmapNode> { it.layer }
+        compareBy<RoadmapNode> { it.state.isTerminal }
+            .thenBy { it.layer }
             .thenBy { it.isBlocked }
             .thenBy { it.projectName }
     )

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/WorldRoadmapIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/WorldRoadmapIT.kt
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * `GET /worlds/{worldId}/roadmap` (MCO-288): the derived dependency table, its empty state,
@@ -109,6 +110,30 @@ class WorldRoadmapIT : WithUser() {
         assertContains(farmRow.supplies, "Beacon Build")
         assertContains(farmRow.supplies, STATUS_SUPPLYING)
         assertFalse(farmRow.supplies.contains(STATUS_BLOCKING), "a DONE farm blocks nothing")
+
+        deleteWorld(worldId)
+    }
+
+    @Test
+    fun `finished projects sort below the work that is left`() = testApplication {
+        setupRoutes()
+        val worldId = createWorld("Roadmap Order World")
+        // Named so that every tiebreak the old rule had — depth 0 first, then name — puts the
+        // finished farm on top: it is layer 0 because nothing blocks it, and alphabetically first.
+        val farm = createProject(worldId, "Alpha Farm")
+        val consumer = createProject(worldId, "Zulu Build")
+        createRequirement(consumer, "minecraft:iron_ingot", "Iron Ingot")
+        createDemand(consumer, "minecraft:iron_ingot", "Iron Ingot", 32)
+        createProduction(farm, "minecraft:iron_ingot", "Iron Ingot")
+        runBlocking { UpdateProjectStageStep(farm).process(ProjectStage.COMPLETED) }
+
+        val body = client.get("/worlds/$worldId/roadmap") { addAuthCookie(this) }.bodyAsText()
+
+        // MCO-405: the dev world opened on 20-odd finished farms with the one active build
+        // underneath. Depth is still the sequence — it just no longer leads.
+        val buildAt = body.indexOf("Zulu Build")
+        val farmAt = body.indexOf("Alpha Farm")
+        assertTrue(buildAt in 1..<farmAt, "unfinished work comes first: $buildAt should precede $farmAt")
 
         deleteWorld(worldId)
     }


### PR DESCRIPTION
The table sorted by `layer → isBlocked → name`. Depth is the right *sequence* — but ascending depth answers "what came first", and the question at the top of a roadmap is "what do I do next". On the dev world that opened with 23 finished farms, alphabetically, and the one active build below them, because a finished prerequisite genuinely has depth 0.

State leads now, depth still orders within each band. The Layer column reads exactly as it did, and the blocked-sinks and name tiebreaks (which exist so the order is stable between renders) are untouched.

**Terminal, not DONE**: cancelled and archived projects are not what to do next either, and they block nothing downstream.

The issue notes the table view is getting reworked anyway — this is the ordering rule only, so whatever replaces the markup can carry it over rather than inheriting the old one unexamined.

## Verified in the app

`Forever world` (29 projects, 23 of them Done), clean build. First screen is now:

| Layer | Project | State |
| --- | --- | --- |
| 0 | Redstone Crafting Area | Pending |
| 0 | Sort all items | Pending |
| 0 | Test project | Pending |
| 1 | New slime farm | Pending |
| 2 | Ghast Farm | Active |
| 3 | Storage System YAMS | Active |

then the Done band, still depth-then-name inside it. The IT asserts the rule against the case that used to break it: a finished layer-0 farm named "Alpha Farm" and an unfinished layer-1 build named "Zulu Build", so every old tiebreak favoured the farm.

Unrelated observation: the YAMS row's "Depends on" cell renders ~80 edge lines, making one row taller than the rest of the table put together. That is the table-rework / MCO-307 territory the issue mentions, not this change.

Closes MCO-405.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
