### PR TITLE
MCO-457: import an idea for a farm you already built as supply, not work

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -18,6 +18,7 @@ import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.failure.ValidationFailure
 import app.mcorg.pipeline.project.resources.GetItemsInWorldVersionStep
+import app.mcorg.pipeline.resources.invalidateDemandSuppliedBy
 import app.mcorg.presentation.handler.defaultHandleError
 import app.mcorg.presentation.handler.handlePipeline
 import io.ktor.server.response.respond
@@ -91,6 +92,11 @@ suspend fun ApplicationCall.handleReviewIdeaImport() {
                     placedCounts = materials.placedCounts,
                     warnings = computeImportWarnings(worldId, requirements),
                     unrecordableProductions = idea.unrecordableProductions,
+                    // Only the idea door offers this (MCO-457). A schematic is a file of blocks
+                    // to place, with nothing to say about what the thing produces; an idea
+                    // carries the rates, which is the whole reason to record a farm you already
+                    // built rather than re-typing them into the MCO-298 form.
+                    offerAlreadyBuilt = true,
                     action = Link.Ideas.single(ideaId) + "/import",
                     hiddenFields = buildMap {
                         put("worldId", worldId.toString())
@@ -128,6 +134,10 @@ suspend fun ApplicationCall.handleImportIdea() {
 
     val taskId = (submitted["forTask"] ?: parameters["forTask"])?.toIntOrNull()
 
+    // An unchecked checkbox posts nothing at all, so presence is the signal — the same
+    // reading every other checkbox on this screen gets.
+    val alreadyBuilt = submitted["alreadyBuilt"] != null
+
     val items = GetItemsInWorldVersionStep.process(worldId).getOrNull() ?: emptyList()
 
     handlePipeline(
@@ -147,8 +157,14 @@ suspend fun ApplicationCall.handleImportIdea() {
         ValidateVersionRangeStep.run(worldId to ideaId)
         val ideaData = GetIdeaForImportStep.run(ideaId)
         val validatedIdea = ValidateItemIdsStep(items).run(ideaData)
-        val reviewedIdea = ApplyReviewedRequirementsStep(submitted, items).run(validatedIdea)
-        val projectId = CreateProjectFromIdeaStep(worldId, taskId).run(reviewedIdea)
+        val reviewedIdea = ApplyReviewedRequirementsStep(submitted, items, alreadyBuilt).run(validatedIdea)
+        val projectId = CreateProjectFromIdeaStep(worldId, taskId, alreadyBuilt).run(reviewedIdea)
+        // An already-built import is DONE the moment it exists, so it is world supply now —
+        // every stored plan that gathers what it makes is already wrong (MCO-404). An ordinary
+        // import is ACTIVE and supplies nothing yet, so it has nothing to invalidate.
+        if (alreadyBuilt) {
+            invalidateDemandSuppliedBy(worldId, projectId)
+        }
         CacheManager.onProjectCreated(worldId, projectId)
         bus.publish(IdeaImported(worldId, user.id, Instant.now(), ideaId, reviewedIdea.name))
         projectId
@@ -166,13 +182,24 @@ suspend fun ApplicationCall.handleImportIdea() {
  * row unchecked and a bare direct post are near-identical, so a fallback would silently
  * import everything at exactly the moment the user asked for nothing. Import goes through
  * the review screen; a submission with no rows — or with no list at all — is refused.
+ *
+ * [alreadyBuilt] (MCO-457) drops the list instead of reading it: the farm is standing in the
+ * world already, so there is nothing to gather and the review screen said so. That is not the
+ * fallback this step refuses to have — the fallback would import *more* than was asked for,
+ * where this imports nothing at all, which is the direction it is safe to be wrong in. The
+ * name is still taken from the form, since renaming is orthogonal to whether it is built.
  */
 internal data class ApplyReviewedRequirementsStep(
     val submitted: Parameters,
     val availableItems: List<Item>,
+    val alreadyBuilt: Boolean = false,
 ) : Step<IdeaForImport, AppFailure, IdeaForImport> {
 
     override suspend fun process(input: IdeaForImport): Result<AppFailure, IdeaForImport> {
+        if (alreadyBuilt) {
+            return Result.success(input.copy(name = submittedName(input.name), requirements = emptyMap()))
+        }
+
         val submittedRows = when (
             val decoded = ReviewedMaterialsCodec.decode(submitted[ReviewedMaterialsCodec.FIELD])
         ) {
@@ -208,9 +235,11 @@ internal data class ApplyReviewedRequirementsStep(
             )
         }
 
-        val name = submitted["name"]?.trim()?.takeIf { it.isNotBlank() }?.take(100) ?: input.name
-        return Result.success(input.copy(name = name, requirements = requirements))
+        return Result.success(input.copy(name = submittedName(input.name), requirements = requirements))
     }
+
+    private fun submittedName(fallback: String): String =
+        submitted["name"]?.trim()?.takeIf { it.isNotBlank() }?.take(100) ?: fallback
 }
 
 private object ValidateVersionRangeStep : Step<Pair<Int, Int>, AppFailure, Pair<Int, Int>> {
@@ -412,17 +441,50 @@ data class CreateDependencyInput(
     val dependsOnProjectId: Int
 )
 
-private data class CreateProjectFromIdeaStep(val worldId: Int, val taskId: Int?) : Step<IdeaForImport, AppFailure.DatabaseError, Int> {
+/**
+ * Writes the project the idea becomes.
+ *
+ * [alreadyBuilt] (MCO-457) is the same fact MCO-298's `RecordExistingFarmPipeline` records for a
+ * farm with no idea behind it: the build is standing in the world, so it enters operational
+ * (`COMPLETED` + `DONE`) with its productions and **no gathering list at all**. Under MCO-287's
+ * anchor decision DONE *is* the producing condition, so that is what makes it supply other
+ * projects' plans ([app.mcorg.pipeline.resources.GetWorldFarmSuppliesStep]) instead of merely
+ * promising to via `GetWorldPlannedFarmsStep`. Like that pipeline, it bypasses
+ * [app.mcorg.domain.model.project.ProjectState.allowedTransitions] on purpose — there is no
+ * `PENDING -> DONE` edge because a pre-existing build was never planned here.
+ *
+ * It stays this step rather than routing through `CreateExistingFarmStep`: that one writes no
+ * `project_idea_id` and knows nothing about `forTask`, so reusing it would drop the link back to
+ * the idea — the thing that makes this door worth having over the MCO-298 form.
+ */
+private data class CreateProjectFromIdeaStep(
+    val worldId: Int,
+    val taskId: Int?,
+    val alreadyBuilt: Boolean = false,
+) : Step<IdeaForImport, AppFailure.DatabaseError, Int> {
+
+    // Two literals rather than a bound parameter: the lifecycle is this step's own choice, not
+    // anything the request carries, and SafeSQL takes a constant.
+    private val insertProject = if (alreadyBuilt) {
+        SafeSQL.insert("""
+            INSERT INTO projects (world_id, name, description, type, stage, state, location_x, location_y, location_z, location_dimension, project_idea_id)
+            VALUES (?, ?, ?, ?, 'COMPLETED', 'DONE', NULL, NULL, NULL, NULL, ?)
+            RETURNING id
+        """.trimIndent())
+    } else {
+        SafeSQL.insert("""
+            INSERT INTO projects (world_id, name, description, type, stage, state, location_x, location_y, location_z, location_dimension, project_idea_id)
+            VALUES (?, ?, ?, ?, 'RESOURCE_GATHERING', 'ACTIVE', NULL, NULL, NULL, NULL, ?)
+            RETURNING id
+        """.trimIndent())
+    }
+
     override suspend fun process(input: IdeaForImport): Result<AppFailure.DatabaseError, Int> {
         return DatabaseSteps.transaction { connection ->
             object : Step<IdeaForImport, AppFailure.DatabaseError, Int> {
                 override suspend fun process(input: IdeaForImport): Result<AppFailure.DatabaseError, Int> {
                     val projectIdResult = DatabaseSteps.update<IdeaForImport>(
-                        sql = SafeSQL.insert("""
-                            INSERT INTO projects (world_id, name, description, type, stage, state, location_x, location_y, location_z, location_dimension, project_idea_id)
-                            VALUES (?, ?, ?, ?, 'RESOURCE_GATHERING', 'ACTIVE', NULL, NULL, NULL, NULL, ?)
-                            RETURNING id
-                        """.trimIndent()),
+                        sql = insertProject,
                         parameterSetter = { statement, idea ->
                             statement.setInt(1, worldId)
                             statement.setString(2, idea.name)
@@ -439,23 +501,27 @@ private data class CreateProjectFromIdeaStep(val worldId: Int, val taskId: Int?)
 
                     val projectId = projectIdResult.getOrNull()!!
 
-                    val reqs = DatabaseSteps.batchUpdate<Pair<Item, Int>>(
-                        SafeSQL.insert("""
-                            INSERT INTO resource_gathering
-                                (project_id, name, required, item_id)
-                                values (?, ?, ?, ?)
-                        """.trimIndent()),
-                        parameterSetter = { statement, idea ->
-                            statement.setInt(1, projectId)
-                            statement.setString(2, idea.first.name)
-                            statement.setInt(3, idea.second)
-                            statement.setString(4, idea.first.id)
-                        },
-                        transactionConnection = connection
-                    ).process(input.requirements.toList())
+                    // Empty for an already-built import, and batching zero rows is a wasted
+                    // round trip either way.
+                    if (input.requirements.isNotEmpty()) {
+                        val reqs = DatabaseSteps.batchUpdate<Pair<Item, Int>>(
+                            SafeSQL.insert("""
+                                INSERT INTO resource_gathering
+                                    (project_id, name, required, item_id)
+                                    values (?, ?, ?, ?)
+                            """.trimIndent()),
+                            parameterSetter = { statement, idea ->
+                                statement.setInt(1, projectId)
+                                statement.setString(2, idea.first.name)
+                                statement.setInt(3, idea.second)
+                                statement.setString(4, idea.first.id)
+                            },
+                            transactionConnection = connection
+                        ).process(input.requirements.toList())
 
-                    if (reqs is Result.Failure) {
-                        return Result.Failure(reqs.error)
+                        if (reqs is Result.Failure) {
+                            return Result.Failure(reqs.error)
+                        }
                     }
 
                     val production = DatabaseSteps.batchUpdate<Pair<Item, Int>>(

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -80,6 +80,7 @@ fun importReviewPage(
     regions: List<ResolvedRegion> = emptyList(),
     warnings: ImportWarnings = ImportWarnings(),
     unrecordableProductions: List<String> = emptyList(),
+    offerAlreadyBuilt: Boolean = false,
 ): String = pageShell(
     pageTitle = "Seam — review import",
     user = user,
@@ -139,12 +140,18 @@ fun importReviewPage(
 
                 productionNotice(unrecordableProductions)
 
+                alreadyBuiltControl(offerAlreadyBuilt)
+
                 materialsSection(requirements, emptySet(), placedCounts, regions, warnings)
 
                 div("import-review__actions") {
                     button(classes = "btn btn--primary") {
                         type = ButtonType.submit
-                        +"Create project"
+                        // Both labels render and CSS shows one, as with the region toggle: the
+                        // button is the last thing read before committing, and "Create project"
+                        // above a struck-through list would be the wrong promise.
+                        span("import-review__submit--planned") { +"Create project" }
+                        span("import-review__submit--built") { +"Record as built" }
                     }
                     a(classes = "btn btn--ghost") {
                         href = "/worlds/$worldId/projects"
@@ -155,6 +162,47 @@ fun importReviewPage(
         }
     }
 }
+
+/**
+ * "This is already built in my world" (MCO-457) — the one control on this screen that changes
+ * what the import *is* rather than which rows it carries.
+ *
+ * Ticked, the project is created operational with its productions and no gathering list, so it
+ * supplies the world's other plans immediately (MCO-287's DONE-is-producing rule). That is the
+ * same fact MCO-298's "record an existing farm" records for a farm with no idea behind it; this
+ * is the door that also keeps the idea's rates and the link back to it.
+ *
+ * It sits above the material list rather than beside it because it makes the whole list moot,
+ * and the list is long. MCO-306's argument for reviewing — "not that part" — has no meaning for
+ * a build that already exists, so ticking this strikes the list through wholesale rather than
+ * hiding it: what the design cost is still worth seeing, it is just not work any more.
+ *
+ * No JavaScript. The label, the list and the submit button all key off `:has(:checked)` in CSS,
+ * so the screen reads correctly with scripting off — and the server ignores the material field
+ * entirely when the box is ticked, so nothing depends on the styling having happened.
+ */
+private fun FlowContent.alreadyBuiltControl(offer: Boolean) {
+    if (!offer) return
+
+    div("import-review__already-built") {
+        label("import-review__already-built-label") {
+            htmlFor = ALREADY_BUILT_ID
+            input(type = InputType.checkBox, classes = "import-review__already-built-box") {
+                id = ALREADY_BUILT_ID
+                name = "alreadyBuilt"
+            }
+            span("import-review__already-built-text") {
+                span("import-review__already-built-title") { +"This is already built in my world" }
+                span("import-review__already-built-hint") {
+                    +"Records it as a finished project that produces from now on, with nothing to gather. "
+                    +"Use this for a farm that was standing before you found the design."
+                }
+            }
+        }
+    }
+}
+
+private const val ALREADY_BUILT_ID = "import-review-already-built"
 
 /**
  * One group of rows. [name] is null for a schematic that has nothing worth grouping by, which

--- a/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
@@ -218,6 +218,95 @@
     border-top: 1px solid var(--border);
 }
 
+/* ==========================================================================
+   ALREADY BUILT (MCO-457)
+   The one control here that changes what the import is, not which rows it carries.
+   ========================================================================== */
+
+/* Boxed and tinted, unlike the bare checkboxes in the table. Those pick rows out of a list;
+   this one decides whether the list means anything, so it has to read as a different kind of
+   thing before it is read as a checkbox. */
+.import-review__already-built {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-raised);
+    padding: var(--space-3) var(--space-4);
+}
+
+.import-review__already-built-label {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-3);
+    cursor: pointer;
+}
+
+.import-review__already-built-box {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--accent);
+    cursor: pointer;
+    /* Line up with the cap-height of the title beside it rather than the top of its box. */
+    margin-top: 2px;
+    flex-shrink: 0;
+}
+
+.import-review__already-built-text {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.import-review__already-built-title {
+    font-family: var(--font-ui);
+    font-size: var(--text-ui);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.import-review__already-built-hint {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    max-width: 70ch;
+}
+
+/* Ticked, the control is the active decision on the screen — say so, or a box this
+   consequential looks the same ticked as unticked. */
+.import-review__already-built:has(.import-review__already-built-box:checked) {
+    border-color: var(--accent);
+    background: var(--accent-muted);
+}
+
+/* The list is struck as a whole rather than hidden: what the design cost is still worth
+   seeing, it is just not work any more. Rows keep their own strike-through for exclusions,
+   which is now moot and reads as consistent rather than contradictory. */
+#import-review-form:has(.import-review__already-built-box:checked) .import-review__materials {
+    opacity: 0.45;
+}
+
+#import-review-form:has(.import-review__already-built-box:checked) .import-review__item-name {
+    text-decoration: line-through;
+}
+
+/* Nothing in the list is a decision any more, so nothing in it should invite one. The server
+   ignores the field outright in this case — this only stops the pointer from disagreeing. */
+#import-review-form:has(.import-review__already-built-box:checked) .import-review__materials {
+    pointer-events: none;
+}
+
+/* One of the two submit labels, never both. Default (unticked) shows "Create project". */
+.import-review__submit--built {
+    display: none;
+}
+
+#import-review-form:has(.import-review__already-built-box:checked) .import-review__submit--planned {
+    display: none;
+}
+
+#import-review-form:has(.import-review__already-built-box:checked) .import-review__submit--built {
+    display: inline;
+}
+
 @media (max-width: 768px) {
     /* data-table stacks rows into cards below this width; a scroll box would fight it. */
     .import-review__table-wrap {
@@ -232,6 +321,10 @@
        squeezes the section name to a few characters, which is the one part that has to read. */
     .import-review__region-summary {
         flex-wrap: wrap;
+    }
+
+    .import-review__already-built {
+        padding: var(--space-3);
     }
 
     .import-review__region-meta {

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
@@ -1,6 +1,8 @@
 package app.mcorg.presentation.handler.project
 
 import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.project.ProjectStage
+import app.mcorg.domain.model.project.ProjectState
 import app.mcorg.domain.model.user.Role
 import app.mcorg.config.CacheManager
 import app.mcorg.pipeline.DatabaseSteps
@@ -10,6 +12,8 @@ import app.mcorg.pipeline.project.ReviewedMaterial
 import app.mcorg.pipeline.project.ReviewedMaterialsCodec
 import app.mcorg.pipeline.project.handleImportIdea
 import app.mcorg.pipeline.project.handleReviewIdeaImport
+import app.mcorg.pipeline.resources.GetWorldFarmSuppliesStep
+import app.mcorg.pipeline.resources.WorldFarmSuppliesInput
 import app.mcorg.pipeline.world.CreateWorldInput
 import app.mcorg.pipeline.world.CreateWorldStep
 import app.mcorg.presentation.plugins.AuthPlugin
@@ -37,6 +41,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
@@ -348,6 +353,134 @@ class ImportIdeaReviewIT : WithUser() {
         )
     }
 
+    // ---- already built (MCO-457) ---------------------------------------------------
+
+    @Test
+    fun `the review screen offers to record the idea as already built`() = testApplication {
+        setupRoutes()
+
+        val response = client.get("/ideas/$ideaId/import/review?worldId=$worldId") { addAuthCookie(this) }
+
+        val body = response.bodyAsText()
+        assertContains(body, "This is already built in my world")
+        assertContains(body, "name=\"alreadyBuilt\"")
+        // Both submit labels ship; CSS picks one, so the screen still says the right thing
+        // with scripting off.
+        assertContains(body, "Record as built")
+        assertContains(body, "Create project")
+    }
+
+    @Test
+    fun `an already-built import lands operational, producing, with nothing to gather`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        val response = client.post("/ideas/$ideaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "worldId=$worldId&name=Standing Iron Farm&alreadyBuilt=on&" + materials(
+                    "minecraft:iron_ingot" to 64,
+                    "minecraft:oak_planks" to 32,
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val projectId = response.headers["Location"]!!.substringAfterLast("/").toInt()
+
+        // MCO-298's lifecycle, reached through the idea door. DONE is the producing condition
+        // (MCO-287), so this is what makes it supply rather than promise.
+        assertEquals(
+            ProjectStage.COMPLETED.name to ProjectState.DONE.name,
+            readLifecycle(projectId),
+        )
+        assertEquals(
+            listOf("minecraft:iron_ingot" to 620),
+            readProductions(projectId),
+            "the idea's rates are the reason to come through this door rather than the MCO-298 form",
+        )
+        assertEquals(
+            emptyList(),
+            readRequirements(projectId),
+            "no invented gathering work for a build that already exists",
+        )
+        assertEquals(ideaId, getProjectIdeaId(projectId), "and the link back to the idea survives")
+    }
+
+    @Test
+    fun `an already-built import supplies the world immediately`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        val response = client.post("/ideas/$multiModeIdeaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "worldId=$worldId&name=Standing Fortress Farm&alreadyBuilt=on&" +
+                    materials("minecraft:oak_planks" to 10)
+            )
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+
+        // The whole of MCO-457: before it, this import arrived ACTIVE and showed up in
+        // GetWorldPlannedFarmsStep as supply that "will come" — for a farm already standing.
+        val supplies = runBlocking {
+            GetWorldFarmSuppliesStep.process(WorldFarmSuppliesInput(worldId, excludeProjectId = -1))
+        }
+        assertIs<Result.Success<*>>(supplies)
+        val supplied = (supplies as Result.Success).value.map { it.itemId to it.projectName }
+        assertTrue(
+            supplied.contains("minecraft:blaze_rod" to "Standing Fortress Farm"),
+            "got $supplied",
+        )
+    }
+
+    @Test
+    fun `an already-built import ignores the material list instead of refusing an empty one`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        // Striking every row is refused for an ordinary import — it would import everything at
+        // the moment the user asked for nothing. Here the list is moot either way, so the
+        // guard must not fire: the same post with the box ticked has to succeed.
+        val response = client.post("/ideas/$ideaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "worldId=$worldId&name=Struck But Built&alreadyBuilt=on&" +
+                    materials("!minecraft:iron_ingot" to 64)
+            )
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val projectId = response.headers["Location"]!!.substringAfterLast("/").toInt()
+        assertEquals(emptyList(), readRequirements(projectId))
+    }
+
+    @Test
+    fun `an ordinary import still lands as work to do`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        val response = client.post("/ideas/$ideaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("worldId=$worldId&name=Planned Iron Farm&" + materials("minecraft:iron_ingot" to 64))
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val projectId = response.headers["Location"]!!.substringAfterLast("/").toInt()
+
+        assertEquals(
+            ProjectStage.RESOURCE_GATHERING.name to ProjectState.ACTIVE.name,
+            readLifecycle(projectId),
+            "an unticked box must leave the common case exactly as it was",
+        )
+        assertEquals(listOf("minecraft:iron_ingot" to 64), readRequirements(projectId))
+    }
+
     @Test
     fun `a submission with no rows is refused rather than importing the whole idea`() = testApplication {
         setupRoutes()
@@ -590,6 +723,15 @@ class ImportIdeaReviewIT : WithUser() {
             sql = SafeSQL.select("SELECT name FROM projects WHERE id = ?"),
             parameterSetter = { stmt, id -> stmt.setInt(1, id) },
             resultMapper = { rs -> rs.next(); rs.getString("name") }
+        ).process(projectId)
+        (result as Result.Success).value
+    }
+
+    private fun readLifecycle(projectId: Int): Pair<String, String> = runBlocking {
+        val result = DatabaseSteps.query<Int, Pair<String, String>>(
+            sql = SafeSQL.select("SELECT stage, state FROM projects WHERE id = ?"),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) },
+            resultMapper = { rs -> rs.next(); rs.getString("stage") to rs.getString("state") }
         ).process(projectId)
         (result as Result.Success).value
     }


### PR DESCRIPTION
Closes MCO-457.

`CreateProjectFromIdeaStep` hardcoded `RESOURCE_GATHERING`/`ACTIVE`, so importing an idea for a farm **already standing in the world** produced a full gathering list for a build that exists, and supply `GetWorldFarmSuppliesStep` would not count until someone opened the project and hand-marked it DONE.

## What changed

The review screen now carries one control — **"This is already built in my world"**. Ticked, the project is created `COMPLETED`/`DONE` with the idea's productions and **no `resource_gathering` rows at all**.

That is the same fact MCO-298's `RecordExistingFarmPipeline` records for a farm with no idea behind it. It stays in `CreateProjectFromIdeaStep` rather than routing through `CreateExistingFarmStep`, which writes no `project_idea_id` and knows nothing about `forTask` — the link back to the idea is the reason to use this door over the MCO-298 form.

Because such an import is world supply the moment it exists, it invalidates stored project demand the way the MCO-298 door does (MCO-404).

## Decisions on the issue's open questions

- **Skip the requirements, don't keep them struck-but-recorded.** There is no representation for "gathered before Seam existed" that isn't a fiction, and AC 3 asks for no invented gathering work.
- **The list is dropped, not read.** So the "keep at least one material" guard cannot fire on a list that is moot. This is not the fallback `ApplyReviewedRequirementsStep` refuses to have — that one would import *more* than was asked for; this imports nothing.
- **Offered for every idea category, not just FARM.** The semantics are the same for any build that already exists, and productions only exist on farms anyway.

## Notes

- **No JavaScript.** The struck-through list and the two submit labels key off `:has(:checked)`, already the pattern for excluded rows on this screen. `import-review.js` selects by `.import-review__include` / `.import-review__region-include`, so the new checkbox cannot reach the materials field.
- Only the idea door offers the control — a schematic says nothing about what the thing produces.

## Tests

Five new ITs in `ImportIdeaReviewIT` — the control renders; an already-built import lands `COMPLETED`/`DONE` with productions, no requirements and the idea link intact; it supplies the world immediately via `GetWorldFarmSuppliesStep`; it ignores a fully-struck list instead of refusing it; and an ordinary import still lands `RESOURCE_GATHERING`/`ACTIVE`.

`test.sh --database`: 465 tests, 0 failures, 5 skipped (the known MCO-301 disabled set).

`preview` label applied — the CSS-only toggle is the half tests don't cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
