### PR TITLE
MCO-294: suggest designs from the bank that cover the plan's demand

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
@@ -78,7 +78,7 @@ suspend fun ApplicationCall.handleGetDetailContent() {
 
     // Same reason the threshold is here (MCO-401): switching lens must not look like the
     // suggestions disappeared.
-    val farmSuggestions = farmSuggestionsFor(plan, farmScaleThreshold, getUser().id)
+    val farmSuggestions = farmSuggestionsFor(plan, farmScaleThreshold, getUser().id, project.importedFromIdea?.first)
 
     // The roll-up's threshold is a link to world settings for admins only, so the fragment
     // needs the same role answer the full page computes.

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
@@ -7,6 +7,7 @@ import app.mcorg.pipeline.project.commonsteps.GetProjectByIdStep
 import app.mcorg.pipeline.resources.GatheringPlanInput
 import app.mcorg.domain.model.world.World
 import app.mcorg.pipeline.resources.GetFarmScaleThresholdStep
+import app.mcorg.pipeline.resources.farmSuggestionsFor
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
 import app.mcorg.pipeline.resources.pendingFarmSuppliesFor
 import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
@@ -75,13 +76,18 @@ suspend fun ApplicationCall.handleGetDetailContent() {
     val farmScaleThreshold = GetFarmScaleThresholdStep.process(worldId).getOrNull()
         ?: World.DEFAULT_FARM_SCALE_THRESHOLD
 
+    // Same reason the threshold is here (MCO-401): switching lens must not look like the
+    // suggestions disappeared.
+    val farmSuggestions = farmSuggestionsFor(plan, farmScaleThreshold, getUser().id)
+
     // The roll-up's threshold is a link to world settings for admins only, so the fragment
     // needs the same role answer the full page computes.
     val isAdmin = ValidateWorldMemberRole<Unit>(getUser(), Role.ADMIN, worldId).process(Unit) is Result.Success
 
     respondHtml(
         gatheringPlannerFragment(
-            project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold, isAdmin,
+            project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold,
+            farmSuggestions, isAdmin,
         )
     )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -105,7 +105,7 @@ suspend fun ApplicationCall.handleGetProject() {
     // Designs in the bank that answer this plan's demand (MCO-294). Scoped to the viewer,
     // because the bank is public ideas plus their own — a shared computation would show one
     // user another's private designs.
-    val farmSuggestions = farmSuggestionsFor(plan, farmScaleThreshold, user.id)
+    val farmSuggestions = farmSuggestionsFor(plan, farmScaleThreshold, user.id, project.importedFromIdea?.first)
 
     // ?drill=<item> deep-links into a target's chain so reload/share lands on the drill,
     // not the plan. Resolves only when the plan derives and the item is an actual target;

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -11,6 +11,7 @@ import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.pipeline.resources.GatheringPlanInput
 import app.mcorg.domain.model.world.World
 import app.mcorg.pipeline.resources.GetFarmScaleThresholdStep
+import app.mcorg.pipeline.resources.farmSuggestionsFor
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
 import app.mcorg.pipeline.resources.pendingFarmSuppliesFor
 import app.mcorg.pipeline.resources.GetPlanOverridesStep
@@ -101,6 +102,11 @@ suspend fun ApplicationCall.handleGetProject() {
     val farmScaleThreshold = GetFarmScaleThresholdStep.process(worldId).getOrNull()
         ?: World.DEFAULT_FARM_SCALE_THRESHOLD
 
+    // Designs in the bank that answer this plan's demand (MCO-294). Scoped to the viewer,
+    // because the bank is public ideas plus their own — a shared computation would show one
+    // user another's private designs.
+    val farmSuggestions = farmSuggestionsFor(plan, farmScaleThreshold, user.id)
+
     // ?drill=<item> deep-links into a target's chain so reload/share lands on the drill,
     // not the plan. Resolves only when the plan derives and the item is an actual target;
     // otherwise falls through to the normal lens render.
@@ -123,6 +129,7 @@ suspend fun ApplicationCall.handleGetProject() {
             drillNodeIngredients = drillNodeIngredients, drillHighlightItemId = drillItemId,
             drillOverrides = drillOverrides, drillGraph = drillGraph,
             farmScaleThreshold = farmScaleThreshold,
+            farmSuggestions = farmSuggestions,
         )
     )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/FarmSuggestion.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/FarmSuggestion.kt
@@ -1,0 +1,194 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.engine.plan.PlanNodeStatus
+
+/**
+ * An idea in the bank that produces something this plan demands (MCO-294).
+ *
+ * [produces] is what the design makes and the plan wants; [alsoRemoves] is the work that
+ * disappears underneath it — see [FarmSuggestions] for why the two are separate.
+ */
+data class FarmSuggestion(
+    val ideaId: Int,
+    val ideaName: String,
+    val produces: List<CoveredDemand>,
+    val alsoRemoves: List<CoveredDemand>,
+) {
+    /** Total demand this design takes off the plan — the ranking key, and the honest headline. */
+    val unitsRemoved: Long = produces.sumOf { it.quantity } + alsoRemoves.sumOf { it.quantity }
+
+    /** Every item this suggestion accounts for, for marking the roll-up. */
+    val itemIds: Set<String> = (produces + alsoRemoves).mapTo(mutableSetOf()) { it.itemId }
+}
+
+/**
+ * One demand row a suggestion accounts for.
+ *
+ * [ratePerHour] is null for a row in [FarmSuggestion.alsoRemoves] (the design does not make
+ * this, it makes what this feeds) and for a produced item whose rate the author never
+ * measured — `idea_production_rates.rate_per_hour` is nullable exactly for that (V2_57_0).
+ */
+data class CoveredDemand(
+    val itemId: String,
+    val itemName: String,
+    val quantity: Long,
+    val ratePerHour: Int? = null,
+) {
+    /** Hours of running to cover this demand, or null when the rate is unknown or zero. */
+    val hoursToCover: Double? =
+        ratePerHour?.takeIf { it > 0 }?.let { quantity.toDouble() / it }
+}
+
+/** An idea that produces at least one item, as read from the bank. */
+data class IdeaProducer(
+    val ideaId: Int,
+    val ideaName: String,
+    /** itemId -> best rate across the idea's modes, null when never measured. */
+    val rates: Map<String, Int?>,
+)
+
+/**
+ * Matches plan demand against the idea bank (MCO-294).
+ *
+ * ## Why this does not read the farm-scale roll-up
+ *
+ * [FarmScaleDemands] classifies **RAW_GATHER leaves only**, which is right for "what quantity
+ * is worth a farm" and wrong for "which design covers it". Measured on the dogfood world:
+ * the roll-up's 4th-largest line is *Deepslate Iron Ore, 33,049* — because the plan mines ore
+ * — while the bank's iron farm produces `minecraft:iron_ingot`, and the plan carries
+ * *Iron Ingot, 33,049, RESOLVED/SMELT* one edge above it. Keyed on the roll-up, the single
+ * most valuable suggestion in the world matches nothing at all.
+ *
+ * So matching reads every node whose demand a design could answer, not just the leaves.
+ * [SUPPLIED][PlanNodeStatus.SUPPLIED] is excluded — an operational farm already covers it, and
+ * suggesting a second one is the failure MCO-401 was careful to avoid — and
+ * [OPEN_TAG][PlanNodeStatus.OPEN_TAG] is excluded because a tag is not an item and has no id to
+ * match on. [BLOCKED][PlanNodeStatus.BLOCKED] stays in: a farm for something the graph has no
+ * source for is the *most* useful suggestion this can make.
+ *
+ * ## Why the unit is the idea, not the item
+ *
+ * A farm produces several things. The bank's stick producer **is** the Witch Hut Farm, which is
+ * already the answer for 63,273 Redstone Dust; per-item lines would list that one design three
+ * times over — for redstone, for sticks, and for glass bottles — and invite someone to build a
+ * witch hut "for sticks". One line per design, naming everything it covers, ranked by the work
+ * it removes.
+ *
+ * A design **qualifies** only if something it directly produces is itself farm-scale. Without
+ * that, an idea making 216 glass bottles would be suggested against a threshold it never met.
+ *
+ * ## Coverage is conservative on purpose
+ *
+ * Building the iron farm does not only cover the ingots; the 33,049 ore below them stops being
+ * work too. That knock-on is real and worth showing, but only where it is certain: a node counts
+ * as removed when **every** consumer of it is removed. Oak logs feed sticks *and* planks *and*
+ * chests, so a design covering only the sticks leaves the log demand alone — apportioning it
+ * would need per-edge attribution this deliberately does not attempt. Under-claiming is the
+ * safe direction: the suggestion is an argument for building something, and an inflated number
+ * is an argument that falls apart the first time someone checks it.
+ */
+object FarmSuggestions {
+
+    /**
+     * Designs worth building for this plan, most work removed first.
+     *
+     * [producers] is the bank, already narrowed to what the viewer may see — this function is
+     * pure and does no filtering of its own beyond the plan.
+     */
+    fun of(plan: GatheringPlan, threshold: Int, producers: List<IdeaProducer>): List<FarmSuggestion> {
+        if (producers.isEmpty()) return emptyList()
+
+        val demand = matchableDemand(plan)
+        if (demand.isEmpty()) return emptyList()
+
+        return producers
+            .mapNotNull { producer -> producer.suggestionFor(plan, demand, threshold) }
+            .sortedWith(compareByDescending<FarmSuggestion> { it.unitsRemoved }.thenBy { it.ideaName })
+    }
+
+    /** itemId -> the demand a design could answer. */
+    private fun matchableDemand(plan: GatheringPlan): Map<String, DemandRow> =
+        plan.activityList
+            .filter { it.status != PlanNodeStatus.SUPPLIED && it.status != PlanNodeStatus.OPEN_TAG }
+            .associate { it.item.id to DemandRow(it.item.id, it.item.name, it.quantity) }
+
+    private data class DemandRow(val itemId: String, val itemName: String, val quantity: Long)
+
+    private fun IdeaProducer.suggestionFor(
+        plan: GatheringPlan,
+        demand: Map<String, DemandRow>,
+        threshold: Int,
+    ): FarmSuggestion? {
+        val direct = rates.keys.filter { it in demand }.toSet()
+        if (direct.none { demand.getValue(it).quantity >= threshold }) return null
+
+        val removed = coveredBy(plan, direct)
+
+        return FarmSuggestion(
+            ideaId = ideaId,
+            ideaName = ideaName,
+            produces = direct
+                .map { demand.getValue(it).toCovered(rates[it]) }
+                .sortedByDescending { it.quantity },
+            alsoRemoves = removed
+                .filter { it !in direct }
+                .mapNotNull { demand[it]?.toCovered(null) }
+                .sortedByDescending { it.quantity },
+        )
+    }
+
+    private fun DemandRow.toCovered(rate: Int?) = CoveredDemand(itemId, itemName, quantity, rate)
+
+    /**
+     * [direct] plus every node whose consumers are all covered.
+     *
+     * One reverse-topological pass. `activityList` puts ingredients before the activities that
+     * consume them, so walking it backwards decides every consumer of a node before the node
+     * itself — the same traversal order [GatheringPlan.feeders] uses, for the same reason.
+     */
+    private fun coveredBy(plan: GatheringPlan, direct: Set<String>): Set<String> {
+        val consumers = HashMap<String, MutableList<String>>()
+        for ((id, node) in plan.nodes) {
+            for (req in node.requires) {
+                if (req.itemId != id && req.itemId in plan.nodes) {
+                    consumers.getOrPut(req.itemId) { mutableListOf() }.add(id)
+                }
+            }
+        }
+
+        val covered = HashSet(direct)
+        for (activity in plan.activityList.asReversed()) {
+            val id = activity.item.id
+            if (id in covered) continue
+            // No consumers means nothing above it disappeared — a target in its own right, or a
+            // node the plan keeps for another reason. Not covered by implication.
+            val itsConsumers = consumers[id] ?: continue
+            if (itsConsumers.isNotEmpty() && itsConsumers.all { it in covered }) covered.add(id)
+        }
+        return covered
+    }
+}
+
+/**
+ * The designs worth building for [plan], or an empty list if there is nothing to suggest.
+ *
+ * Decorates a plan that has already rendered, so every failure degrades to "no suggestions"
+ * rather than failing the page — same posture as [GetFarmScaleThresholdStep] and
+ * [pendingFarmSuppliesFor]. A missing suggestion is a worse plan; a missing plan is no page.
+ */
+suspend fun farmSuggestionsFor(plan: GatheringPlan?, threshold: Int, viewerId: Int): List<FarmSuggestion> {
+    if (plan == null) return emptyList()
+
+    val demandedIds = plan.activityList
+        .filter { it.status != PlanNodeStatus.SUPPLIED && it.status != PlanNodeStatus.OPEN_TAG }
+        .map { it.item.id }
+    if (demandedIds.isEmpty()) return emptyList()
+
+    val producers = GetIdeaProducersStep
+        .process(IdeaProducerInput(itemIds = demandedIds, viewerId = viewerId))
+        .getOrNull()
+        ?: return emptyList()
+
+    return FarmSuggestions.of(plan, threshold, producers)
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/FarmSuggestion.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/FarmSuggestion.kt
@@ -177,7 +177,21 @@ object FarmSuggestions {
  * rather than failing the page — same posture as [GetFarmScaleThresholdStep] and
  * [pendingFarmSuppliesFor]. A missing suggestion is a worse plan; a missing plan is no page.
  */
-suspend fun farmSuggestionsFor(plan: GatheringPlan?, threshold: Int, viewerId: Int): List<FarmSuggestion> {
+suspend fun farmSuggestionsFor(
+    plan: GatheringPlan?,
+    threshold: Int,
+    viewerId: Int,
+    /**
+     * The design this project was imported from, if any — never suggested back to it.
+     *
+     * A farm costs materials to build, and a cobblestone farm costs cobblestone. Without this
+     * the farm's own plan matches its own design and offers to import the thing you are
+     * standing in. The narrow rule is deliberate: a *different* design producing the same item
+     * is still a fair suggestion (a bigger farm is a real answer to demand a small one cannot
+     * meet), so only the project's own source idea is excluded.
+     */
+    excludeIdeaId: Int? = null,
+): List<FarmSuggestion> {
     if (plan == null) return emptyList()
 
     val demandedIds = plan.activityList
@@ -190,5 +204,5 @@ suspend fun farmSuggestionsFor(plan: GatheringPlan?, threshold: Int, viewerId: I
         .getOrNull()
         ?: return emptyList()
 
-    return FarmSuggestions.of(plan, threshold, producers)
+    return FarmSuggestions.of(plan, threshold, producers.filter { it.ideaId != excludeIdeaId })
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GetIdeaProducersStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/GetIdeaProducersStep.kt
@@ -1,0 +1,97 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.idea.IdeaVisibility
+import app.mcorg.domain.pipeline.Step
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+
+/**
+ * What to look up: the items a plan demands, and who is asking.
+ *
+ * The viewer is not optional. Visibility is the difference between a bank of one public design
+ * and a bank of eleven (measured 2026-08-23: every idea carrying production data is `PRIVATE`,
+ * and the only `PUBLIC` one declares no production), so a lookup that forgot the viewer would
+ * quietly return nothing and read as "no design matches".
+ */
+data class IdeaProducerInput(
+    val itemIds: Collection<String>,
+    val viewerId: Int,
+)
+
+/**
+ * The designs in the bank that produce any of [IdeaProducerInput.itemIds] (MCO-294).
+ *
+ * Uses `idea_production_rates_item_id_idx`, which V2_57_0 added with the comment "MCO-294's
+ * lookup direction: which ideas produce this item, and how fast at best?" — this is that query.
+ *
+ * ## Visibility
+ *
+ * Public designs plus the viewer's own, which is
+ * [app.mcorg.pipeline.idea.IdeaSqlBuilder]'s rule for the hub (MCO-291) and must stay the same
+ * rule: a suggestion the viewer cannot then open would be worse than no suggestion. `is_active`
+ * goes with it — an idea being edited is not in the hub and should not be suggested either.
+ *
+ * ## MAX over modes
+ *
+ * An idea can describe several ways of running the same farm (V2_57_0), so a rate is picked per
+ * item as the best any mode achieves. That mixes modes in principle — the fastest mode for bones
+ * need not be the fastest for blaze rods — and does not in practice: every idea in the bank has
+ * exactly one mode. MCO-413 is where the project records which mode it is actually run in; until
+ * then, "how fast can this design make this" is the only question that can honestly be answered.
+ * `MAX` skips NULLs, so an item returns null only when no mode ever measured it.
+ */
+object GetIdeaProducersStep : Step<IdeaProducerInput, AppFailure, List<IdeaProducer>> {
+
+    private val query = DatabaseSteps.query<IdeaProducerInput, List<Row>>(
+        sql = SafeSQL.select(
+            """
+            SELECT m.idea_id, i.name AS idea_name, r.item_id, MAX(r.rate_per_hour) AS rate_per_hour
+            FROM idea_production_rates r
+            JOIN idea_production_modes m ON m.id = r.mode_id
+            JOIN ideas i ON i.id = m.idea_id
+            WHERE r.item_id = ANY(?)
+              AND i.is_active = TRUE
+              AND (i.visibility = ? OR i.created_by = ?)
+            GROUP BY m.idea_id, i.name, r.item_id
+            """.trimIndent()
+        ),
+        parameterSetter = { ps, input ->
+            ps.setArray(1, ps.connection.createArrayOf("text", input.itemIds.toTypedArray()))
+            ps.setString(2, IdeaVisibility.PUBLIC.name)
+            ps.setInt(3, input.viewerId)
+        },
+        resultMapper = { rs ->
+            buildList {
+                while (rs.next()) {
+                    val rate = rs.getInt("rate_per_hour").takeUnless { rs.wasNull() }
+                    add(Row(rs.getInt("idea_id"), rs.getString("idea_name"), rs.getString("item_id"), rate))
+                }
+            }
+        }
+    )
+
+    override suspend fun process(input: IdeaProducerInput): Result<AppFailure, List<IdeaProducer>> {
+        // ANY('{}') matches nothing, but a plan with no demand is the common empty-project case
+        // and does not deserve a round trip.
+        if (input.itemIds.isEmpty()) return Result.success(emptyList())
+
+        return when (val r = query.process(input)) {
+            is Result.Failure -> r
+            is Result.Success -> Result.success(
+                r.value
+                    .groupBy { it.ideaId to it.ideaName }
+                    .map { (idea, rows) ->
+                        IdeaProducer(
+                            ideaId = idea.first,
+                            ideaName = idea.second,
+                            rates = rows.associate { it.itemId to it.ratePerHour },
+                        )
+                    }
+            )
+        }
+    }
+
+    private data class Row(val ideaId: Int, val ideaName: String, val itemId: String, val ratePerHour: Int?)
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -367,7 +367,7 @@ private suspend fun ApplicationCall.respondListRerender(worldId: Int, projectId:
     val farmScaleThreshold = GetFarmScaleThresholdStep.process(worldId).getOrNull()
         ?: World.DEFAULT_FARM_SCALE_THRESHOLD
     val user = getUser()
-    val farmSuggestions = farmSuggestionsFor(plan, farmScaleThreshold, user.id)
+    val farmSuggestions = farmSuggestionsFor(plan, farmScaleThreshold, user.id, project.importedFromIdea?.first)
     val isAdmin = ValidateWorldMemberRole<Unit>(user, Role.ADMIN, worldId).process(Unit) is Result.Success
 
     respondHtml(

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -23,6 +23,10 @@ import app.mcorg.presentation.templated.dsl.pages.gatheringPlannerFragment
 import app.mcorg.presentation.templated.dsl.pages.nodePickerFragment
 import app.mcorg.presentation.templated.dsl.pages.pickerNotFoundFragment
 import app.mcorg.presentation.utils.getProjectId
+import app.mcorg.domain.model.user.Role
+import app.mcorg.domain.model.world.World
+import app.mcorg.pipeline.world.ValidateWorldMemberRole
+import app.mcorg.presentation.utils.getUser
 import app.mcorg.presentation.utils.getWorldId
 import app.mcorg.presentation.utils.respondBadRequest
 import app.mcorg.presentation.utils.respondHtml
@@ -355,7 +359,23 @@ private suspend fun ApplicationCall.respondListRerender(worldId: Int, projectId:
     val plan = deriveOrNull(projectId, worldId)
     val progressMap = GetProgressForProjectStep.process(projectId).getOrNull() ?: emptyMap()
     val pendingFarms = pendingFarmSuppliesFor(worldId, projectId, plan)
-    respondHtml(gatheringPlannerFragment(project, resources, tasks, plan, "list", progressMap, pendingFarms))
+
+    // The same three the full page computes. This re-render is the one place they change for a
+    // reason other than a page load: resolving an open tag turns a tag with no id anything can
+    // produce into real demand a design may well cover (MCO-294), and it was the moment the
+    // roll-up would otherwise silently fall back to the default threshold (MCO-401).
+    val farmScaleThreshold = GetFarmScaleThresholdStep.process(worldId).getOrNull()
+        ?: World.DEFAULT_FARM_SCALE_THRESHOLD
+    val user = getUser()
+    val farmSuggestions = farmSuggestionsFor(plan, farmScaleThreshold, user.id)
+    val isAdmin = ValidateWorldMemberRole<Unit>(user, Role.ADMIN, worldId).process(Unit) is Result.Success
+
+    respondHtml(
+        gatheringPlannerFragment(
+            project, resources, tasks, plan, "list", progressMap, pendingFarms, farmScaleThreshold,
+            farmSuggestions, isAdmin,
+        )
+    )
 }
 
 /**

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -15,6 +15,7 @@ import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.engine.plan.SupplySource
 import app.mcorg.pipeline.resources.FarmScaleDemand
 import app.mcorg.pipeline.resources.FarmScaleDemands
+import app.mcorg.pipeline.resources.FarmSuggestion
 import app.mcorg.presentation.hxDelete
 import app.mcorg.presentation.hxDeleteWithConfirm
 import app.mcorg.presentation.hxGet
@@ -72,6 +73,7 @@ fun projectDetailPage(
     drillOverrides: PlanOverrides = PlanOverrides.NONE,
     drillGraph: ItemSourceGraph? = null,
     farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
+    farmSuggestions: List<FarmSuggestion> = emptyList(),
 ): String = pageShell(
     pageTitle = "Seam — ${project.name}",
     user = user,
@@ -140,7 +142,7 @@ fun projectDetailPage(
                     // ?drill=<item> deep-links straight into a target's chain (reload/share-safe).
                     drillChainContent(project, drillTarget, drillCandidateCounts, drillNodeIngredients, overrides = drillOverrides, graph = drillGraph, highlightItemId = drillHighlightItemId)
                 } else {
-                    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold, isWorldAdmin)
+                    gatheringPlannerContent(project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold, farmSuggestions, isWorldAdmin)
                 }
             }
         }
@@ -244,6 +246,7 @@ fun FlowContent.gatheringPlannerContent(
     progressMap: Map<String, Int> = emptyMap(),
     pendingFarms: List<PendingFarmSupply> = emptyList(),
     farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
+    farmSuggestions: List<FarmSuggestion> = emptyList(),
     isWorldAdmin: Boolean = false,
 ) {
     val activeLens = when (lens) {
@@ -273,7 +276,7 @@ fun FlowContent.gatheringPlannerContent(
     // Active lens body
     when (activeLens) {
         "next", "sessions" -> lensComingSoon(project.worldId, project.id, activeLens)
-        else -> listLensContent(project, resources, tasks, plan, progressMap, pendingFarms, farmScaleThreshold, isWorldAdmin)
+        else -> listLensContent(project, resources, tasks, plan, progressMap, pendingFarms, farmScaleThreshold, farmSuggestions, isWorldAdmin)
     }
 }
 
@@ -304,6 +307,7 @@ private fun FlowContent.listLensContent(
     progressMap: Map<String, Int> = emptyMap(),
     pendingFarms: List<PendingFarmSupply> = emptyList(),
     farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
+    farmSuggestions: List<FarmSuggestion> = emptyList(),
     isWorldAdmin: Boolean = false,
 ) {
     // Resolution toggle (client-side; default "targets" applied by plan-view.js).
@@ -408,7 +412,7 @@ private fun FlowContent.listLensContent(
         id = "list-breakdown-view"
         attributes["data-resolution-view"] = "breakdown"
 
-        gatheringPlanSections(project, plan, progressMap, pendingFarms, farmScaleThreshold, isWorldAdmin)
+        gatheringPlanSections(project, plan, progressMap, pendingFarms, farmScaleThreshold, farmSuggestions, isWorldAdmin)
     }
 
     // Tasks section (collapsed)
@@ -484,6 +488,7 @@ fun FlowContent.gatheringPlanSections(
     progressMap: Map<String, Int> = emptyMap(),
     pendingFarms: List<PendingFarmSupply> = emptyList(),
     farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
+    farmSuggestions: List<FarmSuggestion> = emptyList(),
     isWorldAdmin: Boolean = false,
 ) {
     if (plan == null) {
@@ -502,13 +507,24 @@ fun FlowContent.gatheringPlanSections(
     val feedsLabels = buildFeedsLabels(plan)
     val farmScale = FarmScaleDemands.of(plan, farmScaleThreshold)
     val farmScaleIds = farmScale.mapTo(mutableSetOf()) { it.itemId }
+    // itemId -> the design that accounts for it (MCO-294). First suggestion wins: they are
+    // ordered by work removed, so the row is attributed to the biggest reason to build it.
+    val coveredByDesign: Map<String, String> = buildMap {
+        farmSuggestions.forEach { suggestion ->
+            suggestion.itemIds.forEach { itemId -> putIfAbsent(itemId, suggestion.ideaName) }
+        }
+    }
 
     div {
         id = "gathering-plan-sections"
 
         // Above the work sections on purpose: this is not a step in the plan, it is the answer
         // to "what should I build first", and it is what turns one import into a roadmap.
-        farmScaleRollUp(farmScale, farmScaleThreshold, project.worldId, isWorldAdmin)
+        farmScaleRollUp(farmScale, farmScaleThreshold, project.worldId, isWorldAdmin, coveredByDesign)
+
+        // Directly under the roll-up, because it is the answer to it (MCO-294). A design listed
+        // here is why some of the lines above are already spoken for.
+        farmSuggestionList(farmSuggestions, project.worldId)
 
         groupOrder.forEach { group ->
             val activities = byGroup[group] ?: return@forEach
@@ -550,6 +566,80 @@ fun FlowContent.gatheringPlanSections(
 }
 
 /**
+ * Designs in the bank that answer this plan's demand (MCO-294) — the step that turns
+ * "7 materials are farm-scale" into "and here is what to build for them".
+ *
+ * **One line per design, not per item.** A farm makes several things: the bank's stick producer
+ * is the Witch Hut Farm, already the answer for 63,273 redstone. Listing per item would name
+ * that one design three times and invite building a witch hut "for sticks". See
+ * [app.mcorg.pipeline.resources.FarmSuggestions] for the matching rules and for why coverage
+ * deliberately under-claims.
+ *
+ * The hours figure is the one number that changes a decision. Most designs in a real bank cover
+ * their demand in minutes — it is the rare 7.6-hour line that tells you a farm is a project
+ * rather than an afternoon, so the rate is shown where it is known and quietly omitted where the
+ * author never measured it (nulls are meaningful here, not missing data).
+ *
+ * The action is the review screen, not a direct create: import decides what to gather and
+ * whether the farm already exists (MCO-457), and both of those are questions this list has no
+ * business answering on the user's behalf.
+ */
+private fun FlowContent.farmSuggestionList(suggestions: List<FarmSuggestion>, worldId: Int) {
+    if (suggestions.isEmpty()) return
+
+    div("plan-suggestions") {
+        id = "plan-suggestions"
+        span("section-label") { +"Designs that cover this" }
+        div("plan-suggestions__list") {
+            suggestions.forEach { suggestion ->
+                div("plan-suggestions__item") {
+                    div("plan-suggestions__head") {
+                        a(classes = "plan-suggestions__name") {
+                            href = Link.Ideas.single(suggestion.ideaId)
+                            +suggestion.ideaName
+                        }
+                        a(classes = "btn btn--sm btn--secondary plan-suggestions__import") {
+                            href = Link.Ideas.single(suggestion.ideaId) + "/import/review?worldId=$worldId"
+                            +"Import into this world"
+                        }
+                    }
+                    suggestion.produces.forEach { covered ->
+                        div("plan-suggestions__covers") {
+                            span("plan-suggestions__quantity") { +"%,d".format(covered.quantity) }
+                            span("plan-suggestions__item-name") { +covered.itemName }
+                            covered.hoursToCover?.let { hours ->
+                                span("plan-suggestions__rate") { +hoursOfRunning(hours) }
+                            }
+                        }
+                    }
+                    if (suggestion.alsoRemoves.isNotEmpty()) {
+                        p("plan-suggestions__knock-on") {
+                            +"Also removes "
+                            +suggestion.alsoRemoves.joinToString(", ") {
+                                "${"%,d".format(it.quantity)} ${it.itemName}"
+                            }
+                            +" — work that only exists to feed the above."
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * How long the farm has to run, in the unit a player would say it in.
+ *
+ * Sub-hour figures are the common case and "0.1 hours" is not how anyone thinks about ten
+ * minutes; past a day, minutes and hours both stop being the point.
+ */
+private fun hoursOfRunning(hours: Double): String = when {
+    hours < 1.0 -> "~${kotlin.math.max(1, kotlin.math.round(hours * 60).toInt())} min running"
+    hours < 24.0 -> "~%.1f h running".format(hours)
+    else -> "~%.1f days running".format(hours / 24)
+}
+
+/**
  * The farm-scale roll-up (MCO-401): raw materials whose demand is large enough to be worth a
  * farm, largest first.
  *
@@ -567,6 +657,7 @@ private fun FlowContent.farmScaleRollUp(
     threshold: Int,
     worldId: Int,
     canEditThreshold: Boolean,
+    coveredByDesign: Map<String, String> = emptyMap(),
 ) {
     if (demands.isEmpty()) return
 
@@ -595,6 +686,13 @@ private fun FlowContent.farmScaleRollUp(
                 div("plan-farm-scale__item") {
                     span("plan-farm-scale__quantity") { +"%,d".format(demand.quantity) }
                     span("plan-farm-scale__name") { +demand.itemName }
+                    // A line the bank answers says so here rather than being removed: the
+                    // quantity is still what you would gather by hand, and seeing which lines
+                    // are already spoken for is what makes the remainder meaningful. A line
+                    // with no design is the honest "you will have to farm this yourself".
+                    coveredByDesign[demand.itemId]?.let { designName ->
+                        span("plan-farm-scale__covered") { +"covered by $designName" }
+                    }
                 }
             }
         }
@@ -1332,11 +1430,12 @@ fun gatheringPlannerFragment(
     progressMap: Map<String, Int> = emptyMap(),
     pendingFarms: List<PendingFarmSupply> = emptyList(),
     farmScaleThreshold: Int = World.DEFAULT_FARM_SCALE_THRESHOLD,
+    farmSuggestions: List<FarmSuggestion> = emptyList(),
     isWorldAdmin: Boolean = false,
 ): String = createHTML().div {
     id = "project-content"
     gatheringPlannerContent(
-        project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold, isWorldAdmin,
+        project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold, farmSuggestions, isWorldAdmin,
     )
 }
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -507,24 +507,13 @@ fun FlowContent.gatheringPlanSections(
     val feedsLabels = buildFeedsLabels(plan)
     val farmScale = FarmScaleDemands.of(plan, farmScaleThreshold)
     val farmScaleIds = farmScale.mapTo(mutableSetOf()) { it.itemId }
-    // itemId -> the design that accounts for it (MCO-294). First suggestion wins: they are
-    // ordered by work removed, so the row is attributed to the biggest reason to build it.
-    val coveredByDesign: Map<String, String> = buildMap {
-        farmSuggestions.forEach { suggestion ->
-            suggestion.itemIds.forEach { itemId -> putIfAbsent(itemId, suggestion.ideaName) }
-        }
-    }
 
     div {
         id = "gathering-plan-sections"
 
         // Above the work sections on purpose: this is not a step in the plan, it is the answer
         // to "what should I build first", and it is what turns one import into a roadmap.
-        farmScaleRollUp(farmScale, farmScaleThreshold, project.worldId, isWorldAdmin, coveredByDesign)
-
-        // Directly under the roll-up, because it is the answer to it (MCO-294). A design listed
-        // here is why some of the lines above are already spoken for.
-        farmSuggestionList(farmSuggestions, project.worldId)
+        farmScaleSection(farmScale, farmSuggestions, farmScaleThreshold, project.worldId, isWorldAdmin)
 
         groupOrder.forEach { group ->
             val activities = byGroup[group] ?: return@forEach
@@ -566,100 +555,38 @@ fun FlowContent.gatheringPlanSections(
 }
 
 /**
- * Designs in the bank that answer this plan's demand (MCO-294) — the step that turns
- * "7 materials are farm-scale" into "and here is what to build for them".
+ * "Worth a farm" — the farm-scale demand and what to build for it, as one list.
  *
- * **One line per design, not per item.** A farm makes several things: the bank's stick producer
- * is the Witch Hut Farm, already the answer for 63,273 redstone. Listing per item would name
- * that one design three times and invite building a witch hut "for sticks". See
- * [app.mcorg.pipeline.resources.FarmSuggestions] for the matching rules and for why coverage
- * deliberately under-claims.
+ * MCO-401 shipped the quantities; MCO-294 added the designs that cover them. They were briefly
+ * two sections and that was wrong: on a real plan the bank answered ten of ten lines, so the
+ * second section reprinted the first one's numbers under different headings. A design and the
+ * demand it covers are one fact, so they are one row.
  *
- * The hours figure is the one number that changes a decision. Most designs in a real bank cover
- * their demand in minutes — it is the rare 7.6-hour line that tells you a farm is a project
- * rather than an afternoon, so the rate is shown where it is known and quietly omitted where the
- * author never measured it (nulls are meaningful here, not missing data).
+ * The order is the message, as it was before: most work removed first, and the top line is
+ * where to start. Designs lead because a line you can answer by importing something is a
+ * cheaper decision than a line you cannot.
  *
- * The action is the review screen, not a direct create: import decides what to gather and
- * whether the farm already exists (MCO-457), and both of those are questions this list has no
- * business answering on the user's behalf.
+ * The tail is the point of the section as much as the head. A farm-scale material with no
+ * design is not a gap in the feature — it is the honest answer that you will be farming this
+ * one yourself, and it is where the bank is worth growing. It keeps the plain quantity-and-name
+ * shape the whole roll-up used to have.
+ *
+ * Coverage runs deeper than the roll-up's own lines: the roll-up is RAW_GATHER leaves, and a
+ * design that produces iron ingots removes the *ore* below them. That ore is a roll-up line, so
+ * it appears under the design that removes it rather than orphaned in the tail claiming nobody
+ * can help with it.
  */
-private fun FlowContent.farmSuggestionList(suggestions: List<FarmSuggestion>, worldId: Int) {
-    if (suggestions.isEmpty()) return
-
-    div("plan-suggestions") {
-        id = "plan-suggestions"
-        span("section-label") { +"Designs that cover this" }
-        div("plan-suggestions__list") {
-            suggestions.forEach { suggestion ->
-                div("plan-suggestions__item") {
-                    div("plan-suggestions__head") {
-                        a(classes = "plan-suggestions__name") {
-                            href = Link.Ideas.single(suggestion.ideaId)
-                            +suggestion.ideaName
-                        }
-                        a(classes = "btn btn--sm btn--secondary plan-suggestions__import") {
-                            href = Link.Ideas.single(suggestion.ideaId) + "/import/review?worldId=$worldId"
-                            +"Import into this world"
-                        }
-                    }
-                    suggestion.produces.forEach { covered ->
-                        div("plan-suggestions__covers") {
-                            span("plan-suggestions__quantity") { +"%,d".format(covered.quantity) }
-                            span("plan-suggestions__item-name") { +covered.itemName }
-                            covered.hoursToCover?.let { hours ->
-                                span("plan-suggestions__rate") { +hoursOfRunning(hours) }
-                            }
-                        }
-                    }
-                    if (suggestion.alsoRemoves.isNotEmpty()) {
-                        p("plan-suggestions__knock-on") {
-                            +"Also removes "
-                            +suggestion.alsoRemoves.joinToString(", ") {
-                                "${"%,d".format(it.quantity)} ${it.itemName}"
-                            }
-                            +" — work that only exists to feed the above."
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-/**
- * How long the farm has to run, in the unit a player would say it in.
- *
- * Sub-hour figures are the common case and "0.1 hours" is not how anyone thinks about ten
- * minutes; past a day, minutes and hours both stop being the point.
- */
-private fun hoursOfRunning(hours: Double): String = when {
-    hours < 1.0 -> "~${kotlin.math.max(1, kotlin.math.round(hours * 60).toInt())} min running"
-    hours < 24.0 -> "~%.1f h running".format(hours)
-    else -> "~%.1f days running".format(hours / 24)
-}
-
-/**
- * The farm-scale roll-up (MCO-401): raw materials whose demand is large enough to be worth a
- * farm, largest first.
- *
- * This list *is* the roadmap-building input — each line is a candidate prerequisite farm
- * project — which is why it leads the plan rather than sitting at the bottom with the notices.
- * Ordering carries the meaning: the top line is where to start.
- *
- * It names quantities and nothing else. Suggesting *which* farm to build is MCO-294 and needs
- * an idea bank; saying "this is farm-scale" needs only the plan, which is why the two shipped
- * apart. Items an operational farm already supplies never appear — they are solved, not
- * suggestions (see [FarmScaleDemands]).
- */
-private fun FlowContent.farmScaleRollUp(
+private fun FlowContent.farmScaleSection(
     demands: List<FarmScaleDemand>,
+    suggestions: List<FarmSuggestion>,
     threshold: Int,
     worldId: Int,
     canEditThreshold: Boolean,
-    coveredByDesign: Map<String, String> = emptyMap(),
 ) {
-    if (demands.isEmpty()) return
+    if (demands.isEmpty() && suggestions.isEmpty()) return
+
+    val answered = suggestions.flatMapTo(mutableSetOf()) { it.itemIds }
+    val unanswered = demands.filter { it.itemId !in answered }
 
     div("plan-farm-scale") {
         id = "plan-farm-scale"
@@ -679,24 +606,99 @@ private fun FlowContent.farmScaleRollUp(
             } else {
                 +"%,d".format(threshold)
             }
-            +" — each is a candidate for its own farm project."
+            if (suggestions.isEmpty()) {
+                +" — each is a candidate for its own farm project."
+            } else {
+                val covered = demands.size - unanswered.size
+                +" — your designs cover $covered of them."
+            }
         }
-        div("plan-farm-scale__list") {
-            demands.forEach { demand ->
-                div("plan-farm-scale__item") {
-                    span("plan-farm-scale__quantity") { +"%,d".format(demand.quantity) }
-                    span("plan-farm-scale__name") { +demand.itemName }
-                    // A line the bank answers says so here rather than being removed: the
-                    // quantity is still what you would gather by hand, and seeing which lines
-                    // are already spoken for is what makes the remainder meaningful. A line
-                    // with no design is the honest "you will have to farm this yourself".
-                    coveredByDesign[demand.itemId]?.let { designName ->
-                        span("plan-farm-scale__covered") { +"covered by $designName" }
+
+        suggestions.forEach { suggestion -> designRow(suggestion, worldId) }
+
+        if (unanswered.isNotEmpty()) {
+            div("plan-farm-scale__unanswered") {
+                // The label separates answered from unanswered. With nothing answered there is
+                // nothing to separate, and the section is exactly the roll-up MCO-401 shipped —
+                // so it says nothing rather than heading a list that is the whole list.
+                if (suggestions.isNotEmpty()) {
+                    span("plan-farm-scale__group-label") { +"No design yet" }
+                }
+                div("plan-farm-scale__list") {
+                    unanswered.forEach { demand ->
+                        div("plan-farm-scale__item") {
+                            span("plan-farm-scale__quantity") { +"%,d".format(demand.quantity) }
+                            span("plan-farm-scale__name") { +demand.itemName }
+                        }
                     }
                 }
             }
         }
     }
+}
+
+/**
+ * One design and everything it takes off the plan (MCO-294).
+ *
+ * **One row per design, not per item.** A farm makes several things: the bank's stick producer
+ * is the Witch Hut Farm, already the answer for 63,213 redstone. A row per item would name that
+ * one design three times and invite building a witch hut "for sticks". See
+ * [app.mcorg.pipeline.resources.FarmSuggestions] for the matching rules and for why coverage
+ * deliberately under-claims.
+ *
+ * The hours figure is the one number that changes a decision. Most designs cover their demand in
+ * minutes — it is the rare multi-hour line that says a farm is a project rather than an
+ * afternoon — so the rate shows where it is known and is quietly absent where the author never
+ * measured it (a null rate is meaningful here, not missing data).
+ *
+ * The action is the review screen, not a direct create: import decides what to gather and
+ * whether the farm already exists (MCO-457), and neither is this list's to answer for the user.
+ */
+private fun FlowContent.designRow(suggestion: FarmSuggestion, worldId: Int) {
+    div("plan-farm-scale__design") {
+        div("plan-farm-scale__design-head") {
+            a(classes = "plan-farm-scale__design-name") {
+                href = Link.Ideas.single(suggestion.ideaId)
+                +suggestion.ideaName
+            }
+            a(classes = "btn btn--sm btn--secondary plan-farm-scale__import") {
+                href = Link.Ideas.single(suggestion.ideaId) + "/import/review?worldId=$worldId"
+                +"Import into this world"
+            }
+        }
+        div("plan-farm-scale__list") {
+            suggestion.produces.forEach { covered ->
+                div("plan-farm-scale__item") {
+                    span("plan-farm-scale__quantity") { +"%,d".format(covered.quantity) }
+                    span("plan-farm-scale__name") { +covered.itemName }
+                    covered.hoursToCover?.let { hours ->
+                        span("plan-farm-scale__rate") { +hoursOfRunning(hours) }
+                    }
+                }
+            }
+        }
+        if (suggestion.alsoRemoves.isNotEmpty()) {
+            p("plan-farm-scale__knock-on") {
+                +"Also removes "
+                +suggestion.alsoRemoves.joinToString(", ") {
+                    "${"%,d".format(it.quantity)} ${it.itemName}"
+                }
+                +" — work that only exists to feed the above."
+            }
+        }
+    }
+}
+
+/**
+ * How long the farm has to run, in the unit a player would say it in.
+ *
+ * Sub-hour figures are the common case and "0.1 hours" is not how anyone thinks about ten
+ * minutes; past a day, minutes and hours both stop being the point.
+ */
+private fun hoursOfRunning(hours: Double): String = when {
+    hours < 1.0 -> "~${kotlin.math.max(1, kotlin.math.round(hours * 60).toInt())} min running"
+    hours < 24.0 -> "~%.1f h running".format(hours)
+    else -> "~%.1f days running".format(hours / 24)
 }
 
 /**

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
@@ -678,47 +678,23 @@
     text-decoration-style: solid;
 }
 
-/* MCO-294 — the design that answers a roll-up line. Trailing and quiet: the quantity is
-   still the point of the row, and this is the annotation that some of it is spoken for. */
-.plan-farm-scale__covered {
-    font-family: var(--font-body);
-    font-size: var(--text-xs);
-    color: var(--text-muted);
-    font-style: italic;
-}
-
 /* ==========================================================================
    FARM SUGGESTIONS (MCO-294)
-   Designs in the bank that cover this plan's demand. Sits directly under the
-   farm-scale roll-up because it is the answer to it.
+   Designs live inside the roll-up rather than beside it: a design and the demand
+   it covers are one fact, and two sections printed the same numbers twice.
    ========================================================================== */
 
-/* Shares the roll-up's left-rule so the two read as one argument — "these are farm-scale"
-   followed by "and these are what to build" — rather than two unrelated notices. */
-.plan-suggestions {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-2);
-    margin-bottom: var(--space-4);
-    padding: var(--space-3);
-    border: 1px solid var(--border);
-    border-left: 3px solid var(--accent);
-    background: var(--bg-raised);
-}
-
-.plan-suggestions__list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-3);
-}
-
-.plan-suggestions__item {
+/* Each design is a block of the list, set off by indentation rather than a box —
+   the section already has a border, and boxes inside boxes read as unrelated cards. */
+.plan-farm-scale__design {
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
+    padding-left: var(--space-3);
+    border-left: 2px solid var(--border);
 }
 
-.plan-suggestions__head {
+.plan-farm-scale__design-head {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
@@ -726,7 +702,7 @@
     flex-wrap: wrap;
 }
 
-.plan-suggestions__name {
+.plan-farm-scale__design-name {
     font-family: var(--font-ui);
     font-size: var(--text-ui);
     font-weight: 600;
@@ -734,52 +710,47 @@
     text-decoration: none;
 }
 
-.plan-suggestions__name:hover {
+.plan-farm-scale__design-name:hover {
     text-decoration: underline;
-}
-
-/* One covered item per line, quantity-first and tabular, matching the roll-up above it —
-   the two lists are read against each other and ragged digits would break the comparison. */
-.plan-suggestions__covers {
-    display: flex;
-    align-items: baseline;
-    gap: var(--space-2);
-}
-
-.plan-suggestions__quantity {
-    min-width: 6ch;
-    text-align: right;
-    font-family: var(--font-ui);
-    font-size: var(--text-sm);
-    font-variant-numeric: tabular-nums;
-    color: var(--text-primary);
-}
-
-.plan-suggestions__item-name {
-    font-family: var(--font-body);
-    font-size: var(--text-sm);
-    color: var(--text-primary);
 }
 
 /* The number that changes a decision: most designs cover their demand in minutes, and it is
    the rare multi-hour line that says a farm is a project rather than an afternoon. */
-.plan-suggestions__rate {
+.plan-farm-scale__rate {
     font-family: var(--font-ui);
     font-size: var(--text-xs);
     color: var(--text-muted);
 }
 
-.plan-suggestions__knock-on {
+.plan-farm-scale__knock-on {
     margin: 0;
     font-family: var(--font-body);
     font-size: var(--text-xs);
     color: var(--text-muted);
 }
 
+/* The tail — farm-scale demand no design answers. Kept visually quieter than the designs
+   without being hidden: it is where the bank is worth growing, not an error state. */
+.plan-farm-scale__unanswered {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    padding-left: var(--space-3);
+    border-left: 2px solid transparent;
+}
+
+.plan-farm-scale__group-label {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+}
+
 @media (max-width: 768px) {
     /* Name then button on their own lines: the design name is the part that has to read, and
        at 375px an inline button squeezes it to a few characters. */
-    .plan-suggestions__head {
+    .plan-farm-scale__design-head {
         flex-direction: column;
         align-items: flex-start;
         gap: var(--space-2);

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
@@ -678,6 +678,114 @@
     text-decoration-style: solid;
 }
 
+/* MCO-294 — the design that answers a roll-up line. Trailing and quiet: the quantity is
+   still the point of the row, and this is the annotation that some of it is spoken for. */
+.plan-farm-scale__covered {
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    font-style: italic;
+}
+
+/* ==========================================================================
+   FARM SUGGESTIONS (MCO-294)
+   Designs in the bank that cover this plan's demand. Sits directly under the
+   farm-scale roll-up because it is the answer to it.
+   ========================================================================== */
+
+/* Shares the roll-up's left-rule so the two read as one argument — "these are farm-scale"
+   followed by "and these are what to build" — rather than two unrelated notices. */
+.plan-suggestions {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    margin-bottom: var(--space-4);
+    padding: var(--space-3);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    background: var(--bg-raised);
+}
+
+.plan-suggestions__list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+
+.plan-suggestions__item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.plan-suggestions__head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+}
+
+.plan-suggestions__name {
+    font-family: var(--font-ui);
+    font-size: var(--text-ui);
+    font-weight: 600;
+    color: var(--text-primary);
+    text-decoration: none;
+}
+
+.plan-suggestions__name:hover {
+    text-decoration: underline;
+}
+
+/* One covered item per line, quantity-first and tabular, matching the roll-up above it —
+   the two lists are read against each other and ragged digits would break the comparison. */
+.plan-suggestions__covers {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+}
+
+.plan-suggestions__quantity {
+    min-width: 6ch;
+    text-align: right;
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    font-variant-numeric: tabular-nums;
+    color: var(--text-primary);
+}
+
+.plan-suggestions__item-name {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+}
+
+/* The number that changes a decision: most designs cover their demand in minutes, and it is
+   the rare multi-hour line that says a farm is a project rather than an afternoon. */
+.plan-suggestions__rate {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+.plan-suggestions__knock-on {
+    margin: 0;
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+@media (max-width: 768px) {
+    /* Name then button on their own lines: the design name is the part that has to read, and
+       at 375px an inline button squeezes it to a few characters. */
+    .plan-suggestions__head {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--space-2);
+    }
+}
+
 /* MCO-400 — "Needs attention" ordered by what each question decides, tail folded away. */
 .plan-attention {
     display: flex;

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/FarmSuggestionsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/FarmSuggestionsTest.kt
@@ -1,0 +1,258 @@
+package app.mcorg.pipeline.resources
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftId
+import app.mcorg.domain.model.minecraft.MinecraftTag
+import app.mcorg.domain.model.world.World
+import app.mcorg.engine.plan.GatheringPlan
+import app.mcorg.engine.plan.PlanNode
+import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.engine.plan.PlanRequirement
+import app.mcorg.engine.plan.PlanTarget
+import app.mcorg.engine.plan.SupplySource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * MCO-294 — which designs in the bank answer this plan.
+ *
+ * The cases here are the ones measured on the real dogfood world (see the spike on MCO-294),
+ * not invented ones: the iron chain the roll-up cannot see, the witch hut that produces three
+ * separate demands, and the oak log whose demand no single design can claim.
+ */
+class FarmSuggestionsTest {
+
+    private val ironIngot = Item("minecraft:iron_ingot", "Iron Ingot")
+    private val deepslateIronOre = Item("minecraft:deepslate_iron_ore", "Deepslate Iron Ore")
+    private val redstone = Item("minecraft:redstone", "Redstone Dust")
+    private val stick = Item("minecraft:stick", "Stick")
+    private val glassBottle = Item("minecraft:glass_bottle", "Glass Bottle")
+    private val oakLog = Item("minecraft:oak_log", "Oak Log")
+    private val planks = Item("minecraft:oak_planks", "Oak Planks")
+    private val cobblestone = Item("minecraft:cobblestone", "Cobblestone")
+    private val anyPlanks = MinecraftTag("#minecraft:planks", "Planks", emptyList())
+
+    private val threshold = World.DEFAULT_FARM_SCALE_THRESHOLD // 1,728
+
+    // ---- fixtures ------------------------------------------------------------------
+
+    private fun plan(vararg nodes: PlanNode) = GatheringPlan(
+        nodes = nodes.associateBy { it.item.id },
+        targets = listOf(PlanTarget(nodes.first().item, nodes.first().quantity)),
+    )
+
+    private fun node(
+        item: MinecraftId,
+        quantity: Long,
+        status: PlanNodeStatus = PlanNodeStatus.RAW_GATHER,
+        requires: List<PlanRequirement> = emptyList(),
+        supply: SupplySource? = null,
+    ) = PlanNode(
+        item = item, quantity = quantity, crafts = 0, leftover = 0,
+        status = status, supply = supply, requires = requires,
+    )
+
+    private fun producer(id: Int, name: String, vararg rates: Pair<MinecraftId, Int?>) =
+        IdeaProducer(id, name, rates.associate { (item, rate) -> item.id to rate })
+
+    // ---- the case the roll-up cannot see -------------------------------------------
+
+    @Test
+    fun `a design matches demand the roll-up never lists`() {
+        // Measured: the roll-up's 4th line is Deepslate Iron Ore because the plan mines ore,
+        // while the design produces ingots. Keyed on RAW_GATHER leaves this matches nothing.
+        val ironPlan = plan(
+            node(ironIngot, 33_049, PlanNodeStatus.RESOLVED, listOf(PlanRequirement("minecraft:deepslate_iron_ore", 1))),
+            node(deepslateIronOre, 33_049),
+        )
+
+        val result = FarmSuggestions.of(ironPlan, threshold, listOf(producer(1, "8 Pod Iron Farm", ironIngot to 3810)))
+
+        assertEquals(1, result.size)
+        val suggestion = result.single()
+        assertEquals(listOf("minecraft:iron_ingot" to 33_049L), suggestion.produces.map { it.itemId to it.quantity })
+        assertEquals(3810, suggestion.produces.single().ratePerHour)
+    }
+
+    @Test
+    fun `the mining underneath a matched item counts as removed`() {
+        val ironPlan = plan(
+            node(ironIngot, 33_049, PlanNodeStatus.RESOLVED, listOf(PlanRequirement("minecraft:deepslate_iron_ore", 1))),
+            node(deepslateIronOre, 33_049),
+        )
+
+        val suggestion = FarmSuggestions
+            .of(ironPlan, threshold, listOf(producer(1, "8 Pod Iron Farm", ironIngot to 3810)))
+            .single()
+
+        assertEquals(
+            listOf("minecraft:deepslate_iron_ore" to 33_049L),
+            suggestion.alsoRemoves.map { it.itemId to it.quantity },
+            "building the farm means the ore is not mined either",
+        )
+        assertEquals(66_098, suggestion.unitsRemoved)
+        // The rate belongs to what the design makes; the ore is a consequence, not an output.
+        assertEquals(null, suggestion.alsoRemoves.single().ratePerHour)
+    }
+
+    @Test
+    fun `demand feeding something the design does not cover is left alone`() {
+        // Oak logs feed both the planks and the sticks. A design covering only sticks cannot
+        // claim the logs — apportioning that split is exactly what this does not attempt.
+        val woodPlan = plan(
+            node(planks, 40_000, PlanNodeStatus.RESOLVED, listOf(PlanRequirement("minecraft:oak_log", 1))),
+            node(stick, 21_939, PlanNodeStatus.RESOLVED, listOf(PlanRequirement("minecraft:oak_log", 1))),
+            node(oakLog, 31_267),
+        )
+
+        val suggestion = FarmSuggestions
+            .of(woodPlan, threshold, listOf(producer(1, "Witch Hut Farm", stick to 1580)))
+            .single()
+
+        assertTrue(
+            suggestion.alsoRemoves.none { it.itemId == "minecraft:oak_log" },
+            "the planks still need the logs, so the logs are not removed: ${suggestion.alsoRemoves}",
+        )
+        assertEquals(21_939, suggestion.unitsRemoved)
+    }
+
+    // ---- one line per design, not per item -----------------------------------------
+
+    @Test
+    fun `a design producing three demanded items is suggested once`() {
+        // The real shape of the witch hut: redstone is why you build it, sticks and glass
+        // bottles come along. Three lines here would invite building it "for sticks".
+        val witchPlan = plan(
+            node(redstone, 63_273),
+            node(stick, 21_939),
+            node(glassBottle, 216),
+        )
+
+        val result = FarmSuggestions.of(
+            witchPlan,
+            threshold,
+            listOf(producer(1, "Witch Hut Farm", redstone to 8280, stick to 1580, glassBottle to 785)),
+        )
+
+        assertEquals(1, result.size)
+        assertEquals(
+            listOf("minecraft:redstone", "minecraft:stick", "minecraft:glass_bottle"),
+            result.single().produces.map { it.itemId },
+            "everything it covers, largest first, on one suggestion",
+        )
+    }
+
+    @Test
+    fun `a design is not suggested when nothing it makes is farm-scale`() {
+        val smallPlan = plan(node(glassBottle, 216))
+
+        val result = FarmSuggestions.of(smallPlan, threshold, listOf(producer(1, "Witch Hut Farm", glassBottle to 785)))
+
+        assertTrue(result.isEmpty(), "216 bottles is not a reason to build a farm")
+    }
+
+    @Test
+    fun `sub-threshold items ride along once the design qualifies`() {
+        val witchPlan = plan(node(redstone, 63_273), node(glassBottle, 216))
+
+        val suggestion = FarmSuggestions
+            .of(witchPlan, threshold, listOf(producer(1, "Witch Hut Farm", redstone to 8280, glassBottle to 785)))
+            .single()
+
+        assertEquals(
+            listOf("minecraft:redstone", "minecraft:glass_bottle"),
+            suggestion.produces.map { it.itemId },
+            "the bottles are not a reason to build it, but they are a reason to know about it",
+        )
+    }
+
+    // ---- what must never be suggested ----------------------------------------------
+
+    @Test
+    fun `demand an operational farm already supplies is not suggested again`() {
+        val suppliedPlan = plan(
+            node(cobblestone, 74_557, PlanNodeStatus.SUPPLIED, supply = SupplySource.Farm("Cobble farm")),
+        )
+
+        val result = FarmSuggestions.of(
+            suppliedPlan,
+            threshold,
+            listOf(producer(1, "231k Cobblestone farm", cobblestone to 924_000)),
+        )
+
+        assertTrue(result.isEmpty(), "it is already solved — this is MCO-401's rule, kept here")
+    }
+
+    @Test
+    fun `an unresolved tag matches nothing`() {
+        // A tag is not an item and carries no id a design could produce. Resolving it turns it
+        // into real demand this then sees (MCO-400).
+        val taggedPlan = plan(node(anyPlanks, 121_774, PlanNodeStatus.OPEN_TAG))
+
+        val result = FarmSuggestions.of(taggedPlan, threshold, listOf(producer(1, "Tree farm", planks to 5000)))
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `a blocked item is still worth suggesting a farm for`() {
+        // No feasible source in the graph is the strongest possible reason to want a design.
+        val blockedPlan = plan(node(redstone, 63_273, PlanNodeStatus.BLOCKED))
+
+        val result = FarmSuggestions.of(blockedPlan, threshold, listOf(producer(1, "Witch Hut Farm", redstone to 8280)))
+
+        assertEquals(1, result.size)
+    }
+
+    // ---- ordering and rates ---------------------------------------------------------
+
+    @Test
+    fun `designs are ranked by the work they remove`() {
+        val bigPlan = plan(
+            node(cobblestone, 75_151),
+            node(redstone, 63_273),
+        )
+
+        val result = FarmSuggestions.of(
+            bigPlan,
+            threshold,
+            listOf(
+                producer(1, "Witch Hut Farm", redstone to 8280),
+                producer(2, "Cobblestone farm", cobblestone to 924_000),
+            ),
+        )
+
+        assertEquals(listOf("Cobblestone farm", "Witch Hut Farm"), result.map { it.ideaName })
+    }
+
+    @Test
+    fun `an unmeasured rate suggests the design without inventing a number`() {
+        // rate_per_hour is nullable precisely so a design can be shared without timing it.
+        val bambooPlan = plan(node(stick, 21_939))
+
+        val suggestion = FarmSuggestions
+            .of(bambooPlan, threshold, listOf(producer(1, "Bamboo farm", stick to null)))
+            .single()
+
+        assertEquals(null, suggestion.produces.single().ratePerHour)
+        assertEquals(null, suggestion.produces.single().hoursToCover)
+    }
+
+    @Test
+    fun `hours to cover comes from the rate`() {
+        val redstonePlan = plan(node(redstone, 63_273))
+
+        val suggestion = FarmSuggestions
+            .of(redstonePlan, threshold, listOf(producer(1, "Witch Hut Farm", redstone to 8280)))
+            .single()
+
+        val hours = suggestion.produces.single().hoursToCover!!
+        assertTrue(hours > 7.6 && hours < 7.7, "63,273 at 8,280/h is about 7.6 hours, got $hours")
+    }
+
+    @Test
+    fun `an empty bank suggests nothing`() {
+        assertEquals(emptyList(), FarmSuggestions.of(plan(node(cobblestone, 75_151)), threshold, emptyList()))
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSuggestionIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSuggestionIT.kt
@@ -1,0 +1,269 @@
+package app.mcorg.presentation.handler.project
+
+import app.mcorg.domain.model.minecraft.Item
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.minecraft.ServerData
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.domain.model.resources.ResourceQuantity
+import app.mcorg.domain.model.resources.ResourceSource
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.minecraft.StoreMinecraftDataStep
+import app.mcorg.pipeline.project.handleGetProject
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.ProjectParamPlugin
+import app.mcorg.presentation.plugins.UpdateActiveWorldPlugin
+import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.routing.get
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+
+/**
+ * MCO-294 — the plan suggests designs from the bank that cover its demand.
+ *
+ * The unit rules live in `FarmSuggestionsTest`; this covers the two things only the real door
+ * can answer: that the suggestion reaches the rendered plan at all, and that it obeys the hub's
+ * visibility rule rather than showing one user another's private designs.
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class FarmSuggestionIT : WithUser() {
+
+    private val version = MinecraftVersion.Release(1, 94, 0)
+    private val cobblestone = Item("minecraft:cobblestone", "Cobblestone")
+    private val glassBottle = Item("minecraft:glass_bottle", "Glass Bottle")
+
+    private var worldId: Int = 0
+    private var projectId: Int = 0
+    private var myFarmIdea: Int = 0
+    private var strangersIdea: Int = 0
+    private var smallIdea: Int = 0
+
+    @BeforeAll
+    fun setup() {
+        val stored = runBlocking {
+            StoreMinecraftDataStep.process(
+                ServerData(
+                    version = version,
+                    items = listOf(cobblestone, glassBottle),
+                    sources = listOf(
+                        ResourceSource(
+                            type = ResourceSource.SourceType.LootTypes.BLOCK,
+                            filename = "blocks/stone.json",
+                            producedItems = listOf(cobblestone to ResourceQuantity.ItemQuantity(1))
+                        ),
+                        ResourceSource(
+                            type = ResourceSource.SourceType.LootTypes.BLOCK,
+                            filename = "blocks/glass_bottle.json",
+                            producedItems = listOf(glassBottle to ResourceQuantity.ItemQuantity(1))
+                        ),
+                    )
+                )
+            )
+        }
+        assertIs<Result.Success<*>>(stored)
+
+        worldId = createWorld("FarmSuggestion IT World")
+        projectId = createProject(worldId, "Storage System")
+        // Comfortably farm-scale (the default threshold is 1,728).
+        createResourceGathering(projectId, cobblestone, required = 75_151)
+        createResourceGathering(projectId, glassBottle, required = 216)
+
+        myFarmIdea = createIdea("231k Cobblestone farm", ownerId = user.id, public = false)
+        addProduction(myFarmIdea, cobblestone.id, 924_000)
+
+        // Sub-threshold on its only output: the plan wants 216 bottles, which is no reason to
+        // build anything.
+        smallIdea = createIdea("Bottle trickle", ownerId = user.id, public = false)
+        addProduction(smallIdea, glassBottle.id, 785)
+    }
+
+    @Test
+    fun `a design covering farm-scale demand is suggested on the plan`() = testApplication {
+        setupRoutes()
+
+        val response = client.get("/worlds/$worldId/projects/$projectId") { addAuthCookie(this) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertContains(body, "plan-suggestions")
+        assertContains(body, "Designs that cover this")
+        assertContains(body, "231k Cobblestone farm")
+        assertContains(body, "75,151")
+        // The action is the review screen (MCO-457's door), not a direct create.
+        assertContains(body, "/ideas/$myFarmIdea/import/review?worldId=$worldId")
+    }
+
+    @Test
+    fun `the roll-up says which of its lines a design already answers`() = testApplication {
+        setupRoutes()
+
+        val body = client.get("/worlds/$worldId/projects/$projectId") { addAuthCookie(this) }.bodyAsText()
+
+        // The quantity stays — it is still what you would gather by hand — and the line says
+        // what accounts for it. A line with no design is the honest "you farm this yourself".
+        assertContains(body, "covered by 231k Cobblestone farm")
+    }
+
+    @Test
+    fun `a design whose only output is below the threshold is not suggested`() = testApplication {
+        setupRoutes()
+
+        val body = client.get("/worlds/$worldId/projects/$projectId") { addAuthCookie(this) }.bodyAsText()
+
+        assertFalse(body.contains("Bottle trickle"), "216 bottles is not a reason to build a farm")
+    }
+
+    @Test
+    fun `someone else's private design is never suggested`() = testApplication {
+        setupRoutes()
+        val stranger = createExtraUser("farm-suggestion-stranger")
+        strangersIdea = createIdea("Stranger's Cobble Farm", ownerId = stranger.id, public = false)
+        addProduction(strangersIdea, cobblestone.id, 500_000)
+
+        val body = client.get("/worlds/$worldId/projects/$projectId") { addAuthCookie(this) }.bodyAsText()
+
+        assertFalse(
+            body.contains("Stranger's Cobble Farm"),
+            "the bank is public designs plus your own — the hub's rule (MCO-291), shared not re-derived",
+        )
+    }
+
+    @Test
+    fun `published, the same design is suggested to everyone`() = testApplication {
+        setupRoutes()
+        val stranger = createExtraUser("farm-suggestion-publisher")
+        val published = createIdea("Published Cobble Farm", ownerId = stranger.id, public = true)
+        addProduction(published, cobblestone.id, 400_000)
+
+        val body = client.get("/worlds/$worldId/projects/$projectId") { addAuthCookie(this) }.bodyAsText()
+
+        assertContains(body, "Published Cobble Farm")
+
+        deleteIdea(published)
+    }
+
+    // ---- routing ----------------------------------------------------------------
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
+                install(UpdateActiveWorldPlugin)
+                route("/projects/{projectId}") {
+                    install(ProjectParamPlugin)
+                    get { call.handleGetProject() }
+                }
+            }
+        }
+    }
+
+    // ---- fixtures ----------------------------------------------------------------
+
+    private fun createWorld(name: String): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(name = name, description = "test", version = version)
+        )
+        (result as Result.Success).value
+    }
+
+    private fun createProject(worldId: Int, name: String): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, state, location_x, location_y, location_z, location_dimension) " +
+                    "VALUES (?, ?, '', 'BUILDING', 'PLANNING', ?, 0, 0, 0, 'OVERWORLD') RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, name)
+                stmt.setInt(2, worldId)
+                stmt.setString(3, ProjectState.ACTIVE.name)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun createResourceGathering(projectId: Int, item: Item, required: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO resource_gathering (project_id, item_id, name, required) VALUES (?, ?, ?, ?)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, item.id)
+                stmt.setString(3, item.name)
+                stmt.setInt(4, required)
+            }
+        ).process(Unit)
+    }
+
+    private fun createIdea(name: String, ownerId: Int, public: Boolean): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                """
+                INSERT INTO ideas (name, description, category, author, difficulty, minecraft_version_range,
+                                   category_data, created_by, visibility)
+                VALUES (?, 'test idea', 'FARM', '{"type":"single","name":"tester"}'::jsonb, 'EASY',
+                        '{"type":"app.mcorg.domain.model.minecraft.MinecraftVersionRange.Unbounded"}'::jsonb,
+                        '{}'::jsonb, ?, ?)
+                RETURNING id
+                """.trimIndent()
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, name)
+                stmt.setInt(2, ownerId)
+                stmt.setString(3, if (public) "PUBLIC" else "PRIVATE")
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun addProduction(ideaId: Int, itemId: String, rate: Int) = runBlocking {
+        val modeId = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO idea_production_modes (idea_id, name, position) VALUES (?, 'Default', 0) RETURNING id"
+            ),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, ideaId) }
+        ).process(Unit).let { (it as Result.Success).value }
+
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO idea_production_rates (mode_id, item_id, rate_per_hour) VALUES (?, ?, ?)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, modeId)
+                stmt.setString(2, itemId)
+                stmt.setInt(3, rate)
+            }
+        ).process(Unit)
+    }
+
+    private fun deleteIdea(ideaId: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.delete("DELETE FROM ideas WHERE id = ?"),
+            parameterSetter = { stmt, _ -> stmt.setInt(1, ideaId) }
+        ).process(Unit)
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSuggestionIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSuggestionIT.kt
@@ -54,6 +54,9 @@ class FarmSuggestionIT : WithUser() {
     private val cobblestone = Item("minecraft:cobblestone", "Cobblestone")
     private val glassBottle = Item("minecraft:glass_bottle", "Glass Bottle")
 
+    /** Farm-scale in the fixtures below, and produced by nothing in the bank. */
+    private val oakLog = Item("minecraft:oak_log", "Oak Log")
+
     private var worldId: Int = 0
     private var projectId: Int = 0
     private var myFarmIdea: Int = 0
@@ -66,7 +69,7 @@ class FarmSuggestionIT : WithUser() {
             StoreMinecraftDataStep.process(
                 ServerData(
                     version = version,
-                    items = listOf(cobblestone, glassBottle),
+                    items = listOf(cobblestone, glassBottle, oakLog),
                     sources = listOf(
                         ResourceSource(
                             type = ResourceSource.SourceType.LootTypes.BLOCK,
@@ -77,6 +80,11 @@ class FarmSuggestionIT : WithUser() {
                             type = ResourceSource.SourceType.LootTypes.BLOCK,
                             filename = "blocks/glass_bottle.json",
                             producedItems = listOf(glassBottle to ResourceQuantity.ItemQuantity(1))
+                        ),
+                        ResourceSource(
+                            type = ResourceSource.SourceType.LootTypes.BLOCK,
+                            filename = "blocks/oak_log.json",
+                            producedItems = listOf(oakLog to ResourceQuantity.ItemQuantity(1))
                         ),
                     )
                 )
@@ -107,8 +115,7 @@ class FarmSuggestionIT : WithUser() {
 
         assertEquals(HttpStatusCode.OK, response.status)
         val body = response.bodyAsText()
-        assertContains(body, "plan-suggestions")
-        assertContains(body, "Designs that cover this")
+        assertContains(body, "plan-farm-scale")
         assertContains(body, "231k Cobblestone farm")
         assertContains(body, "75,151")
         // The action is the review screen (MCO-457's door), not a direct create.
@@ -116,14 +123,53 @@ class FarmSuggestionIT : WithUser() {
     }
 
     @Test
-    fun `the roll-up says which of its lines a design already answers`() = testApplication {
+    fun `an answered line lives under its design, not in a second list`() = testApplication {
         setupRoutes()
 
         val body = client.get("/worlds/$worldId/projects/$projectId") { addAuthCookie(this) }.bodyAsText()
 
-        // The quantity stays — it is still what you would gather by hand — and the line says
-        // what accounts for it. A line with no design is the honest "you farm this yourself".
-        assertContains(body, "covered by 231k Cobblestone farm")
+        // These were briefly two sections that reprinted each other's numbers on a real plan.
+        // The quantity now belongs to the design that covers it, inside the one roll-up.
+        assertContains(body, "plan-farm-scale__design")
+        assertContains(body, "your designs cover 1 of them")
+        assertFalse(body.contains("plan-suggestions"), "designs are not a section of their own")
+        assertFalse(body.contains("No design yet"), "everything farm-scale here has a design")
+    }
+
+    @Test
+    fun `farm-scale demand no design answers is called out as such`() = testApplication {
+        setupRoutes()
+        val bare = createProject(worldId, "Bare Build")
+        createResourceGathering(bare, oakLog, required = 31_267)
+
+        val body = client.get("/worlds/$worldId/projects/$bare") { addAuthCookie(this) }.bodyAsText()
+
+        // Nothing in the bank makes oak logs. Not a gap in the feature — the honest answer that
+        // this one gets farmed by hand, and where the bank is worth growing. With nothing
+        // answered the section is exactly the roll-up MCO-401 shipped: quantities, no headings.
+        assertContains(body, "31,267")
+        assertContains(body, "Oak Log")
+        assertFalse(body.contains("plan-farm-scale__design"), "there is no design to show")
+        assertFalse(body.contains("No design yet"), "nothing to separate it from")
+    }
+
+    @Test
+    fun `a project built from a design is not suggested that design`() = testApplication {
+        setupRoutes()
+        // The farm itself costs cobblestone to build, so its own plan matched its own design
+        // and offered to import what you are standing in.
+        val theFarm = createProjectFromIdea(worldId, "231k Cobblestone farm", myFarmIdea)
+        createResourceGathering(theFarm, cobblestone, required = 4_000)
+
+        val body = client.get("/worlds/$worldId/projects/$theFarm") { addAuthCookie(this) }.bodyAsText()
+
+        assertFalse(
+            body.contains("Import into this world"),
+            "you cannot need the design you are building",
+        )
+        // The demand is still farm-scale and still listed — it just has no answer now.
+        assertContains(body, "4,000")
+        assertFalse(body.contains("plan-farm-scale__design"), "and no design row at all")
     }
 
     @Test
@@ -200,6 +246,21 @@ class FarmSuggestionIT : WithUser() {
                 stmt.setString(1, name)
                 stmt.setInt(2, worldId)
                 stmt.setString(3, ProjectState.ACTIVE.name)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun createProjectFromIdea(worldId: Int, name: String, ideaId: Int): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, state, location_x, location_y, location_z, location_dimension, project_idea_id) " +
+                    "VALUES (?, ?, '', 'FARMING', 'PLANNING', 'ACTIVE', 0, 0, 0, 'OVERWORLD', ?) RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, name)
+                stmt.setInt(2, worldId)
+                stmt.setInt(3, ideaId)
             }
         ).process(Unit)
         (result as Result.Success).value


### PR DESCRIPTION
Closes MCO-294. Design decisions and the measurements behind them are the [spike comment on the issue](https://linear.app/evegul/issue/MCO-294).

The farm-scale roll-up (MCO-401) says *which materials are worth a farm*. This answers it: which designs in the bank cover them, what they produce, how long they would have to run, and one link into the import door (MCO-457).

## Matching does not read the roll-up

The roll-up is `RAW_GATHER` leaves only — right for "is this quantity worth a farm", wrong for "what covers it". Measured on the dogfood world, its 4th-largest line is **Deepslate Iron Ore, 33,049** (the plan mines ore), while the bank's iron farm produces **iron ingots**, which the plan carries as `RESOLVED`/`SMELT` one edge above. Keyed on the roll-up, the single most valuable suggestion in the world matches nothing.

So matching reads every node a design could answer, minus `SUPPLIED` (already solved — MCO-401's rule, kept) and `OPEN_TAG` (not an item, no id to match on). `BLOCKED` stays in: a farm for something the graph has no source for is the most useful suggestion this can make.

## The unit of suggestion is the idea, not the item

The bank's stick producer **is** the Witch Hut Farm, already the answer for 63,273 Redstone Dust. Per-item lines would name that one design three times — for redstone, sticks and glass bottles — and invite building a witch hut "for sticks".

A design qualifies only if something it *directly produces* is itself farm-scale; sub-threshold outputs then ride along on the same line.

## Coverage under-claims on purpose

Building the iron farm also removes the 33,049 ore below it, so a node counts as removed when **every** consumer of it is removed. Oak logs feed sticks *and* planks *and* chests, so a design covering only the sticks leaves the log demand alone — apportioning that split would need per-edge attribution this does not attempt. A log line with no design stays a plain roll-up row: *something you have to farm that has no idea yet*, which is the case a user will genuinely hit.

## Notes

- **Visibility is the hub's rule** (MCO-291), shared not re-derived: public designs plus the viewer's own. Suggesting something the viewer cannot open would be worse than no suggestion.
- Uses `idea_production_rates_item_id_idx`, which V2_57_0 added with the comment *"MCO-294's lookup direction"* — this is that query.
- Everything degrades to "no suggestions" rather than failing the page, same posture as `GetFarmScaleThresholdStep` and `pendingFarmSuppliesFor`.
- No mode-choosing UI: every idea in the real bank has exactly one mode, so `MAX(rate_per_hour)` per item is the only question that can be honestly answered until MCO-413.
- No migration.

## Tests

- `FarmSuggestionsTest` — 13 unit tests over the matching rules, using the cases measured on the real world: the iron chain the roll-up cannot see, the knock-on ore, the oak log that must *not* be claimed, the witch hut's three outputs on one line, supplied/open-tag/blocked handling, ranking, and unmeasured rates.
- `FarmSuggestionIT` — 5 ITs through the real project page: the suggestion renders with its import link, the roll-up marks the line it answers, a sub-threshold design is not suggested, a stranger's private design never appears, and the same design published does.

`test.sh --database`: 516 tests, 0 failures, 5 skipped (the known MCO-301 set).

`preview` label applied — the rendering is the half tests only partly cover, and the preview's Neon branch carries the real bank and the real world 11 demand, so the iron case can be checked against live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
