### PR TITLE
MCO-458, MCO-461: don't suggest a design for what the world already covers

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
@@ -78,7 +78,9 @@ suspend fun ApplicationCall.handleGetDetailContent() {
 
     // Same reason the threshold is here (MCO-401): switching lens must not look like the
     // suggestions disappeared.
-    val farmSuggestions = farmSuggestionsFor(plan, farmScaleThreshold, getUser().id, project.importedFromIdea?.first)
+    val farmSuggestions = farmSuggestionsFor(
+        plan, farmScaleThreshold, getUser().id, projectId, pendingFarms, project.importedFromIdea?.first,
+    )
 
     // The roll-up's threshold is a link to world settings for admins only, so the fragment
     // needs the same role answer the full page computes.

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -105,7 +105,9 @@ suspend fun ApplicationCall.handleGetProject() {
     // Designs in the bank that answer this plan's demand (MCO-294). Scoped to the viewer,
     // because the bank is public ideas plus their own — a shared computation would show one
     // user another's private designs.
-    val farmSuggestions = farmSuggestionsFor(plan, farmScaleThreshold, user.id, project.importedFromIdea?.first)
+    val farmSuggestions = farmSuggestionsFor(
+        plan, farmScaleThreshold, user.id, projectId, pendingFarms, project.importedFromIdea?.first,
+    )
 
     // ?drill=<item> deep-links into a target's chain so reload/share lands on the drill,
     // not the plan. Resolves only when the plan derives and the item is an actual target;

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/FarmSuggestion.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/FarmSuggestion.kt
@@ -2,6 +2,7 @@ package app.mcorg.pipeline.resources
 
 import app.mcorg.engine.plan.GatheringPlan
 import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.pipeline.project.resources.GetResourceProductionStep
 
 /**
  * An idea in the bank that produces something this plan demands (MCO-294).
@@ -67,6 +68,22 @@ data class IdeaProducer(
  * match on. [BLOCKED][PlanNodeStatus.BLOCKED] stays in: a farm for something the graph has no
  * source for is the *most* useful suggestion this can make.
  *
+ * ## What the world already covers is not demand (MCO-458, MCO-461)
+ *
+ * [PlanNodeStatus.SUPPLIED] catches only farms that are already `DONE` (MCO-287), which leaves two
+ * doors onto the same absurdity. A farm *under construction* — or one recorded through MCO-298
+ * with no source design at all — has its own build materials, so its plan would offer a design
+ * producing exactly what that farm produces. And a farm merely *planned* is matched too, so one
+ * page could carry MCO-299's notice ("63,213 Redstone Dust will come from Witch Hut Farm once it
+ * is running") beside a suggestion to import that same farm again.
+ *
+ * `alreadyCovered` closes both: an item some project in this world is already going to produce is
+ * not demand a design can answer, whatever state that project is in. The rule is deliberately
+ * blunt — a *bigger* design for a covered item is excluded too. A 924,000/h cobblestone farm is a
+ * real answer to demand a 231,000/h one cannot meet, but "your cobble farm needs 4,000 cobble,
+ * build this other cobble farm" is the wrong first read, and the upgrade case needs a rate
+ * comparison and UI copy that no real data has asked for yet. Even's call, 2026-08-25.
+ *
  * ## Why the unit is the idea, not the item
  *
  * A farm produces several things. The bank's stick producer **is** the Witch Hut Farm, which is
@@ -95,11 +112,19 @@ object FarmSuggestions {
      *
      * [producers] is the bank, already narrowed to what the viewer may see — this function is
      * pure and does no filtering of its own beyond the plan.
+     *
+     * [alreadyCovered] is every item this world is already going to produce; see the section
+     * above for why those are not demand at all rather than demand ranked lower.
      */
-    fun of(plan: GatheringPlan, threshold: Int, producers: List<IdeaProducer>): List<FarmSuggestion> {
+    fun of(
+        plan: GatheringPlan,
+        threshold: Int,
+        producers: List<IdeaProducer>,
+        alreadyCovered: Set<String> = emptySet(),
+    ): List<FarmSuggestion> {
         if (producers.isEmpty()) return emptyList()
 
-        val demand = matchableDemand(plan)
+        val demand = matchableDemand(plan, alreadyCovered)
         if (demand.isEmpty()) return emptyList()
 
         return producers
@@ -108,9 +133,10 @@ object FarmSuggestions {
     }
 
     /** itemId -> the demand a design could answer. */
-    private fun matchableDemand(plan: GatheringPlan): Map<String, DemandRow> =
+    private fun matchableDemand(plan: GatheringPlan, alreadyCovered: Set<String>): Map<String, DemandRow> =
         plan.activityList
             .filter { it.status != PlanNodeStatus.SUPPLIED && it.status != PlanNodeStatus.OPEN_TAG }
+            .filter { it.item.id !in alreadyCovered }
             .associate { it.item.id to DemandRow(it.item.id, it.item.name, it.quantity) }
 
     private data class DemandRow(val itemId: String, val itemName: String, val quantity: Long)
@@ -181,22 +207,30 @@ suspend fun farmSuggestionsFor(
     plan: GatheringPlan?,
     threshold: Int,
     viewerId: Int,
+    projectId: Int,
+    /**
+     * The not-yet-running farms MCO-299 is about to put a notice on this same page for.
+     *
+     * Taken as a parameter rather than re-queried on purpose — see [alreadyCoveredItems].
+     */
+    pendingFarms: List<PendingFarmSupply>,
     /**
      * The design this project was imported from, if any — never suggested back to it.
      *
-     * A farm costs materials to build, and a cobblestone farm costs cobblestone. Without this
-     * the farm's own plan matches its own design and offers to import the thing you are
-     * standing in. The narrow rule is deliberate: a *different* design producing the same item
-     * is still a fair suggestion (a bigger farm is a real answer to demand a small one cannot
-     * meet), so only the project's own source idea is excluded.
+     * Now largely subsumed by the project's own productions (MCO-458), since importing a design
+     * writes `project_productions`. It stays because it is the one exclusion that survives a
+     * project whose productions were edited away, and it costs nothing.
      */
     excludeIdeaId: Int? = null,
 ): List<FarmSuggestion> {
     if (plan == null) return emptyList()
 
+    val alreadyCovered = alreadyCoveredItems(projectId, pendingFarms)
+
     val demandedIds = plan.activityList
         .filter { it.status != PlanNodeStatus.SUPPLIED && it.status != PlanNodeStatus.OPEN_TAG }
         .map { it.item.id }
+        .filter { it !in alreadyCovered }
     if (demandedIds.isEmpty()) return emptyList()
 
     val producers = GetIdeaProducersStep
@@ -204,5 +238,39 @@ suspend fun farmSuggestionsFor(
         .getOrNull()
         ?: return emptyList()
 
-    return FarmSuggestions.of(plan, threshold, producers.filter { it.ideaId != excludeIdeaId })
+    return FarmSuggestions.of(
+        plan,
+        threshold,
+        producers.filter { it.ideaId != excludeIdeaId },
+        alreadyCovered,
+    )
+}
+
+/**
+ * Items this world is already going to produce, and so has no reason to be offered a design for.
+ *
+ * Two sources, one rule:
+ *
+ * * **This project's own productions** (MCO-458). A farm's build materials are demand like any
+ *   other, and a cobblestone farm costs cobblestone. Excluding the project's source design by id
+ *   closes the import door only: a farm recorded through MCO-298 has no `project_idea_id` to
+ *   exclude, and its productions are the thing that actually identifies what it makes.
+ * * **Farms planned but not running** (MCO-461), read off the notice MCO-299 already renders
+ *   rather than queried again. Sharing the value is the point — the notice and the suggestion
+ *   list cannot claim the same item while both are computed from one list, whereas two
+ *   independent reads of [GetWorldPlannedFarmsStep] could drift and put contradictory advice on
+ *   one page.
+ *
+ * Operational (`DONE`) farms need no entry here: MCO-287 already marks their items
+ * [PlanNodeStatus.SUPPLIED], which [FarmSuggestions] drops.
+ *
+ * A failed read of this project's productions degrades to excluding nothing — the same posture as
+ * every other decoration on the plan, and the reason this is not the only guard on the import.
+ */
+private suspend fun alreadyCoveredItems(
+    projectId: Int,
+    pendingFarms: List<PendingFarmSupply>,
+): Set<String> = buildSet {
+    GetResourceProductionStep.process(projectId).getOrNull().orEmpty().mapTo(this) { it.itemId }
+    pendingFarms.flatMapTo(this) { farm -> farm.items.map { it.itemId } }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -367,7 +367,9 @@ private suspend fun ApplicationCall.respondListRerender(worldId: Int, projectId:
     val farmScaleThreshold = GetFarmScaleThresholdStep.process(worldId).getOrNull()
         ?: World.DEFAULT_FARM_SCALE_THRESHOLD
     val user = getUser()
-    val farmSuggestions = farmSuggestionsFor(plan, farmScaleThreshold, user.id, project.importedFromIdea?.first)
+    val farmSuggestions = farmSuggestionsFor(
+        plan, farmScaleThreshold, user.id, projectId, pendingFarms, project.importedFromIdea?.first,
+    )
     val isAdmin = ValidateWorldMemberRole<Unit>(user, Role.ADMIN, worldId).process(Unit) is Result.Success
 
     respondHtml(

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/FarmSuggestionsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/resources/FarmSuggestionsTest.kt
@@ -251,6 +251,99 @@ class FarmSuggestionsTest {
         assertTrue(hours > 7.6 && hours < 7.7, "63,273 at 8,280/h is about 7.6 hours, got $hours")
     }
 
+    // ---- what the world already covers (MCO-458, MCO-461) ---------------------------
+
+    @Test
+    fun `a design for what this project itself produces is not suggested`() {
+        // The cobblestone farm costs 4,000 cobblestone to build, and was offered a cobblestone
+        // farm. Recorded by hand through MCO-298, it has no source design to exclude by id —
+        // its own productions are the only thing that says what it makes.
+        val theFarmsOwnPlan = plan(node(cobblestone, 4_000))
+
+        val result = FarmSuggestions.of(
+            theFarmsOwnPlan,
+            threshold,
+            listOf(producer(1, "231k Cobblestone farm", cobblestone to 231_000)),
+            alreadyCovered = setOf(cobblestone.id),
+        )
+
+        assertTrue(result.isEmpty(), "you cannot need what you produce")
+    }
+
+    @Test
+    fun `a bigger design for a covered item is excluded too`() {
+        // Deliberate, not an oversight: 924,000/h against your 231,000/h is a real answer to
+        // demand the small farm cannot meet, but not one worth reading as "build a second
+        // cobble farm". Excluded rather than ranked down - Even's call, 2026-08-25.
+        val cobblePlan = plan(node(cobblestone, 75_151))
+
+        val result = FarmSuggestions.of(
+            cobblePlan,
+            threshold,
+            listOf(producer(1, "924k Cobblestone farm", cobblestone to 924_000)),
+            alreadyCovered = setOf(cobblestone.id),
+        )
+
+        assertTrue(result.isEmpty(), "the upgrade case needs a rate comparison nobody has asked for")
+    }
+
+    @Test
+    fun `a design still qualifies on what the world does not cover`() {
+        val witchPlan = plan(node(redstone, 63_273), node(cobblestone, 75_151))
+
+        val suggestion = FarmSuggestions
+            .of(
+                witchPlan,
+                threshold,
+                listOf(producer(1, "Witch Hut Farm", redstone to 8280, cobblestone to 100)),
+                alreadyCovered = setOf(cobblestone.id),
+            )
+            .single()
+
+        assertEquals(listOf("minecraft:redstone"), suggestion.produces.map { it.itemId })
+        assertEquals(63_273, suggestion.unitsRemoved, "covered cobblestone is not work this removes")
+    }
+
+    @Test
+    fun `a covered item does not qualify a design on its own`() {
+        // Cobblestone is the only farm-scale line and the world already covers it, so the
+        // ride-along rule must not resurrect the design on the sub-threshold bottles.
+        val mixedPlan = plan(node(cobblestone, 75_151), node(glassBottle, 216))
+
+        val result = FarmSuggestions.of(
+            mixedPlan,
+            threshold,
+            listOf(producer(1, "Cobble and bottles", cobblestone to 924_000, glassBottle to 785)),
+            alreadyCovered = setOf(cobblestone.id),
+        )
+
+        assertTrue(result.isEmpty(), "216 bottles is still not a reason to build a farm")
+    }
+
+    @Test
+    fun `the mining under a covered item is not claimed either`() {
+        val ironPlan = plan(
+            node(ironIngot, 33_049, PlanNodeStatus.RESOLVED, listOf(PlanRequirement("minecraft:deepslate_iron_ore", 1))),
+            node(deepslateIronOre, 33_049),
+            node(redstone, 63_273),
+        )
+
+        val suggestion = FarmSuggestions
+            .of(
+                ironPlan,
+                threshold,
+                listOf(producer(1, "Iron and redstone", ironIngot to 3810, redstone to 8280)),
+                alreadyCovered = setOf(ironIngot.id),
+            )
+            .single()
+
+        assertEquals(listOf("minecraft:redstone"), suggestion.produces.map { it.itemId })
+        assertTrue(
+            suggestion.alsoRemoves.none { it.itemId == "minecraft:deepslate_iron_ore" },
+            "the ore feeds ingots the world already covers, so this design does not remove it: ${suggestion.alsoRemoves}",
+        )
+    }
+
     @Test
     fun `an empty bank suggests nothing`() {
         assertEquals(emptyList(), FarmSuggestions.of(plan(node(cobblestone, 75_151)), threshold, emptyList()))

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSuggestionIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSuggestionIT.kt
@@ -210,6 +210,62 @@ class FarmSuggestionIT : WithUser() {
         deleteIdea(published)
     }
 
+    @Test
+    fun `a farm recorded by hand is not suggested a design for what it produces`() {
+        // MCO-458's second door. `a project built from a design is not suggested that design`
+        // covers the import door, which excludes by project_idea_id; a farm recorded through
+        // MCO-298 has no such id, and used to be offered a design for its own output.
+        val world = createWorld("Recorded farm world")
+        val theFarm = createProject(world, "Hand-recorded Cobble Farm")
+        addProjectProduction(theFarm, cobblestone, rate = 231_000)
+        createResourceGathering(theFarm, cobblestone, required = 4_000)
+
+        testApplication {
+            setupRoutes()
+
+            val body = client.get("/worlds/$world/projects/$theFarm") { addAuthCookie(this) }.bodyAsText()
+
+            assertFalse(
+                body.contains("231k Cobblestone farm"),
+                "it produces cobblestone; a cobblestone design answers nothing it needs",
+            )
+            assertFalse(body.contains("plan-farm-scale__design"), "and so no design row at all")
+            // The demand itself is untouched — still farm-scale, still listed, just unanswered.
+            assertContains(body, "4,000")
+        }
+    }
+
+    @Test
+    fun `a farm already planned is not offered as an import`() {
+        // MCO-461. The identical fixture to `a design covering farm-scale demand is suggested
+        // on the plan` — which is the control showing the design *would* appear — plus a farm
+        // the world has already filed. MCO-299's notice and the suggestion cannot both claim
+        // the cobblestone.
+        val world = createWorld("Planned farm world")
+        val build = createProject(world, "Storage System")
+        createResourceGathering(build, cobblestone, required = 75_151)
+
+        val plannedFarm = createProject(world, "Filed Cobble Farm")
+        addProjectProduction(plannedFarm, cobblestone, rate = 231_000)
+
+        testApplication {
+            setupRoutes()
+
+            val body = client.get("/worlds/$world/projects/$build") { addAuthCookie(this) }.bodyAsText()
+
+            assertContains(body, "plan-pending-farms")
+            assertContains(body, "Filed Cobble Farm")
+            assertFalse(
+                body.contains("231k Cobblestone farm"),
+                "the notice says it is coming; offering to import a second cobble farm contradicts it",
+            )
+            assertFalse(
+                body.contains("Import into this world"),
+                "nothing left on this plan to import",
+            )
+        }
+    }
+
     // ---- routing ----------------------------------------------------------------
 
     private fun ApplicationTestBuilder.setupRoutes() {
@@ -276,6 +332,20 @@ class FarmSuggestionIT : WithUser() {
                 stmt.setString(2, item.id)
                 stmt.setString(3, item.name)
                 stmt.setInt(4, required)
+            }
+        ).process(Unit)
+    }
+
+    private fun addProjectProduction(projectId: Int, item: Item, rate: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO project_productions (project_id, item_id, name, rate_per_hour) VALUES (?, ?, ?, ?)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, item.id)
+                stmt.setString(3, item.name)
+                stmt.setInt(4, rate)
             }
         ).process(Unit)
     }


### PR DESCRIPTION
Closes MCO-458. Partially addresses MCO-461 — see *What is not here*.

## The bug

Farm suggestions (MCO-294) read only the plan, so `SUPPLIED` was the sole thing keeping a design off the list — and MCO-287 makes that `DONE` farms only. Two doors got past it, both found by Even verifying #414 on the preview:

- **MCO-458** — a farm project's own build materials are demand like any other, and a cobblestone farm costs cobblestone. MCO-294 excluded the project's source design by id, which closes the *import* door only. A farm recorded through MCO-298 has no `project_idea_id`, and was offered a design for its own output.
- **MCO-461** — a farm merely *planned* is invisible to `GetWorldFarmSuppliesStep`, so one page could carry MCO-299's notice ("63,213 Redstone Dust will come from Witch Hut Farm once it is running") beside a suggestion to import that same farm again. Two components, same page, same item, opposite advice.

## The fix

Both close on one input. `farmSuggestionsFor` now takes `projectId` and `pendingFarms`, and builds an `alreadyCovered` set that drops those items out of matchable demand — the same shape as the existing `SUPPLIED` filter.

`pendingFarms` is **passed in, not re-queried**. Every call site already computes it one line above for MCO-299's notice. Sharing the value makes "the notice and the suggestion list cannot both claim the same item" true by construction, where two independent reads of `GetWorldPlannedFarmsStep` could drift and put contradictory advice on one page.

Both new parameters are non-defaulted so the compiler enforces all three call sites — that wiring drift is how this bug class arises.

### The "bigger farm" decision

A *bigger* design for a covered item is **excluded too, not ranked down**. 924,000/h against your 231,000/h is a real answer to demand a small farm cannot meet, but "your cobble farm needs 4,000 cobble, build this other cobble farm" is the wrong first read, and the upgrade case wants a rate comparison and UI copy no real data has asked for yet. Even's call, 2026-08-25; reasoning is in the `FarmSuggestions` KDoc, per MCO-458's AC.

## What is not here

**MCO-461's second half** — making the pending farm read as a *prerequisite* rather than a notice. That needs a dependency edge, which is MCO-288/302 territory and wants deciding together with MCO-460 (those same derived edges producing roadmap cycles). MCO-461 stays open, blocked by MCO-460.

## Tests

- 5 unit tests in `FarmSuggestionsTest`, including one pinning the bigger-farm decision so it reads as deliberate.
- 2 ITs in `FarmSuggestionIT` (9 total, was 7) — one per door. The MCO-461 one has the existing `a design covering farm-scale demand is suggested on the plan` as its control: same fixture, minus the planned farm.
- Full suite green: 977 unit, 520 database.
- Neutered `alreadyCoveredItems` and re-ran: both new ITs fail on exactly the assertion they guard, other 7 still pass. Not vacuous.

No `preview` label — the change is a suppression, there is nothing new to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)