### PR TITLE
MCO-459: batch the suggested-farm imports into one review wizard

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -74,6 +74,22 @@ suspend fun ApplicationCall.handleReviewIdeaImport() {
     val taskId = request.queryParameters["forTask"]?.toIntOrNull()
     val items = GetItemsInWorldVersionStep.process(worldId).getOrNull() ?: emptyList()
 
+    // A batch started from a plan's suggestion list (MCO-459), or null for every other door
+    // into this screen. Resolved here rather than in the template so a hand-edited URL naming
+    // a design the batch never selected degrades to a plain single import.
+    val queue = ImportQueue.from(
+        request.queryParameters[ImportQueue.QUEUE_PARAM],
+        request.queryParameters[ImportQueue.RETURN_PARAM],
+    )
+    val wizard = queue?.positionOf(ideaId)?.let { position ->
+        ImportWizardStep(
+            position = position,
+            total = queue.size,
+            nextHref = queue.nextAfter(ideaId)?.let { queue.reviewHref(it, worldId) },
+            returnHref = queue.returnHref(worldId),
+        )
+    }
+
     handlePipeline(
         onSuccess = { idea: IdeaForImport ->
             // Same treatment as the schematic door for placed cells (MCO-396): drop the ones
@@ -97,10 +113,14 @@ suspend fun ApplicationCall.handleReviewIdeaImport() {
                     // carries the rates, which is the whole reason to record a farm you already
                     // built rather than re-typing them into the MCO-298 form.
                     offerAlreadyBuilt = true,
+                    wizard = wizard,
                     action = Link.Ideas.single(ideaId) + "/import",
                     hiddenFields = buildMap {
                         put("worldId", worldId.toString())
                         taskId?.let { put("forTask", it.toString()) }
+                        // Carried so the POST can hand the user to the next step without
+                        // re-deriving the batch from anywhere but the form it came from.
+                        if (wizard != null) putAll(queue!!.hiddenFields())
                     },
                 )
             )
@@ -134,6 +154,11 @@ suspend fun ApplicationCall.handleImportIdea() {
 
     val taskId = (submitted["forTask"] ?: parameters["forTask"])?.toIntOrNull()
 
+    val queue = ImportQueue.from(
+        submitted[ImportQueue.QUEUE_PARAM] ?: request.queryParameters[ImportQueue.QUEUE_PARAM],
+        submitted[ImportQueue.RETURN_PARAM] ?: request.queryParameters[ImportQueue.RETURN_PARAM],
+    )
+
     // An unchecked checkbox posts nothing at all, so presence is the signal — the same
     // reading every other checkbox on this screen gets.
     val alreadyBuilt = submitted["alreadyBuilt"] != null
@@ -142,7 +167,12 @@ suspend fun ApplicationCall.handleImportIdea() {
 
     handlePipeline(
         onSuccess = { projectId: Int ->
-            val target = Link.Worlds.world(worldId).project(projectId).to
+            // Mid-batch, the next design is where you want to be; at the end of one, the plan
+            // you started from. Only a lone import lands on the project it just made, which is
+            // MCO-457's rule and still right for the single case (MCO-459).
+            val target = queue
+                ?.let { it.nextAfter(ideaId)?.let { next -> it.reviewHref(next, worldId) } ?: it.returnHref(worldId) }
+                ?: Link.Worlds.world(worldId).project(projectId).to
             // The review page submits as a plain form, so a browser needs a real redirect;
             // an HX-Redirect header would be silently ignored and leave a blank page.
             if (request.headers["HX-Request"] == "true") {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportQueue.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportQueue.kt
@@ -1,0 +1,113 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.presentation.templated.dsl.Link
+
+/**
+ * The wizard's place in a batch import of suggested designs (MCO-459).
+ *
+ * MCO-294 renders a plan's farm-scale demand grouped by the design that covers it — on the
+ * dogfood world, seven designs against ten lines. Importing them was seven independent
+ * decisions: click Import, review, create, land on the *new* project, navigate back to the
+ * plan you were reading. Every individual step was right (MCO-306 put review there
+ * deliberately, MCO-457's redirect is correct for a single import); what was wrong is that a
+ * roadmap was being walked as if it were unrelated errands.
+ *
+ * ## Why the queue lives in the URL
+ *
+ * There is no server-side wizard state, no session key, no draft rows. The whole queue is two
+ * query parameters, so a review step is still exactly what [handleReviewIdeaImport] says it
+ * is — "a GET … reloadable and shareable rather than tied to one upload". Reloading step 2 of
+ * 3 lands on step 2 of 3. Closing the tab loses nothing that was not already created.
+ *
+ * ## Why each step creates instead of accumulating
+ *
+ * The alternative — collect every reviewed list and commit at the end — means carrying
+ * hundreds of material rows across N requests, and one validation failure at the end losing
+ * all of it. Creating as you go keeps each step atomic and exactly today's POST, and bailing
+ * out at 2 of 3 leaves two farms you did want. It is also self-healing: the plan you return to
+ * re-renders, and MCO-458/MCO-461's `alreadyCovered` means the farms you just made no longer
+ * appear as suggestions, so the third is still offered and nothing is double-imported.
+ */
+data class ImportQueue(
+    /** Every design selected on the plan, in the order the suggestion list showed them. */
+    val ideaIds: List<Int>,
+    /** The project whose plan the batch started from — where "Done" and the last step land. */
+    val returnToProjectId: Int,
+) {
+    val size: Int get() = ideaIds.size
+
+    /** 1-based position of [ideaId] for "Review N of M", or null when it is not in the queue. */
+    fun positionOf(ideaId: Int): Int? = ideaIds.indexOf(ideaId).takeIf { it >= 0 }?.plus(1)
+
+    /** The next design to review after [ideaId], or null when this is the last one. */
+    fun nextAfter(ideaId: Int): Int? {
+        val index = ideaIds.indexOf(ideaId)
+        if (index < 0) return null
+        return ideaIds.getOrNull(index + 1)
+    }
+
+    /** Where the wizard lands once there is nothing left to review. */
+    fun returnHref(worldId: Int): String =
+        Link.Worlds.world(worldId).project(returnToProjectId).to
+
+    /** The review URL for [ideaId], carrying the queue forward unchanged. */
+    fun reviewHref(ideaId: Int, worldId: Int): String =
+        Link.Ideas.single(ideaId) + "/import/review?worldId=$worldId&" + queryString()
+
+    /** The two parameters that carry this queue, for a link or a hidden field pair. */
+    fun queryString(): String = "$QUEUE_PARAM=${ideaIds.joinToString(",")}&$RETURN_PARAM=$returnToProjectId"
+
+    /** The same two, as hidden form fields for the review page to post back. */
+    fun hiddenFields(): Map<String, String> = mapOf(
+        QUEUE_PARAM to ideaIds.joinToString(","),
+        RETURN_PARAM to returnToProjectId.toString(),
+    )
+
+    companion object {
+        const val QUEUE_PARAM = "queue"
+        const val RETURN_PARAM = "returnTo"
+
+        /**
+         * Reads a queue from a request, or null when this is an ordinary single import.
+         *
+         * Null is the important case, not an error case: every existing door into the review
+         * screen (the idea page, the world picker, a bookmark) sends neither parameter and
+         * must keep behaving exactly as it did. A malformed or partial queue degrades to null
+         * for the same reason — a batch is a convenience, and losing it costs one navigation,
+         * where guessing at it could import into the wrong world.
+         *
+         * Duplicates are dropped rather than rejected. The plan cannot render one design twice,
+         * so a repeat is a hand-edited URL; deduping keeps [positionOf] and [nextAfter] honest
+         * (both key off the first index) instead of quietly looping.
+         */
+        fun from(rawQueue: String?, rawReturnTo: String?): ImportQueue? {
+            val returnTo = rawReturnTo?.toIntOrNull() ?: return null
+            val ids = rawQueue
+                ?.split(",")
+                ?.mapNotNull { it.trim().toIntOrNull() }
+                ?.distinct()
+                ?.takeIf { it.isNotEmpty() }
+                ?: return null
+            return ImportQueue(ids, returnTo)
+        }
+    }
+}
+
+/**
+ * One review step's place in the batch, as the page needs it (MCO-459).
+ *
+ * Built by the handler rather than by the template so the page stays a pure renderer, and so
+ * the "not actually in the queue" case — a hand-edited URL naming a design the batch never
+ * selected — is resolved server-side into a plain single import rather than a broken "Review
+ * 0 of 3".
+ */
+data class ImportWizardStep(
+    val position: Int,
+    val total: Int,
+    /** Review URL of the next design, or null on the last step. */
+    val nextHref: String?,
+    /** The plan this batch started from — "Done" now, and where the last create lands. */
+    val returnHref: String,
+) {
+    val isLast: Boolean get() = nextHref == null
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/StartFarmSuggestionImportPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/StartFarmSuggestionImportPipeline.kt
@@ -1,0 +1,66 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.presentation.handler.defaultHandleError
+import app.mcorg.presentation.templated.dsl.Link
+import app.mcorg.presentation.utils.clientRedirect
+import app.mcorg.presentation.utils.getProjectId
+import app.mcorg.presentation.utils.getWorldId
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.respond
+
+/** The checkbox name on each suggested design in the plan's farm-scale section (MCO-459). */
+const val SELECTED_DESIGN_FIELD = "design"
+
+/**
+ * Opens the batch review wizard for the designs ticked on a plan (MCO-459).
+ *
+ * This endpoint exists only because the wizard's first URL is not knowable until the form is
+ * submitted — it names the first *selected* idea. A GET form cannot build that, and the
+ * alternative is client-side URL assembly, which this codebase does not do for navigation.
+ * So the form posts here and this hands back a redirect; it creates nothing and validates
+ * nothing beyond the selection itself.
+ *
+ * Authorization is the route's, not this handler's: it sits inside the world/project block,
+ * so `WorldParticipantPlugin` has already run. Each review step then re-checks ADMIN on the
+ * world before showing anything, which is where the real gate has always been — this only
+ * decides which URL to open.
+ */
+suspend fun ApplicationCall.handleStartFarmSuggestionImport() {
+    val worldId = getWorldId()
+    val projectId = getProjectId()
+
+    val selected = receiveParameters()
+        .getAll(SELECTED_DESIGN_FIELD)
+        ?.mapNotNull { it.toIntOrNull() }
+        ?.distinct()
+        .orEmpty()
+
+    if (selected.isEmpty()) {
+        // Submitting with nothing ticked is a slip, not an error worth a page: the plan is
+        // where the user already is and where the checkboxes are.
+        return redirectTo(Link.Worlds.world(worldId).project(projectId).to)
+    }
+
+    val queue = ImportQueue(ideaIds = selected, returnToProjectId = projectId)
+    redirectTo(queue.reviewHref(selected.first(), worldId))
+}
+
+/**
+ * Sends the browser to [target].
+ *
+ * Mirrors [handleImportIdea]'s redirect exactly, and for the same reason: the plan's batch
+ * form is a plain POST, so a real 303 is what a browser needs. The HX branch is there because
+ * the fragment re-render paths (`PlanChainPipeline`) can render this section too, and an
+ * `HX-Redirect` on a non-HTMX request would silently leave a blank page.
+ */
+private suspend fun ApplicationCall.redirectTo(target: String) {
+    if (request.headers["HX-Request"] == "true") {
+        clientRedirect(target)
+    } else {
+        response.headers.append("Location", target)
+        respond(HttpStatusCode.SeeOther, "")
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -39,6 +39,7 @@ import app.mcorg.pipeline.project.handleGetProjectListFragment
 import app.mcorg.pipeline.project.handleGetFieldLogRow
 import app.mcorg.pipeline.project.handleGetFieldLogSliceItems
 import app.mcorg.pipeline.project.handleGetResumeRows
+import app.mcorg.pipeline.project.handleStartFarmSuggestionImport
 import app.mcorg.pipeline.project.handleUpdateProjectState
 import app.mcorg.pipeline.project.handleGetProjectNameField
 import app.mcorg.pipeline.project.handleUpdateProjectName
@@ -177,6 +178,11 @@ class WorldHandler {
                         }
                         patch("/state") {
                             call.handleUpdateProjectState()
+                        }
+                        // Opens the batch review wizard for the designs ticked on the plan
+                        // (MCO-459). Creates nothing itself — see the handler.
+                        post("/farm-suggestions/import") {
+                            call.handleStartFarmSuggestionImport()
                         }
                         route("/meta") {
                             get("/name") { call.handleGetProjectNameField() }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -5,6 +5,7 @@ import app.mcorg.domain.model.user.TokenProfile
 import app.mcorg.pipeline.project.ImportWarning
 import app.mcorg.pipeline.project.ImportWarningKind
 import app.mcorg.pipeline.project.ImportWarnings
+import app.mcorg.pipeline.project.ImportWizardStep
 import app.mcorg.pipeline.project.ResolvedRegion
 import app.mcorg.pipeline.project.ReviewedMaterial
 import app.mcorg.pipeline.project.ReviewedMaterialsCodec
@@ -67,6 +68,12 @@ import kotlinx.html.tr
  * [warnings] (MCO-305) name the painful rows without standing in their way. Advisory only —
  * every warned row arrives checked. Since MCO-397 the strip above the list carries only
  * creative-only rows, the one kind worth interrupting for; everything else is a row chip.
+ *
+ * [wizard] (MCO-459) makes this one step of a batch started from a plan's suggestion list.
+ * The screen itself is unchanged — the review is the point, and MCO-306 put it here on
+ * purpose — so the wizard adds only a position line, a Skip, a way out, and a submit that
+ * promises the next step rather than the end. Null for every other door in, which is what
+ * keeps a single import exactly what it was.
  */
 fun importReviewPage(
     user: TokenProfile,
@@ -81,6 +88,7 @@ fun importReviewPage(
     warnings: ImportWarnings = ImportWarnings(),
     unrecordableProductions: List<String> = emptyList(),
     offerAlreadyBuilt: Boolean = false,
+    wizard: ImportWizardStep? = null,
 ): String = pageShell(
     pageTitle = "Seam — review import",
     user = user,
@@ -105,6 +113,7 @@ fun importReviewPage(
     main {
         container {
             div("import-review__title") {
+                wizardProgress(wizard)
                 h1("import-review__heading") { +"Review this import" }
                 p("import-review__lead") {
                     +"Everything below will become a resource to gather. Uncheck what you are not building — you can add it back later from the project."
@@ -149,15 +158,59 @@ fun importReviewPage(
                         type = ButtonType.submit
                         // Both labels render and CSS shows one, as with the region toggle: the
                         // button is the last thing read before committing, and "Create project"
-                        // above a struck-through list would be the wrong promise.
-                        span("import-review__submit--planned") { +"Create project" }
-                        span("import-review__submit--built") { +"Record as built" }
+                        // above a struck-through list would be the wrong promise. Mid-batch
+                        // both gain "& next", for the same reason — the button should say where
+                        // it puts you (MCO-459).
+                        val next = if (wizard != null && !wizard.isLast) " & next" else ""
+                        span("import-review__submit--planned") { +"Create project$next" }
+                        span("import-review__submit--built") { +"Record as built$next" }
                     }
-                    a(classes = "btn btn--ghost") {
-                        href = "/worlds/$worldId/projects"
-                        +"Cancel"
+                    if (wizard != null) {
+                        // Skip is a link, not a form control: it must not submit. Passing on a
+                        // design is a real answer — the batch was selected against a plan, and
+                        // reading the list is when you find out one of them is wrong.
+                        wizard.nextHref?.let { href ->
+                            a(classes = "btn btn--ghost") {
+                                this.href = href
+                                +"Skip this one"
+                            }
+                        }
+                        a(classes = "btn btn--ghost") {
+                            href = wizard.returnHref
+                            +"Done, back to plan"
+                        }
+                    } else {
+                        a(classes = "btn btn--ghost") {
+                            href = "/worlds/$worldId/projects"
+                            +"Cancel"
+                        }
                     }
                 }
+            }
+        }
+    }
+}
+
+/**
+ * "Review 2 of 3", with a dot per design (MCO-459).
+ *
+ * The count is the whole point of the component: the complaint that opened MCO-459 was not
+ * that reviewing is slow, it was not knowing how much of it was left or how to get back. A
+ * bare review screen answers neither.
+ */
+private fun FlowContent.wizardProgress(wizard: ImportWizardStep?) {
+    if (wizard == null) return
+
+    div("import-review__wizard") {
+        span("import-review__wizard-count") { +"Review ${wizard.position} of ${wizard.total}" }
+        div("import-review__wizard-dots") {
+            repeat(wizard.total) { index ->
+                val state = when {
+                    index + 1 < wizard.position -> " import-review__wizard-dot--done"
+                    index + 1 == wizard.position -> " import-review__wizard-dot--current"
+                    else -> ""
+                }
+                span("import-review__wizard-dot$state") {}
             }
         }
     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -15,6 +15,7 @@ import app.mcorg.engine.plan.PlanOverrides
 import app.mcorg.engine.plan.SupplySource
 import app.mcorg.pipeline.resources.FarmScaleDemand
 import app.mcorg.pipeline.resources.FarmScaleDemands
+import app.mcorg.pipeline.project.SELECTED_DESIGN_FIELD
 import app.mcorg.pipeline.resources.FarmSuggestion
 import app.mcorg.presentation.hxDelete
 import app.mcorg.presentation.hxDeleteWithConfirm
@@ -513,7 +514,7 @@ fun FlowContent.gatheringPlanSections(
 
         // Above the work sections on purpose: this is not a step in the plan, it is the answer
         // to "what should I build first", and it is what turns one import into a roadmap.
-        farmScaleSection(farmScale, farmSuggestions, farmScaleThreshold, project.worldId, isWorldAdmin)
+        farmScaleSection(farmScale, farmSuggestions, farmScaleThreshold, project.worldId, project.id, isWorldAdmin)
 
         groupOrder.forEach { group ->
             val activities = byGroup[group] ?: return@forEach
@@ -581,6 +582,7 @@ private fun FlowContent.farmScaleSection(
     suggestions: List<FarmSuggestion>,
     threshold: Int,
     worldId: Int,
+    projectId: Int,
     canEditThreshold: Boolean,
 ) {
     if (demands.isEmpty() && suggestions.isEmpty()) return
@@ -614,7 +616,29 @@ private fun FlowContent.farmScaleSection(
             }
         }
 
-        suggestions.forEach { suggestion -> designRow(suggestion, worldId) }
+        // One form around every design so a batch is one submit (MCO-459). A plain POST, not
+        // HTMX: the wizard it opens is a sequence of full pages, and swapping a fragment in
+        // would leave the plan underneath claiming demand the first step is about to answer.
+        //
+        // Guarded on there being designs at all: this section also renders for a plan whose
+        // farm-scale demand nothing in the bank answers, and an empty form with a live submit
+        // is a button that does nothing.
+        if (suggestions.isNotEmpty()) form(classes = "plan-farm-scale__batch") {
+            method = FormMethod.post
+            action = "/worlds/$worldId/projects/$projectId/farm-suggestions/import"
+
+            suggestions.forEach { suggestion -> designRow(suggestion, worldId) }
+
+            div("plan-farm-scale__batch-actions") {
+                button(classes = "btn btn--sm btn--primary plan-farm-scale__batch-submit") {
+                    type = ButtonType.submit
+                    +"Review selected designs"
+                }
+                span("plan-farm-scale__batch-hint") {
+                    +"Reviewed one at a time, then back to this plan."
+                }
+            }
+        }
 
         if (unanswered.isNotEmpty()) {
             div("plan-farm-scale__unanswered") {
@@ -657,13 +681,24 @@ private fun FlowContent.farmScaleSection(
 private fun FlowContent.designRow(suggestion: FarmSuggestion, worldId: Int) {
     div("plan-farm-scale__design") {
         div("plan-farm-scale__design-head") {
-            a(classes = "plan-farm-scale__design-name") {
-                href = Link.Ideas.single(suggestion.ideaId)
-                +suggestion.ideaName
+            // The checkbox replaces the per-row "Import into this world" link rather than
+            // sitting beside it (MCO-459). Two doors to the same place on an already dense
+            // row is a choice nobody wants to make; selecting one design and submitting is
+            // the old flow exactly, one click longer, and every other route into the review
+            // screen still exists from the idea page itself.
+            label("plan-farm-scale__select") {
+                htmlFor = "design-select-${suggestion.ideaId}"
+                checkBoxInput(classes = "plan-farm-scale__select-box") {
+                    id = "design-select-${suggestion.ideaId}"
+                    name = SELECTED_DESIGN_FIELD
+                    value = suggestion.ideaId.toString()
+                }
+                span("plan-farm-scale__design-name") { +suggestion.ideaName }
             }
-            a(classes = "btn btn--sm btn--secondary plan-farm-scale__import") {
-                href = Link.Ideas.single(suggestion.ideaId) + "/import/review?worldId=$worldId"
-                +"Import into this world"
+            a(classes = "plan-farm-scale__design-link") {
+                href = Link.Ideas.single(suggestion.ideaId)
+                title = "Open ${suggestion.ideaName}"
+                +"View design"
             }
         }
         div("plan-farm-scale__list") {

--- a/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
@@ -7,6 +7,48 @@
     margin-bottom: var(--space-5);
 }
 
+/* MCO-459 — where you are in a batch started from a plan's suggestion list. Sits above the
+   heading because "2 of 3" is the thing that was missing, not a decoration on the title. */
+.import-review__wizard {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-bottom: var(--space-2);
+}
+
+.import-review__wizard-count {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+}
+
+.import-review__wizard-dots {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+}
+
+.import-review__wizard-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--border);
+}
+
+/* Done and current are both "accounted for"; the current one is larger rather than a
+   different hue, so the row still reads at a glance in one colour. */
+.import-review__wizard-dot--done {
+    background: var(--text-muted);
+}
+
+.import-review__wizard-dot--current {
+    width: 8px;
+    height: 8px;
+    background: var(--accent);
+}
+
 .import-review__heading {
     font-family: var(--font-ui);
     font-size: var(--text-xl);

--- a/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/project-detail.css
@@ -714,6 +714,70 @@
     text-decoration: underline;
 }
 
+/* MCO-459 — the batch. Selecting designs is the primary action of this section now, so the
+   checkbox sits where the name was and the name rides with it: one target, not two. */
+.plan-farm-scale__batch {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+
+.plan-farm-scale__select {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+    cursor: pointer;
+}
+
+.plan-farm-scale__select-box {
+    /* Nudged off the text baseline the label sets, so the box aligns with the name's cap
+       height rather than hanging below it. */
+    transform: translateY(2px);
+    cursor: pointer;
+}
+
+/* Demoted from a button to a quiet link (MCO-459): the row's action is now the checkbox, and
+   two buttons of equal weight on one row is a choice nobody asked to make. */
+.plan-farm-scale__design-link {
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.plan-farm-scale__design-link:hover {
+    color: var(--text-primary);
+    text-decoration: underline;
+}
+
+.plan-farm-scale__batch-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+    padding-left: var(--space-3);
+}
+
+/* Nothing ticked is the resting state of this section, and a live button there would invite a
+   submit that does nothing. Same :has(:checked) reading the import review uses for its own
+   submit, rather than JS keeping a disabled attribute in sync. */
+.plan-farm-scale__batch-submit {
+    opacity: 0.5;
+    pointer-events: none;
+}
+
+.plan-farm-scale__batch:has(.plan-farm-scale__select-box:checked) .plan-farm-scale__batch-submit {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.plan-farm-scale__batch-hint {
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
 /* The number that changes a decision: most designs cover their demand in minutes, and it is
    the rare multi-hour line that says a farm is a project rather than an afternoon. */
 .plan-farm-scale__rate {

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/ImportQueueTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/ImportQueueTest.kt
@@ -1,0 +1,128 @@
+package app.mcorg.pipeline.project
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * MCO-459 — the batch import wizard's whole state, which is two query parameters.
+ *
+ * The cases that matter here are the ones where the queue is *absent or wrong*: every existing
+ * door into the review screen sends neither parameter, and a single import must keep behaving
+ * exactly as it did before the wizard existed.
+ */
+class ImportQueueTest {
+
+    private val queue = ImportQueue(ideaIds = listOf(3, 7, 12), returnToProjectId = 42)
+
+    // ---- position and traversal ------------------------------------------------------
+
+    @Test
+    fun `position is 1-based so it can be read aloud`() {
+        assertEquals(1, queue.positionOf(3))
+        assertEquals(2, queue.positionOf(7))
+        assertEquals(3, queue.positionOf(12))
+    }
+
+    @Test
+    fun `a design outside the queue has no position`() {
+        // A hand-edited URL naming a design the batch never selected. The handler turns this
+        // into a plain single import rather than rendering "Review 0 of 3".
+        assertNull(queue.positionOf(99))
+    }
+
+    @Test
+    fun `next walks the queue and stops at the end`() {
+        assertEquals(7, queue.nextAfter(3))
+        assertEquals(12, queue.nextAfter(7))
+        assertNull(queue.nextAfter(12), "the last step has nowhere to go but the plan")
+    }
+
+    @Test
+    fun `next from outside the queue is null`() {
+        assertNull(queue.nextAfter(99))
+    }
+
+    // ---- parsing ---------------------------------------------------------------------
+
+    @Test
+    fun `a queue round-trips through its own query string`() {
+        val parsed = ImportQueue.from("3,7,12", "42")
+
+        assertEquals(queue, parsed)
+    }
+
+    @Test
+    fun `no parameters means no batch`() {
+        // The important case, not an error case: the idea page, the world picker and any
+        // bookmark all arrive this way and must stay single imports.
+        assertNull(ImportQueue.from(null, null))
+    }
+
+    @Test
+    fun `a queue without a return target is not a batch`() {
+        // Without it there is nowhere to land at the end, which is the whole feature.
+        assertNull(ImportQueue.from("3,7,12", null))
+    }
+
+    @Test
+    fun `a return target without a queue is not a batch`() {
+        assertNull(ImportQueue.from(null, "42"))
+    }
+
+    @Test
+    fun `garbage degrades to no batch rather than a partial one`() {
+        assertNull(ImportQueue.from("nonsense", "42"))
+        assertNull(ImportQueue.from("3,7,12", "nonsense"))
+        assertNull(ImportQueue.from("", "42"))
+    }
+
+    @Test
+    fun `unparseable ids are dropped, not fatal`() {
+        val parsed = ImportQueue.from("3,oops,12", "42")
+
+        assertEquals(listOf(3, 12), parsed?.ideaIds)
+    }
+
+    @Test
+    fun `duplicates are dropped so the wizard cannot loop`() {
+        // The plan cannot render one design twice, so this is a hand-edited URL. Keeping the
+        // repeat would make nextAfter(3) return 3 forever, since both key off the first index.
+        val parsed = ImportQueue.from("3,7,3,12", "42")
+
+        assertEquals(listOf(3, 7, 12), parsed?.ideaIds)
+        assertEquals(7, parsed?.nextAfter(3))
+    }
+
+    @Test
+    fun `whitespace around ids is tolerated`() {
+        assertEquals(listOf(3, 7), ImportQueue.from(" 3 , 7 ", "42")?.ideaIds)
+    }
+
+    // ---- links -----------------------------------------------------------------------
+
+    @Test
+    fun `the review link carries the world and the whole queue`() {
+        val href = queue.reviewHref(ideaId = 7, worldId = 5)
+
+        assertTrue(href.contains("/import/review?worldId=5"), href)
+        assertTrue(href.contains("queue=3,7,12"), href)
+        assertTrue(href.contains("returnTo=42"), href)
+    }
+
+    @Test
+    fun `done lands on the plan the batch started from`() {
+        assertEquals("/worlds/5/projects/42", queue.returnHref(worldId = 5))
+    }
+
+    @Test
+    fun `hidden fields carry the same two values the URL does`() {
+        // The POST reads the queue back off the form, so the two encodings must agree.
+        val fields = queue.hiddenFields()
+
+        assertEquals("3,7,12", fields[ImportQueue.QUEUE_PARAM])
+        assertEquals("42", fields[ImportQueue.RETURN_PARAM])
+        assertEquals(queue, ImportQueue.from(fields[ImportQueue.QUEUE_PARAM], fields[ImportQueue.RETURN_PARAM]))
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/BatchImportWizardIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/BatchImportWizardIT.kt
@@ -1,0 +1,366 @@
+package app.mcorg.presentation.handler.project
+
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.project.ImportQueue
+import app.mcorg.pipeline.project.ReviewedMaterial
+import app.mcorg.pipeline.project.ReviewedMaterialsCodec
+import app.mcorg.pipeline.project.handleImportIdea
+import app.mcorg.pipeline.project.handleReviewIdeaImport
+import app.mcorg.pipeline.project.handleStartFarmSuggestionImport
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.presentation.plugins.AuthPlugin
+import app.mcorg.presentation.plugins.IdeaParamPlugin
+import app.mcorg.presentation.plugins.ProjectParamPlugin
+import app.mcorg.presentation.plugins.WorldParamPlugin
+import app.mcorg.presentation.plugins.WorldParticipantPlugin
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * MCO-459 — importing several suggested designs without losing the plan you were reading.
+ *
+ * `ImportQueueTest` covers the queue arithmetic. This covers the two things only the real
+ * doors can answer: that each step hands off to the next instead of to the project it just
+ * made, and that a lone import is untouched by any of it.
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class BatchImportWizardIT : WithUser() {
+
+    private val version = MinecraftVersion.Release(1, 21, 4)
+
+    private var worldId: Int = 0
+    private var planProjectId: Int = 0
+    private var first: Int = 0
+    private var second: Int = 0
+    private var third: Int = 0
+    private var unselected: Int = 0
+
+    @BeforeAll
+    fun setup() {
+        seedItems(listOf("minecraft:oak_planks" to "Oak Planks", "minecraft:iron_ingot" to "Iron Ingot"))
+
+        worldId = createWorld("Batch import world")
+        planProjectId = createProject(worldId, "Storage System")
+
+        first = createIdea("First Farm")
+        addRequirement(first, "minecraft:oak_planks", 32)
+        second = createIdea("Second Farm")
+        addRequirement(second, "minecraft:oak_planks", 16)
+        third = createIdea("Third Farm")
+        addRequirement(third, "minecraft:oak_planks", 8)
+        unselected = createIdea("Unselected Farm")
+        addRequirement(unselected, "minecraft:oak_planks", 4)
+    }
+
+    // ---- opening the batch ---------------------------------------------------------
+
+    @Test
+    fun `selecting designs opens the first review carrying the whole queue`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+        val before = countProjects()
+
+        val response = client.post(batchUrl()) {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("design=$first&design=$second&design=$third")
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val location = response.headers["Location"]!!
+        assertContains(location, "/ideas/$first/import/review")
+        assertContains(location, "worldId=$worldId")
+        assertContains(location, "queue=$first,$second,$third")
+        assertContains(location, "returnTo=$planProjectId")
+        assertEquals(before, countProjects(), "opening the wizard creates nothing")
+    }
+
+    @Test
+    fun `submitting with nothing selected goes back to the plan`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        val response = client.post(batchUrl()) {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("")
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status)
+        assertEquals("/worlds/$worldId/projects/$planProjectId", response.headers["Location"])
+    }
+
+    // ---- the review step knows where it is -----------------------------------------
+
+    @Test
+    fun `the review says which design of how many this is`() = testApplication {
+        setupRoutes()
+
+        val body = client.get(reviewUrl(second, listOf(first, second, third))) { addAuthCookie(this) }.bodyAsText()
+
+        assertContains(body, "Review 2 of 3")
+        assertContains(body, "Skip this one")
+        assertContains(body, "Done, back to plan")
+        assertContains(body, "Create project &amp; next")
+        // The POST reads the queue back off the form, so it has to travel in the form too.
+        assertContains(body, """name="${ImportQueue.QUEUE_PARAM}"""")
+        assertContains(body, """name="${ImportQueue.RETURN_PARAM}"""")
+    }
+
+    @Test
+    fun `the last step offers no skip and promises no next`() = testApplication {
+        setupRoutes()
+
+        val body = client.get(reviewUrl(third, listOf(first, second, third))) { addAuthCookie(this) }.bodyAsText()
+
+        assertContains(body, "Review 3 of 3")
+        assertFalse(body.contains("Skip this one"), "there is nothing after this one to skip to")
+        assertFalse(body.contains("&amp; next"), "the button must not promise a step that does not exist")
+        assertContains(body, "Done, back to plan")
+    }
+
+    @Test
+    fun `a design the batch never selected reviews as a plain single import`() = testApplication {
+        setupRoutes()
+
+        // A hand-edited URL. Rendering "Review 0 of 3" would be worse than ignoring the queue.
+        val body = client.get(reviewUrl(unselected, listOf(first, second))) { addAuthCookie(this) }.bodyAsText()
+
+        assertFalse(body.contains("Review 1 of"), body.substringAfter("import-review__title").take(200))
+        assertFalse(body.contains("Done, back to plan"))
+        assertContains(body, "Cancel", message = "it falls back to the ordinary review screen")
+    }
+
+    @Test
+    fun `an ordinary review is untouched by the wizard`() = testApplication {
+        setupRoutes()
+
+        val body = client.get("/ideas/$first/import/review?worldId=$worldId") { addAuthCookie(this) }.bodyAsText()
+
+        assertFalse(body.contains("Review 1 of"))
+        assertContains(body, "Create project")
+        assertContains(body, "Cancel")
+    }
+
+    // ---- creating hands off to the next step ---------------------------------------
+
+    @Test
+    fun `creating mid-batch lands on the next design, not the project just made`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        val response = client.post("/ideas/$first/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "worldId=$worldId&name=First Farm&" +
+                    queueFields(listOf(first, second, third)) + "&" +
+                    materials("minecraft:oak_planks" to 32)
+            )
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val location = response.headers["Location"]!!
+        assertContains(location, "/ideas/$second/import/review")
+        assertContains(location, "queue=$first,$second,$third", message = "the queue survives the hop")
+        // It really did create — this is a hand-off, not a detour.
+        assertEquals(1, countProjectsNamed("First Farm"))
+    }
+
+    @Test
+    fun `the last create lands back on the plan the batch started from`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        val response = client.post("/ideas/$third/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "worldId=$worldId&name=Third Farm&" +
+                    queueFields(listOf(first, second, third)) + "&" +
+                    materials("minecraft:oak_planks" to 8)
+            )
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        assertEquals("/worlds/$worldId/projects/$planProjectId", response.headers["Location"])
+        assertEquals(1, countProjectsNamed("Third Farm"))
+    }
+
+    @Test
+    fun `a lone import still lands on the project it just made`() = testApplication {
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        // MCO-457's rule, and the reason the queue is optional rather than always-on.
+        val response = client.post("/ideas/$second/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody("worldId=$worldId&name=Lone Farm&" + materials("minecraft:oak_planks" to 16))
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val location = response.headers["Location"]!!
+        val projectId = location.substringAfterLast("/").toInt()
+        assertEquals("/worlds/$worldId/projects/$projectId", location)
+        assertFalse(projectId == planProjectId, "it lands on the new project, not the plan")
+    }
+
+    // ---- routing --------------------------------------------------------------------
+
+    private fun ApplicationTestBuilder.setupRoutes() {
+        routing {
+            install(AuthPlugin)
+            route("/ideas/{ideaId}") {
+                install(IdeaParamPlugin)
+                route("/import") {
+                    get("/review") { call.handleReviewIdeaImport() }
+                    post { call.handleImportIdea() }
+                }
+            }
+            route("/worlds/{worldId}") {
+                install(WorldParamPlugin)
+                install(WorldParticipantPlugin)
+                route("/projects/{projectId}") {
+                    install(ProjectParamPlugin)
+                    post("/farm-suggestions/import") { call.handleStartFarmSuggestionImport() }
+                }
+            }
+        }
+    }
+
+    private fun batchUrl() = "/worlds/$worldId/projects/$planProjectId/farm-suggestions/import"
+
+    private fun reviewUrl(ideaId: Int, queue: List<Int>) =
+        "/ideas/$ideaId/import/review?worldId=$worldId" +
+            "&${ImportQueue.QUEUE_PARAM}=${queue.joinToString(",")}" +
+            "&${ImportQueue.RETURN_PARAM}=$planProjectId"
+
+    private fun queueFields(queue: List<Int>) =
+        "${ImportQueue.QUEUE_PARAM}=${queue.joinToString(",")}&${ImportQueue.RETURN_PARAM}=$planProjectId"
+
+    private fun materials(vararg rows: Pair<String, Int>): String {
+        val encoded = ReviewedMaterialsCodec.encode(
+            rows.map { (id, amount) -> ReviewedMaterial(id, amount, included = true) }
+        )
+        return "${ReviewedMaterialsCodec.FIELD}=$encoded"
+    }
+
+    // ---- fixtures --------------------------------------------------------------------
+
+    private fun createWorld(name: String): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(name = name, description = "test", version = version)
+        )
+        (result as Result.Success).value
+    }
+
+    private fun createProject(worldId: Int, name: String): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, state, location_x, location_y, location_z, location_dimension) " +
+                    "VALUES (?, ?, '', 'BUILDING', 'PLANNING', ?, 0, 0, 0, 'OVERWORLD') RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, name)
+                stmt.setInt(2, worldId)
+                stmt.setString(3, ProjectState.ACTIVE.name)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun seedItems(items: List<Pair<String, String>>) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert("INSERT INTO minecraft_version (version) VALUES ('1.21.4') ON CONFLICT DO NOTHING"),
+            parameterSetter = { _, _ -> }
+        ).process(Unit)
+        DatabaseSteps.batchUpdate<Pair<String, String>>(
+            SafeSQL.insert(
+                "INSERT INTO minecraft_items (version, item_id, item_name) VALUES ('1.21.4', ?, ?) ON CONFLICT DO NOTHING"
+            ),
+            parameterSetter = { stmt, (itemId, itemName) ->
+                stmt.setString(1, itemId)
+                stmt.setString(2, itemName)
+            }
+        ).process(items)
+    }
+
+    private fun createIdea(name: String): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                """
+                INSERT INTO ideas (name, description, category, author, difficulty, minecraft_version_range, category_data, created_by)
+                VALUES (?, 'test idea', 'FARM', '{"type":"single","name":"tester"}'::jsonb, 'EASY',
+                        '{"type":"app.mcorg.domain.model.minecraft.MinecraftVersionRange.Unbounded"}'::jsonb, '{}'::jsonb, ?)
+                RETURNING id
+                """.trimIndent()
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, name)
+                stmt.setInt(2, user.id)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun addRequirement(ideaId: Int, itemId: String, quantity: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            SafeSQL.insert("INSERT INTO idea_item_requirements (idea_id, item_id, quantity) VALUES (?, ?, ?)"),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, ideaId)
+                stmt.setString(2, itemId)
+                stmt.setInt(3, quantity)
+            }
+        ).process(Unit)
+    }
+
+    private fun countProjects(): Int = runBlocking {
+        val result = DatabaseSteps.query<Int, Int>(
+            sql = SafeSQL.select("SELECT COUNT(*) FROM projects WHERE world_id = ?"),
+            parameterSetter = { stmt, id -> stmt.setInt(1, id) },
+            resultMapper = { rs -> if (rs.next()) rs.getInt(1) else 0 }
+        ).process(worldId)
+        (result as Result.Success).value
+    }
+
+    private fun countProjectsNamed(name: String): Int = runBlocking {
+        val result = DatabaseSteps.query<String, Int>(
+            sql = SafeSQL.select("SELECT COUNT(*) FROM projects WHERE world_id = ? AND name = ?"),
+            parameterSetter = { stmt, n ->
+                stmt.setInt(1, worldId)
+                stmt.setString(2, n)
+            },
+            resultMapper = { rs -> if (rs.next()) rs.getInt(1) else 0 }
+        ).process(name)
+        (result as Result.Success).value
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSuggestionIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSuggestionIT.kt
@@ -118,8 +118,11 @@ class FarmSuggestionIT : WithUser() {
         assertContains(body, "plan-farm-scale")
         assertContains(body, "231k Cobblestone farm")
         assertContains(body, "75,151")
-        // The action is the review screen (MCO-457's door), not a direct create.
-        assertContains(body, "/ideas/$myFarmIdea/import/review?worldId=$worldId")
+        // Since MCO-459 the row's action is a checkbox feeding the batch form, not a link
+        // straight to the review. The review is still where it leads — one step later, and
+        // for every design ticked at once (BatchImportWizardIT owns that flow).
+        assertContains(body, "design-select-$myFarmIdea")
+        assertContains(body, "/worlds/$worldId/projects/$projectId/farm-suggestions/import")
     }
 
     @Test
@@ -164,7 +167,7 @@ class FarmSuggestionIT : WithUser() {
         val body = client.get("/worlds/$worldId/projects/$theFarm") { addAuthCookie(this) }.bodyAsText()
 
         assertFalse(
-            body.contains("Import into this world"),
+            body.contains("design-select-$myFarmIdea"),
             "you cannot need the design you are building",
         )
         // The demand is still farm-scale and still listed — it just has no answer now.
@@ -260,8 +263,8 @@ class FarmSuggestionIT : WithUser() {
                 "the notice says it is coming; offering to import a second cobble farm contradicts it",
             )
             assertFalse(
-                body.contains("Import into this world"),
-                "nothing left on this plan to import",
+                body.contains("plan-farm-scale__batch"),
+                "with nothing to suggest there is no batch to open",
             )
         }
     }


### PR DESCRIPTION
Closes MCO-459.

> There's a lot of clicking now. I imported one, ended up there, then another for that, and ended up there. Then I have to go back to the original.

MCO-294 renders a plan's farm-scale demand grouped by the design that covers it — seven designs against ten lines on the dogfood world. Importing them was seven independent decisions: click Import → review → create → land on the *new* project → navigate back to the plan you were reading.

Every individual step was right. MCO-306 put review behind a screen deliberately, and MCO-457's redirect-to-the-new-project is correct for a single import. What was wrong is that a **roadmap** was being walked as if it were unrelated errands.

## The shape

The review screen stays, per design — it is the point, and the material list is where you find out one of the seven is wrong. What changes is that the steps know about each other.

| | Before | After |
|---|---|---|
| Choosing | one design at a time | tick several, one submit |
| Position | none | `Review 2 of 3` + dots |
| Passing on one | back out entirely | Skip this one |
| After create | the new project | the next design, then the plan |
| Single import | new project | **unchanged** |

## The whole wizard state is two query parameters

`?queue=14,15&returnTo=43`. No session, no draft rows. A review step stays exactly what its own KDoc claims — *"a GET … reloadable and shareable rather than tied to one upload"*. Reloading step 2 of 3 lands on step 2 of 3.

**Each step creates rather than accumulating.** Collecting every reviewed list and committing at the end would mean carrying hundreds of material rows across N requests, with one validation failure at the end losing all of it. Creating as you go keeps each step atomic and exactly today's POST, and bailing at 2 of 3 leaves two farms you did want. It is also self-healing: the plan you return to re-renders, and MCO-458/MCO-461's `alreadyCovered` (#417) means the farms you just made are no longer suggested — so the third is still offered and nothing is double-imported.

## The one call worth arguing with

The per-row "Import into this world" link is **replaced** by the checkbox rather than joined by it. Two equal-weight actions on an already dense row is a choice nobody asked to make, and the idea page still has its own import door.

Three assertions in `FarmSuggestionIT` are repointed at the checkbox as a result — one was failing legitimately, and **two were mine from #417 that had gone vacuous**: they asserted the absence of a string that no longer renders for any design, so they would have passed with the bug present.

## Not included

- **Dependency edges between the batch.** MCO-288 already derives farm-supply edges from productions and demand; explicit ones here would pre-empt MCO-302 and walk straight into MCO-460's cycles.
- **The recursion.** An imported farm's own suggestions are left to the next plan view rather than offered in the same pass — that has no natural bound.

## Tests

- 15 unit (`ImportQueueTest`) — mostly the cases where the queue is *absent or wrong*, since every existing door sends neither parameter and a single import must be untouched.
- 9 ITs (`BatchImportWizardIT`) — the hand-off, the last step, the hand-edited URL naming a design the batch never selected, and a lone import still landing on its own project.
- Full suite: **992 unit, 529 database**, green.

## Verified in the running app

Not only under test. Seeded a plan wanting 75,151 cobblestone and 63,213 redstone plus two covering designs, then drove it: ticked both → `Review 1 of 2` → Create & next → `Review 2 of 2` (no Skip, no "& next") → Create → back on the plan. Both projects in the DB with idea links, productions and reviewed material lists. No exceptions, no 5xx. Checked at 1440 and 375.

The part worth seeing: **after the batch the suggestion list is gone and MCO-299's notices have replaced it** — *"75151 Cobblestone will come from Cobblestone Farm 231k once it is running"*. That is #417 reacting to farms this wizard just created, and MCO-461's "the notice and the suggestion list cannot both claim the same item" observed rather than argued.

A test also caught a bug I had written: the batch form rendered with zero suggestions, giving an empty form and a dead button on any plan nothing answers. Guarded.

No `preview` label — verified locally instead; happy to add one if you want the eyeball on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)