### PR TITLE
MCO-460, MCO-461: cycles are real, and a planned farm is a prerequisite

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/world/Roadmap.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/world/Roadmap.kt
@@ -10,16 +10,32 @@ import app.mcorg.domain.model.project.ProjectType
  * traversal and visualization of project relationships.
  *
  * Business Rules:
- * - No circular dependencies are allowed (enforced at creation time)
  * - All dependencies must be within the same world
  * - Projects can have multiple dependencies and dependents
+ *
+ * **Cycles exist and are not an error (MCO-460).** This said "no circular dependencies are
+ * allowed (enforced at creation time)" until 2026-08-25, and nothing enforced it — because
+ * nothing could. Edges are derived from real demand, so two farms that each consume a
+ * farm-scale amount of the other's output close a genuine loop out of two true facts. See
+ * [cycles] for what the roadmap does about it.
  */
 data class Roadmap(
     val worldId: Int,
     val worldName: String,
     val nodes: List<RoadmapNode>,
     val edges: List<RoadmapEdge>,
-    val layers: List<RoadmapLayer>
+    val layers: List<RoadmapLayer>,
+    /**
+     * Loops in the derived graph that no rule broke, each with the edge currently set aside
+     * so that [layers] stays consistent, and the alternatives a person can pick instead.
+     *
+     * Empty is the normal case: MCO-401's farm-scale threshold drops footnote-sized edges
+     * before they get here, which breaks most real loops. What lands here is two or more
+     * farms genuinely waiting on each other.
+     */
+    val cycles: List<RoadmapCycle> = emptyList(),
+    /** Pairs a person has already ordered by hand, so the choice can be seen and changed. */
+    val resolvedOrders: List<RoadmapCycleOrder> = emptyList(),
 ) {
     /**
      * Gets all root nodes (projects with no dependencies)
@@ -200,3 +216,63 @@ data class RoadmapStatistics(
     fun hasBlockedProjects(): Boolean = blockedProjects > 0
 }
 
+
+/**
+ * A loop in the derived dependency graph (MCO-460).
+ *
+ * Detected as a strongly connected component, not inferred from what the layering pass failed
+ * to place: "unplaced" also catches everything downstream of a loop, which would name innocent
+ * projects as part of a cycle they merely depend on.
+ *
+ * [breaking] is applied so [Roadmap.layers] is consistent the first time the page renders —
+ * a roadmap that showed two projects each claiming to block the other would be the bug this
+ * fixes. It is a guess, and the page says so; [options] is what the user picks from instead.
+ */
+data class RoadmapCycle(
+    val projectIds: List<Int>,
+    val projectNames: List<String>,
+    /** Every edge in the loop, each phrased as "set this aside and X comes first". */
+    val options: List<RoadmapCycleOption>,
+    /** The option in force until someone chooses — the smallest claim in the loop. */
+    val breaking: RoadmapCycleOption,
+    /**
+     * Whether this loop is worth interrupting someone for.
+     *
+     * False when [breaking] carries less than the world's farm-scale threshold: below that line
+     * the smallest claim is a footnote, giving way is the obvious answer rather than a judgement
+     * call, and the loop is broken silently. Such a cycle is still *broken* — it just never
+     * reaches the page. Only balanced loops, where both claims are farm-scale, are questions.
+     */
+    val needsAnAnswer: Boolean = true,
+)
+
+/**
+ * One way to break a cycle: set aside [firstProjectName]'s demand on [waitingProjectName],
+ * so the first no longer waits on the second.
+ *
+ * Phrased as "which comes first" rather than "which edge to delete" because that is the
+ * question a person can actually answer about their own world.
+ */
+data class RoadmapCycleOption(
+    /** The consumer of the set-aside edge — freed, so it comes first. */
+    val firstProjectId: Int,
+    val firstProjectName: String,
+    /** The producer of the set-aside edge — still waits on the first. */
+    val waitingProjectId: Int,
+    val waitingProjectName: String,
+    /**
+     * What the first project needs from the second, or null when the edge is a declared
+     * `project_dependencies` row rather than derived demand — see
+     * [ProjectResourceEdge.quantity][app.mcorg.domain.model.project.ProjectResourceEdge.quantity].
+     */
+    val itemName: String?,
+    val quantity: Long?,
+)
+
+/** A pair a person has ordered by hand, as stored in `roadmap_cycle_order` (MCO-460). */
+data class RoadmapCycleOrder(
+    val firstProjectId: Int,
+    val firstProjectName: String,
+    val waitingProjectId: Int,
+    val waitingProjectName: String,
+)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetDetailContentPipeline.kt
@@ -10,6 +10,7 @@ import app.mcorg.pipeline.resources.GetFarmScaleThresholdStep
 import app.mcorg.pipeline.resources.farmSuggestionsFor
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
 import app.mcorg.pipeline.resources.pendingFarmSuppliesFor
+import app.mcorg.pipeline.resources.prerequisiteFarmsFor
 import app.mcorg.pipeline.resources.commonsteps.GetAllResourceGatheringItemsStep
 import app.mcorg.pipeline.resources.commonsteps.GetProgressForProjectStep
 import app.mcorg.pipeline.task.SearchTasksInput
@@ -69,7 +70,13 @@ suspend fun ApplicationCall.handleGetDetailContent() {
     // Load persisted progress for all items in the project (covers derived activities too)
     val progressMap = GetProgressForProjectStep.process(projectId).getOrNull() ?: emptyMap()
 
-    val pendingFarms = pendingFarmSuppliesFor(worldId, projectId, plan)
+    // Two different questions, deliberately two sources (MCO-461):
+    //  - what the world already covers, for suppressing a suggestion (#417) — no threshold,
+    //    because a farm that covers an item makes a second design for it pointless at any size
+    //  - what this project *waits on*, for the prerequisite line — thresholded and
+    //    cycle-ordered, because that is an ordering claim and shares the roadmap's rules
+    val coveredByPlannedFarms = pendingFarmSuppliesFor(worldId, projectId, plan)
+    val prerequisiteFarms = prerequisiteFarmsFor(worldId, projectId)
 
     // Same fallback as the full page (MCO-401): the lens fragment must not silently drop the
     // farm-scale roll-up, or switching lens would look like the markers disappeared.
@@ -79,7 +86,7 @@ suspend fun ApplicationCall.handleGetDetailContent() {
     // Same reason the threshold is here (MCO-401): switching lens must not look like the
     // suggestions disappeared.
     val farmSuggestions = farmSuggestionsFor(
-        plan, farmScaleThreshold, getUser().id, projectId, pendingFarms, project.importedFromIdea?.first,
+        plan, farmScaleThreshold, getUser().id, projectId, coveredByPlannedFarms, project.importedFromIdea?.first,
     )
 
     // The roll-up's threshold is a link to world settings for admins only, so the fragment
@@ -88,7 +95,7 @@ suspend fun ApplicationCall.handleGetDetailContent() {
 
     respondHtml(
         gatheringPlannerFragment(
-            project, resources, tasks, plan, lens, progressMap, pendingFarms, farmScaleThreshold,
+            project, resources, tasks, plan, lens, progressMap, prerequisiteFarms, farmScaleThreshold,
             farmSuggestions, isAdmin,
         )
     )

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/GetProjectPipeline.kt
@@ -14,6 +14,7 @@ import app.mcorg.pipeline.resources.GetFarmScaleThresholdStep
 import app.mcorg.pipeline.resources.farmSuggestionsFor
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
 import app.mcorg.pipeline.resources.pendingFarmSuppliesFor
+import app.mcorg.pipeline.resources.prerequisiteFarmsFor
 import app.mcorg.pipeline.resources.GetPlanOverridesStep
 import app.mcorg.pipeline.resources.buildCandidateCounts
 import app.mcorg.pipeline.resources.buildNodeIngredients
@@ -94,8 +95,13 @@ suspend fun ApplicationCall.handleGetProject() {
     // Load persisted progress for all items in the project (covers derived activities too)
     val progressMap = GetProgressForProjectStep.process(projectId).getOrNull() ?: emptyMap()
 
-    // Farms promised but not running yet — the plan's partial-dependency notice (MCO-299)
-    val pendingFarms = pendingFarmSuppliesFor(worldId, projectId, plan)
+    // Two different questions, deliberately two sources (MCO-461):
+    //  - what the world already covers, for suppressing a suggestion (#417) — no threshold,
+    //    because a farm that covers an item makes a second design for it pointless at any size
+    //  - what this project *waits on*, for the prerequisite line — thresholded and
+    //    cycle-ordered, because that is an ordering claim and shares the roadmap's rules
+    val coveredByPlannedFarms = pendingFarmSuppliesFor(worldId, projectId, plan)
+    val prerequisiteFarms = prerequisiteFarmsFor(worldId, projectId)
 
     // The world's "worth a farm" line (MCO-401). Falls back to the default rather than
     // failing the page: a missing marker beats a missing plan.
@@ -106,7 +112,7 @@ suspend fun ApplicationCall.handleGetProject() {
     // because the bank is public ideas plus their own — a shared computation would show one
     // user another's private designs.
     val farmSuggestions = farmSuggestionsFor(
-        plan, farmScaleThreshold, user.id, projectId, pendingFarms, project.importedFromIdea?.first,
+        plan, farmScaleThreshold, user.id, projectId, coveredByPlannedFarms, project.importedFromIdea?.first,
     )
 
     // ?drill=<item> deep-links into a target's chain so reload/share lands on the drill,
@@ -126,7 +132,7 @@ suspend fun ApplicationCall.handleGetProject() {
             user, project, worldName, resources, tasks, lens,
             isWorldAdmin = isAdmin, plan = plan, progressMap = progressMap,
             productions = productions,
-            pendingFarms = pendingFarms,
+            pendingFarms = prerequisiteFarms,
             drillTarget = drillTarget, drillCandidateCounts = drillCandidateCounts,
             drillNodeIngredients = drillNodeIngredients, drillHighlightItemId = drillItemId,
             drillOverrides = drillOverrides, drillGraph = drillGraph,

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetFarmSupplyEdgesStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/commonsteps/GetFarmSupplyEdgesStep.kt
@@ -44,6 +44,24 @@ import app.mcorg.pipeline.failure.AppFailure
  * rather than deriving a plan per project here. A project nobody has planned yet contributes
  * no rows and therefore no edges; the roadmap says how many those are rather than quietly
  * drawing a thinner graph.
+ *
+ * ## Small edges are still edges (MCO-460)
+ *
+ * Two farms that each consume a little of the other's output close a loop, and both edges are
+ * true: the cobblestone farm really does need 20 gunpowder for TNT, and the witch farm really
+ * does need cobblestone. Drawn as equals they make the roadmap contradict itself.
+ *
+ * The farm-scale threshold is what tells those two claims apart — **20 gunpowder is not a
+ * prerequisite; 75,151 cobblestone is** — but it is applied by [RoadmapCycles], *only where a
+ * loop actually needs breaking*, and deliberately not here. A Beacon needing 32 iron from the
+ * Iron Farm is a perfectly good dependency and belongs on the roadmap; there is nothing
+ * contradictory about it, and thresholding every edge to solve a problem that only arises in
+ * loops would quietly delete most of the graph.
+ *
+ * What this query does carry is `roadmap_cycle_order`: a loop no principle could break, that a
+ * person then ordered by hand. That is a subtraction from the derived graph, and it lives here
+ * so both the roadmap and the project page inherit it from one place — two derivations of "is
+ * this a prerequisite" being the bug MCO-461 was filed for.
  */
 data class GetFarmSupplyEdgesStep(val worldId: Int) : Step<Unit, AppFailure.DatabaseError, List<ProjectResourceEdge>> {
     override suspend fun process(input: Unit): Result<AppFailure.DatabaseError, List<ProjectResourceEdge>> {
@@ -66,6 +84,13 @@ data class GetFarmSupplyEdgesStep(val worldId: Int) : Step<Unit, AppFailure.Data
                   AND prod.world_id = ?
                   AND prod.id <> d.project_id
                   AND prod.state NOT IN (?, ?)
+                  -- A pair a person has already ordered by hand: the edge that would make the
+                  -- winner wait is set aside. A subtraction, never an addition (MCO-460).
+                  AND NOT EXISTS (
+                      SELECT 1 FROM roadmap_cycle_order rco
+                      WHERE rco.consumer_project_id = d.project_id
+                        AND rco.producer_project_id = pp.project_id
+                  )
                   -- An explicitly solved requirement already produces an edge via
                   -- GetProjectEdgesStep; deriving a second one would double-count it.
                   AND NOT EXISTS (

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PendingFarmSupply.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PendingFarmSupply.kt
@@ -2,6 +2,7 @@ package app.mcorg.pipeline.resources
 
 import app.mcorg.engine.plan.GatheringPlan
 import app.mcorg.engine.plan.PlanNodeStatus
+import app.mcorg.pipeline.project.commonsteps.GetFarmSupplyEdgesStep
 
 /** One item a not-yet-operational farm has promised, with the amount this plan still needs. */
 data class PendingFarmItem(
@@ -79,6 +80,58 @@ fun buildPendingFarmSupplies(
                 .sortedWith(compareByDescending<PendingFarmItem> { it.quantity }.thenBy { it.itemName })
             if (items.isEmpty()) null
             else PendingFarmSupply(projectId = project.first, projectName = project.second, items = items)
+        }
+        .sortedBy { it.projectName }
+}
+
+/**
+ * The farms this project is waiting on, as prerequisites rather than as a courtesy notice
+ * (MCO-461).
+ *
+ * MCO-299 shipped this as a promise — "63,213 Redstone Dust will come from Witch Hut Farm once
+ * it is running". True, and useful, but it is not an *ordering fact*: nothing on the page said
+ * the witch farm comes first, which is why MCO-294 could offer to import that same farm again
+ * right beside it. #417 stopped the contradiction; this is the other half — the page saying
+ * what the relationship actually is.
+ *
+ * ## Why this reads the roadmap's edges rather than the planned-farm list
+ *
+ * [pendingFarmSuppliesFor] answers "which planned farm will make this", which is the right
+ * question for suppressing a suggestion (#417's `alreadyCovered`) and the wrong one for
+ * claiming a prerequisite: it applies no threshold and knows nothing about loops. A cobblestone
+ * farm needing 20 gunpowder is not waiting on the witch farm in any sense worth sequencing, and
+ * where two farms supply each other the answer depends on an ordering the user chose.
+ *
+ * [GetFarmSupplyEdgesStep] already encodes both rules — the farm-scale threshold (MCO-460) and
+ * `roadmap_cycle_order` — because the roadmap needs them. Reading the same step here is what
+ * makes the project page and the roadmap incapable of disagreeing about what blocks what, which
+ * is the whole point of MCO-461. Two independent derivations of "is this a prerequisite" is the
+ * bug, not the fix.
+ *
+ * Soft-fails to none, like every other decoration on the plan: a missing prerequisite line is a
+ * worse page, a failed query is no page.
+ */
+suspend fun prerequisiteFarmsFor(worldId: Int, projectId: Int): List<PendingFarmSupply> {
+    val edges = GetFarmSupplyEdgesStep(worldId).process(Unit).getOrNull() ?: return emptyList()
+
+    return edges
+        // `isBlocking` is producerState != DONE (MCO-287): a farm already running supplies now
+        // and is nobody's prerequisite. That is the same rule the roadmap draws with.
+        .filter { it.consumerId == projectId && it.isBlocking }
+        .groupBy { it.producerId to it.producerName }
+        .mapNotNull { (producer, group) ->
+            val items = group
+                .mapNotNull { edge ->
+                    val name = edge.itemName ?: return@mapNotNull null
+                    val quantity = edge.quantity ?: return@mapNotNull null
+                    PendingFarmItem(itemId = name, itemName = name, quantity = quantity)
+                }
+                .distinctBy { it.itemId }
+                .sortedWith(compareByDescending<PendingFarmItem> { it.quantity }.thenBy { it.itemName })
+            // A declared `project_dependencies` row carries no item and no quantity, so it
+            // produces no line here — the roadmap is where non-resource sequencing shows up.
+            if (items.isEmpty()) null
+            else PendingFarmSupply(projectId = producer.first, projectName = producer.second, items = items)
         }
         .sortedBy { it.projectName }
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/resources/PlanChainPipeline.kt
@@ -358,7 +358,13 @@ private suspend fun ApplicationCall.respondListRerender(worldId: Int, projectId:
     val tasks = SearchTasksStep(projectId).process(SearchTasksInput(completionStatus = "ALL")).getOrNull() ?: emptyList()
     val plan = deriveOrNull(projectId, worldId)
     val progressMap = GetProgressForProjectStep.process(projectId).getOrNull() ?: emptyMap()
-    val pendingFarms = pendingFarmSuppliesFor(worldId, projectId, plan)
+    // Two different questions, deliberately two sources (MCO-461):
+    //  - what the world already covers, for suppressing a suggestion (#417) — no threshold,
+    //    because a farm that covers an item makes a second design for it pointless at any size
+    //  - what this project *waits on*, for the prerequisite line — thresholded and
+    //    cycle-ordered, because that is an ordering claim and shares the roadmap's rules
+    val coveredByPlannedFarms = pendingFarmSuppliesFor(worldId, projectId, plan)
+    val prerequisiteFarms = prerequisiteFarmsFor(worldId, projectId)
 
     // The same three the full page computes. This re-render is the one place they change for a
     // reason other than a page load: resolving an open tag turns a tag with no id anything can
@@ -368,13 +374,13 @@ private suspend fun ApplicationCall.respondListRerender(worldId: Int, projectId:
         ?: World.DEFAULT_FARM_SCALE_THRESHOLD
     val user = getUser()
     val farmSuggestions = farmSuggestionsFor(
-        plan, farmScaleThreshold, user.id, projectId, pendingFarms, project.importedFromIdea?.first,
+        plan, farmScaleThreshold, user.id, projectId, coveredByPlannedFarms, project.importedFromIdea?.first,
     )
     val isAdmin = ValidateWorldMemberRole<Unit>(user, Role.ADMIN, worldId).process(Unit) is Result.Success
 
     respondHtml(
         gatheringPlannerFragment(
-            project, resources, tasks, plan, "list", progressMap, pendingFarms, farmScaleThreshold,
+            project, resources, tasks, plan, "list", progressMap, prerequisiteFarms, farmScaleThreshold,
             farmSuggestions, isAdmin,
         )
     )

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/roadmap/GetWorldRoadMapStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/roadmap/GetWorldRoadMapStep.kt
@@ -5,6 +5,9 @@ import app.mcorg.domain.model.project.ProjectStage
 import app.mcorg.domain.model.project.ProjectState
 import app.mcorg.domain.model.project.ProjectType
 import app.mcorg.domain.model.world.Roadmap
+import app.mcorg.domain.model.world.World
+import app.mcorg.domain.model.world.RoadmapCycle
+import app.mcorg.domain.model.world.RoadmapCycleOrder
 import app.mcorg.domain.model.world.RoadmapEdge
 import app.mcorg.domain.model.world.RoadmapLayer
 import app.mcorg.domain.model.world.RoadmapNode
@@ -17,6 +20,7 @@ import app.mcorg.pipeline.project.commonsteps.GetFarmSupplyEdgesStep
 import app.mcorg.pipeline.project.commonsteps.GetProjectEdgesStep
 import app.mcorg.pipeline.resources.GatheringPlanInput
 import app.mcorg.pipeline.resources.GenerateGatheringPlanStep
+import app.mcorg.pipeline.resources.GetFarmScaleThresholdStep
 import app.mcorg.pipeline.resources.GetWorldDemandCoverageStep
 import java.sql.ResultSet
 
@@ -37,6 +41,13 @@ import java.sql.ResultSet
  * Blocking is a function of the producer's [ProjectState]: not DONE means still blocking.
  * This is the same rule as [ProjectResourceEdge.isBlocking] and the same one the planner
  * uses to decide whether a farm supplies anything yet.
+ *
+ * ## Cycles are real (MCO-460)
+ *
+ * Derived edges can close a loop out of two true facts, so [RoadmapCycles] detects them
+ * explicitly and sets one edge aside per loop before layering. Without that the layering pass
+ * left both projects at depth 0 making opposite claims — each shown as blocked by the other —
+ * which reads as a bug in the numbers rather than the real ordering question it is.
  */
 data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadmap> {
 
@@ -73,7 +84,20 @@ data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadma
         val edges = (declaredEdges + farmEdges)
             .distinctBy { Triple(it.consumerId, it.producerId, it.itemName) }
 
-        return Result.success(buildRoadmap(worldName, projects, edges))
+        // Pairs someone has already ordered by hand. GetFarmSupplyEdgesStep has removed the
+        // matching edges, so they are no longer cycles — but the choice has to stay visible, or
+        // it could never be changed.
+        val resolvedOrders = when (val r = getResolvedOrders()) {
+            is Result.Success -> r.value
+            is Result.Failure -> emptyList()
+        }
+
+        // MCO-401's line, used here only to tell a footnote-sized loop from a real question
+        // (MCO-460). Falls back to the default rather than failing the page.
+        val farmScaleThreshold = GetFarmScaleThresholdStep.process(worldId).getOrNull()
+            ?: World.DEFAULT_FARM_SCALE_THRESHOLD
+
+        return Result.success(buildRoadmap(worldName, projects, edges, resolvedOrders, farmScaleThreshold))
     }
 
     /**
@@ -126,17 +150,70 @@ data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadma
             resultMapper = { it.toProjectRecords() }
         ).process(Unit)
 
+    /**
+     * The hand-made orderings for this world (MCO-460).
+     *
+     * Soft-fails to none: losing them means the page offers a question the user has already
+     * answered, which is a worse roadmap but still a roadmap.
+     */
+    private suspend fun getResolvedOrders(): Result<AppFailure.DatabaseError, List<RoadmapCycleOrder>> =
+        DatabaseSteps.query<Unit, List<RoadmapCycleOrder>>(
+            SafeSQL.select("""
+                SELECT
+                    o.consumer_project_id AS first_id,
+                    first.name            AS first_name,
+                    o.producer_project_id AS waiting_id,
+                    waiting.name          AS waiting_name
+                FROM roadmap_cycle_order o
+                JOIN projects first   ON first.id = o.consumer_project_id
+                JOIN projects waiting ON waiting.id = o.producer_project_id
+                WHERE o.world_id = ?
+                ORDER BY first.name
+            """.trimIndent()),
+            parameterSetter = { statement, _ -> statement.setInt(1, worldId) },
+            resultMapper = { rs ->
+                buildList {
+                    while (rs.next()) {
+                        add(
+                            RoadmapCycleOrder(
+                                firstProjectId = rs.getInt("first_id"),
+                                firstProjectName = rs.getString("first_name"),
+                                waitingProjectId = rs.getInt("waiting_id"),
+                                waitingProjectName = rs.getString("waiting_name"),
+                            )
+                        )
+                    }
+                }
+            }
+        ).process(Unit)
+
     private fun buildRoadmap(
         worldName: String,
         projects: List<ProjectRecord>,
         edges: List<ProjectResourceEdge>,
+        resolvedOrders: List<RoadmapCycleOrder>,
+        farmScaleThreshold: Int,
     ): Roadmap {
+        // Detect loops and set one edge aside per loop, so the page never renders two projects
+        // each claiming to block the other (MCO-460).
+        val cycles = RoadmapCycles.detect(edges, farmScaleThreshold)
+        // Every loop is broken; only the balanced ones are put to the user. A loop the threshold
+        // settled still has to be removed from the graph, or what it was breaking comes back.
+        val setAside = cycles.mapTo(mutableSetOf()) { it.breaking.firstProjectId to it.breaking.waitingProjectId }
+
+        // **The whole page derives from this one graph.** Layering it but drawing the full set
+        // would put Cobblestone Farm at depth 0 while its own row still read "depends on Witch
+        // Hut Farm — BLOCKING": two true-looking claims that cannot both hold, which is MCO-318's
+        // complaint all over again. The set-aside edge is not lost — the cycle panel above the
+        // table names it, and names it as an assumption someone can change.
+        val sequencing = edges.filterNot { (it.consumerId to it.producerId) in setAside }
+
         // Edges reference only projects in this world (every query is world-scoped), but a
         // project may appear in neither map — that just means it is isolated.
-        val incoming = edges.groupBy { it.consumerId }
-        val outgoing = edges.groupBy { it.producerId }
+        val incoming = sequencing.groupBy { it.consumerId }
+        val outgoing = sequencing.groupBy { it.producerId }
 
-        val layers = calculateLayers(projects, edges)
+        val layers = calculateLayers(projects, sequencing)
 
         val nodes = projects.map { project ->
             val dependencies = incoming[project.id].orEmpty()
@@ -157,7 +234,7 @@ data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadma
             )
         }
 
-        val roadmapEdges = edges.map { edge ->
+        val roadmapEdges = sequencing.map { edge ->
             RoadmapEdge(
                 fromNodeId = edge.consumerId,
                 fromNodeName = edge.consumerName,
@@ -183,6 +260,8 @@ data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadma
             nodes = nodes,
             edges = roadmapEdges,
             layers = layerGroups,
+            cycles = cycles.filter { it.needsAnAnswer },
+            resolvedOrders = resolvedOrders,
         )
     }
 
@@ -191,9 +270,14 @@ data class GetWorldRoadMapStep(val worldId: Int) : Step<Unit, AppFailure, Roadma
      * max(dependency layer) + 1. BFS from the roots, promoting a project only once every
      * one of its dependencies is placed.
      *
-     * Anything left unplaced is in a dependency cycle. Cycles are not supposed to exist,
-     * but a roadmap that silently dropped projects would be worse than one that shows them
-     * at depth 0 — so they land at the top, visible.
+     * [edges] arrives acyclic: the caller has already run [RoadmapCycles] and removed one edge
+     * per loop. This used to say "cycles are not supposed to exist" and put whatever BFS could
+     * not place at depth 0 — which happened constantly, because derived farm edges close loops
+     * out of two true facts (MCO-460).
+     *
+     * The depth-0 fallback below is kept as a floor rather than a diagnosis. If a loop ever
+     * survives detection, a roadmap that silently dropped projects would still be worse than
+     * one that shows them at the top.
      */
     private fun calculateLayers(
         projects: List<ProjectRecord>,

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/roadmap/RoadmapCycles.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/roadmap/RoadmapCycles.kt
@@ -1,0 +1,218 @@
+package app.mcorg.pipeline.world.roadmap
+
+import app.mcorg.domain.model.project.ProjectResourceEdge
+import app.mcorg.domain.model.world.RoadmapCycle
+import app.mcorg.domain.model.world.RoadmapCycleOption
+
+/**
+ * Finds the loops in a derived dependency graph and picks one edge per loop to set aside
+ * (MCO-460).
+ *
+ * ## Why cycles are not a data error
+ *
+ * The cobblestone farm requires 20 gunpowder for TNT. The witch farm produces gunpowder. The
+ * witch farm requires cobblestone. The cobblestone farm produces cobblestone. Both edges are
+ * **true**, derived from real demand — nothing here is bad data to clean up. The loop is a fact
+ * about the world, and which farm to build first is a sequencing decision a person makes.
+ *
+ * ## The threshold breaks most loops, and only loops
+ *
+ * The asymmetry is the way out: **20 gunpowder is not a prerequisite; 75,151 cobblestone is.**
+ * That judgement is one the world already carries — MCO-401's farm-scale threshold is precisely
+ * "the quantity above which this is worth a farm" — so a loop containing a sub-threshold claim
+ * breaks there, on a principle the product already committed to rather than by picking an
+ * arbitrary edge to cut.
+ *
+ * It is applied **here, inside a detected loop**, and not to the edge query. A Beacon needing 32
+ * iron from the Iron Farm is a perfectly good dependency with nothing contradictory about it;
+ * thresholding every edge to solve a problem that only arises in loops would quietly delete most
+ * of the roadmap. Small edges are only ever a problem when they are load-bearing in a cycle, so
+ * that is the only place the rule fires.
+ *
+ * What survives is two or more farms each needing a farm-scale amount of the other, where no
+ * principle picks a winner and only a person can.
+ *
+ * ## Detected, not inferred
+ *
+ * `calculateLayers` used to leave cycle members unplaced and drop them at depth 0, with a doc
+ * comment saying cycles "are not supposed to exist". Reading the loop back out of *what BFS
+ * failed to place* does not work as a diagnosis: everything downstream of a loop is also
+ * unplaced, so that set names innocent projects as cycle members. This runs Tarjan's algorithm
+ * and reports strongly connected components of size ≥ 2 — the actual loops, and only those.
+ *
+ * ## The guess, and why there is one
+ *
+ * A person picks which project comes first, but the roadmap has to render before they answer,
+ * and rendering two projects that each claim to block the other is precisely the bug MCO-460
+ * filed. So each loop is broken at its **smallest claim** — the edge carrying the least demand,
+ * ties broken by project id so a reload never reshuffles the page. That is a guess in the same
+ * spirit as the threshold: the weakest link is the one you would most easily do by hand. The
+ * page says it is a guess and offers the alternatives.
+ *
+ * One edge is never the guess while any other will do: a declared `project_dependencies` row
+ * (MCO-302), which carries no quantity because a person wrote it rather than a plan deriving it.
+ * Overriding somebody's explicit "dig the perimeter first" to tidy up a loop they did not create
+ * would be the wrong way round.
+ */
+object RoadmapCycles {
+
+    /**
+     * Every loop in [edges], each with its alternatives and the edge set aside to break it.
+     *
+     * **All** loops are returned, including the ones the threshold settles on its own — the
+     * caller needs every `breaking` edge to lay the graph out, and only shows the subset where
+     * [RoadmapCycle.needsAnAnswer]. Filtering here would leave the quiet ones unbroken and put
+     * two contradicting projects back on the page.
+     *
+     * [edges] should already have the user's saved answers removed — a pair someone has
+     * ordered is not an open question, and re-detecting it would put the prompt back on the
+     * page after it was answered.
+     */
+    fun detect(edges: List<ProjectResourceEdge>, farmScaleThreshold: Int): List<RoadmapCycle> {
+        if (edges.isEmpty()) return emptyList()
+
+        // One edge per ordered pair: a consumer needing three different items from the same
+        // producer is one dependency, and would otherwise produce three identical options.
+        // The largest claim represents the pair, and a derived edge beats a declared one
+        // (null quantity) so the pair keeps a number to show wherever it has one.
+        val byPair = edges
+            .groupBy { it.consumerId to it.producerId }
+            .mapValues { (_, group) -> group.maxBy { it.quantity ?: -1L } }
+
+        val dependencies = byPair.values.groupBy({ it.consumerId }, { it.producerId })
+
+        return stronglyConnectedComponents(dependencies)
+            .filter { it.size >= 2 }
+            .map { component -> component.toCycle(byPair, farmScaleThreshold) }
+            .sortedBy { it.projectNames.firstOrNull() ?: "" }
+    }
+
+    private fun Set<Int>.toCycle(
+        byPair: Map<Pair<Int, Int>, ProjectResourceEdge>,
+        farmScaleThreshold: Int,
+    ): RoadmapCycle {
+        // Only edges with both ends inside the component are part of the loop; an edge leaving
+        // it is an ordinary dependency and removing it would break nothing.
+        val internal = byPair.values.filter { it.consumerId in this && it.producerId in this }
+
+        val options = internal
+            .map { edge ->
+                RoadmapCycleOption(
+                    // Setting aside "consumer needs producer" frees the consumer: it no longer
+                    // waits, so it is the one that comes first.
+                    firstProjectId = edge.consumerId,
+                    firstProjectName = edge.consumerName,
+                    waitingProjectId = edge.producerId,
+                    waitingProjectName = edge.producerName,
+                    itemName = edge.itemName,
+                    quantity = edge.quantity,
+                )
+            }
+            .sortedWith(
+                compareBy(
+                    // A null quantity is a declared `project_dependencies` row — someone said
+                    // "dig the perimeter first" in as many words. Never break a cycle at a
+                    // human's own decision while a derived edge is available to break instead,
+                    // so those sort last and are only ever the guess when nothing else is.
+                    { it.quantity == null },
+                    { it.quantity ?: Long.MAX_VALUE },
+                    { it.firstProjectId },
+                    { it.waitingProjectId },
+                )
+            )
+
+        val names = internal
+            .flatMap { listOf(it.consumerId to it.consumerName, it.producerId to it.producerName) }
+            .distinctBy { it.first }
+            .sortedBy { it.second }
+
+        // Sorted smallest-first above, so the head is the smallest claim with a stable
+        // tiebreak. `first()` is safe: a component of size >= 2 has at least two internal
+        // edges, or it would not be strongly connected.
+        val breaking = options.first()
+
+        return RoadmapCycle(
+            projectIds = names.map { it.first },
+            projectNames = names.map { it.second },
+            options = options,
+            breaking = breaking,
+            // Below the world's line, the smallest claim is a footnote and giving way is the
+            // obvious answer rather than a judgement call — so the loop is broken silently and
+            // never reaches the page. A declared dependency (null quantity) is never a footnote:
+            // a person wrote it, so a loop resting on one is always worth asking about.
+            needsAnAnswer = (breaking.quantity ?: Long.MAX_VALUE) >= farmScaleThreshold,
+        )
+    }
+
+    /**
+     * Tarjan's strongly connected components, iterative.
+     *
+     * Iterative rather than the shorter recursive form because the graph is user data: a long
+     * enough dependency chain would overflow the stack, and a roadmap that 500s on a big world
+     * is worse than one that takes a few more lines to build.
+     */
+    private fun stronglyConnectedComponents(dependencies: Map<Int, List<Int>>): List<Set<Int>> {
+        val nodes = (dependencies.keys + dependencies.values.flatten()).toSet()
+
+        val index = HashMap<Int, Int>()
+        val lowLink = HashMap<Int, Int>()
+        val onStack = HashSet<Int>()
+        val stack = ArrayDeque<Int>()
+        val components = mutableListOf<Set<Int>>()
+        var nextIndex = 0
+
+        for (root in nodes) {
+            if (root in index) continue
+
+            // Each frame is a node plus how far through its neighbours we have walked.
+            val callStack = ArrayDeque<Frame>()
+            callStack.addLast(Frame(root, 0))
+            index[root] = nextIndex
+            lowLink[root] = nextIndex
+            nextIndex++
+            stack.addLast(root)
+            onStack.add(root)
+
+            while (callStack.isNotEmpty()) {
+                val frame = callStack.last()
+                val neighbours = dependencies[frame.node].orEmpty()
+
+                if (frame.next < neighbours.size) {
+                    val neighbour = neighbours[frame.next]
+                    frame.next++
+                    when {
+                        neighbour !in index -> {
+                            index[neighbour] = nextIndex
+                            lowLink[neighbour] = nextIndex
+                            nextIndex++
+                            stack.addLast(neighbour)
+                            onStack.add(neighbour)
+                            callStack.addLast(Frame(neighbour, 0))
+                        }
+                        neighbour in onStack ->
+                            lowLink[frame.node] = minOf(lowLink.getValue(frame.node), index.getValue(neighbour))
+                    }
+                } else {
+                    callStack.removeLast()
+                    callStack.lastOrNull()?.let { parent ->
+                        lowLink[parent.node] = minOf(lowLink.getValue(parent.node), lowLink.getValue(frame.node))
+                    }
+                    if (lowLink.getValue(frame.node) == index.getValue(frame.node)) {
+                        val component = mutableSetOf<Int>()
+                        while (true) {
+                            val popped = stack.removeLast()
+                            onStack.remove(popped)
+                            component.add(popped)
+                            if (popped == frame.node) break
+                        }
+                        components.add(component)
+                    }
+                }
+            }
+        }
+
+        return components
+    }
+
+    private data class Frame(val node: Int, var next: Int)
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/roadmap/SaveRoadmapCycleOrderPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/world/roadmap/SaveRoadmapCycleOrderPipeline.kt
@@ -1,0 +1,127 @@
+package app.mcorg.pipeline.world.roadmap
+
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.failure.AppFailure
+import app.mcorg.presentation.handler.defaultHandleError
+import app.mcorg.presentation.utils.clientRedirect
+import app.mcorg.presentation.utils.getWorldId
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.request.receiveParameters
+import io.ktor.server.response.respond
+
+/**
+ * Records which of two mutually-supplying projects comes first (MCO-460).
+ *
+ * The pair is a genuine loop — both edges derived from real demand, both true — so no rule can
+ * pick a winner and the page asks. Saving means "set aside the first project's demand on the
+ * second", which is a **subtraction** from the derived graph and never an addition: an ordering
+ * someone wants to *assert* is a `project_dependencies` row (MCO-302), a different thing.
+ *
+ * Both surfaces inherit the answer, because both read
+ * [GetFarmSupplyEdgesStep][app.mcorg.pipeline.project.commonsteps.GetFarmSupplyEdgesStep] —
+ * the roadmap stops drawing the edge, and the project page stops calling it a prerequisite.
+ * Keeping the rule in one query is what stops the two disagreeing again, which is the bug
+ * MCO-461 was filed for.
+ *
+ * Authorization is the route's: this sits inside the world block behind `WorldAdminPlugin`,
+ * because sequencing the world's projects is a world-level decision rather than a per-viewer
+ * preference — the next person to open the roadmap sees the same order.
+ */
+suspend fun ApplicationCall.handleSaveRoadmapCycleOrder() {
+    val worldId = getWorldId()
+    val (first, waiting) = readPair() ?: return
+
+    val result = DatabaseSteps.update<Unit>(
+        sql = SafeSQL.insert("""
+            INSERT INTO roadmap_cycle_order (world_id, consumer_project_id, producer_project_id)
+            VALUES (?, ?, ?)
+            ON CONFLICT (consumer_project_id, producer_project_id) DO NOTHING
+        """.trimIndent()),
+        parameterSetter = { statement, _ ->
+            statement.setInt(1, worldId)
+            statement.setInt(2, first)
+            statement.setInt(3, waiting)
+        }
+    ).process(Unit)
+
+    if (result is Result.Failure) return defaultHandleError(result.error)
+
+    // Choosing a direction has to clear the opposite one, or the pair ends up with both edges
+    // set aside and no ordering at all — the loop would vanish instead of being resolved.
+    val opposite = DatabaseSteps.update<Unit>(
+        sql = SafeSQL.delete("""
+            DELETE FROM roadmap_cycle_order
+            WHERE consumer_project_id = ? AND producer_project_id = ?
+        """.trimIndent()),
+        parameterSetter = { statement, _ ->
+            statement.setInt(1, waiting)
+            statement.setInt(2, first)
+        }
+    ).process(Unit)
+
+    if (opposite is Result.Failure) return defaultHandleError(opposite.error)
+
+    backToRoadmap(worldId)
+}
+
+/**
+ * Forgets an ordering, putting the loop back as an open question (MCO-460).
+ *
+ * Undo rather than a toggle: the answer is a claim about the world, and taking it back should
+ * restore the question rather than silently assert the reverse.
+ */
+suspend fun ApplicationCall.handleClearRoadmapCycleOrder() {
+    val worldId = getWorldId()
+    val (first, waiting) = readPair() ?: return
+
+    val result = DatabaseSteps.update<Unit>(
+        sql = SafeSQL.delete("""
+            DELETE FROM roadmap_cycle_order
+            WHERE world_id = ? AND consumer_project_id = ? AND producer_project_id = ?
+        """.trimIndent()),
+        parameterSetter = { statement, _ ->
+            statement.setInt(1, worldId)
+            statement.setInt(2, first)
+            statement.setInt(3, waiting)
+        }
+    ).process(Unit)
+
+    if (result is Result.Failure) return defaultHandleError(result.error)
+
+    backToRoadmap(worldId)
+}
+
+/**
+ * The two project ids the form posts, or null after responding with why not.
+ *
+ * The projects are not checked against the world here: the `world_id` column is set from the
+ * route, and both id columns are foreign keys, so the worst a forged pair can do is store a
+ * suppression for an edge that does not exist — which changes nothing, because the edge query
+ * only ever subtracts.
+ */
+private suspend fun ApplicationCall.readPair(): Pair<Int, Int>? {
+    val submitted = receiveParameters()
+    val first = submitted["first"]?.toIntOrNull()
+    val waiting = submitted["waiting"]?.toIntOrNull()
+
+    if (first == null || waiting == null || first == waiting) {
+        defaultHandleError(
+            AppFailure.customValidationError("first", "Pick which of the two projects comes first")
+        )
+        return null
+    }
+    return first to waiting
+}
+
+private suspend fun ApplicationCall.backToRoadmap(worldId: Int) {
+    val target = "/worlds/$worldId/roadmap"
+    if (request.headers["HX-Request"] == "true") {
+        clientRedirect(target)
+    } else {
+        response.headers.append("Location", target)
+        respond(HttpStatusCode.SeeOther, "")
+    }
+}

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/handler/WorldHandler.kt
@@ -9,7 +9,9 @@ import app.mcorg.pipeline.project.handleReviewSchematic
 import app.mcorg.pipeline.project.handleDeleteProject
 import app.mcorg.pipeline.project.handleGetProject
 import app.mcorg.pipeline.project.handleGetDetailContent
+import app.mcorg.pipeline.world.roadmap.handleClearRoadmapCycleOrder
 import app.mcorg.pipeline.world.roadmap.handleGetWorldRoadmap
+import app.mcorg.pipeline.world.roadmap.handleSaveRoadmapCycleOrder
 import app.mcorg.pipeline.project.handleRecordExistingFarm
 import app.mcorg.pipeline.project.resources.handleAddResourcesFromSchematic
 import app.mcorg.pipeline.project.resources.handleDeleteProjectProduction
@@ -132,6 +134,18 @@ class WorldHandler {
                 }
                 get("/roadmap") {
                     call.handleGetWorldRoadmap()
+                }
+                // Which of two mutually-supplying projects comes first (MCO-460). Admin-only:
+                // it sequences the world's projects for everyone who opens the roadmap, not
+                // just the viewer, so it is a world decision like the farm-scale threshold.
+                route("/roadmap/cycle-order") {
+                    install(WorldAdminPlugin)
+                    post {
+                        call.handleSaveRoadmapCycleOrder()
+                    }
+                    post("/clear") {
+                        call.handleClearRoadmapCycleOrder()
+                    }
                 }
                 route("/projects") {
                     get {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ProjectDetailPage.kt
@@ -745,22 +745,35 @@ private fun hoursOfRunning(hours: Double): String = when {
  * *not* operational; once one is Done, its items move into "Collect from farms" and the
  * line for them disappears on its own.
  */
+/**
+ * The farms this project waits on (MCO-299, reframed by MCO-461).
+ *
+ * This shipped as a promise — "63,213 Redstone Dust will come from Witch Hut Farm once it is
+ * running". Every word true, but it read as a courtesy note rather than an ordering fact, so
+ * nothing on the page contradicted the suggestion list offering to import that same farm again.
+ *
+ * It now leads with the relationship — *Prerequisite* — and keeps the promise as the
+ * explanation underneath it. Same farm, same numbers, one claim instead of two: the list comes
+ * from [prerequisiteFarmsFor], which reads the roadmap's own edges, so this page and the
+ * roadmap cannot disagree about what blocks what.
+ */
 private fun FlowContent.pendingFarmNotice(worldId: Int, pendingFarms: List<PendingFarmSupply>) {
     if (pendingFarms.isEmpty()) return
 
     div("plan-pending-farms") {
         id = "plan-pending-farms"
+        span("section-label") { +"Prerequisites" }
         pendingFarms.forEach { farm ->
             p("plan-pending-farms__line") {
-                +itemsPhrase(farm.items)
-                +" will come from "
                 a(classes = "plan-pending-farms__project") {
                     href = "/worlds/$worldId/projects/${farm.projectId}"
                     +farm.projectName
                 }
-                +" once it is running — gather "
+                +" comes first — it makes "
+                +itemsPhrase(farm.items)
+                +" this build needs. Gather "
                 +(if (farm.items.size == 1) "it" else "them")
-                +" manually meanwhile."
+                +" by hand until it is running."
             }
         }
     }
@@ -768,7 +781,10 @@ private fun FlowContent.pendingFarmNotice(worldId: Int, pendingFarms: List<Pendi
 
 /** "32 Iron Ingot", "32 Iron Ingot and 12 Gold Ingot", "32 Iron Ingot, 12 Gold Ingot and 4 Diamond". */
 private fun itemsPhrase(items: List<PendingFarmItem>): String {
-    val parts = items.map { "${it.quantity} ${it.itemName}" }
+    // Separated, like every other quantity on this page. Unformatted was survivable while
+    // this read "32 Iron Ingot"; MCO-461 made it a prerequisite line carrying farm-scale
+    // numbers, and "2400" beside the roll-up's "2,400" reads as a different number.
+    val parts = items.map { "%,d %s".format(it.quantity, it.itemName) }
     return when (parts.size) {
         1 -> parts.first()
         2 -> "${parts[0]} and ${parts[1]}"

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/RoadmapPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/RoadmapPage.kt
@@ -2,6 +2,9 @@ package app.mcorg.presentation.templated.dsl.pages
 
 import app.mcorg.domain.model.user.TokenProfile
 import app.mcorg.domain.model.world.Roadmap
+import app.mcorg.domain.model.world.RoadmapCycle
+import app.mcorg.domain.model.world.RoadmapCycleOption
+import app.mcorg.domain.model.world.RoadmapCycleOrder
 import app.mcorg.domain.model.world.RoadmapEdge
 import app.mcorg.domain.model.world.RoadmapNode
 import app.mcorg.presentation.templated.dsl.appHeader
@@ -9,13 +12,20 @@ import app.mcorg.presentation.templated.dsl.container
 import app.mcorg.presentation.templated.dsl.emptyState
 import app.mcorg.presentation.templated.dsl.pageShell
 import app.mcorg.presentation.templated.dsl.projectStateBadge
+import kotlinx.html.ButtonType
 import kotlinx.html.FlowContent
+import kotlinx.html.FormMethod
 import kotlinx.html.a
+import kotlinx.html.button
 import kotlinx.html.div
+import kotlinx.html.form
 import kotlinx.html.h1
+import kotlinx.html.hiddenInput
 import kotlinx.html.id
 import kotlinx.html.main
+import kotlinx.html.p
 import kotlinx.html.span
+import kotlinx.html.strong
 import kotlinx.html.table
 import kotlinx.html.tbody
 import kotlinx.html.td
@@ -28,8 +38,13 @@ import kotlinx.html.tr
  * sequence the world implies is readable top to bottom.
  *
  * Table form on purpose: the layered graph the model already computes is the follow-up, and
- * a table is the accessible, mobile-survivable, hundreds-of-rows form to lead with. Nothing
- * here is editable — the roadmap is derived from resource relationships, never curated.
+ * a table is the accessible, mobile-survivable, hundreds-of-rows form to lead with.
+ *
+ * **The roadmap is still derived, never curated** — with one exception that proves the rule.
+ * Where derivation produces a genuine tie, two farms each supplying the other (MCO-460), no
+ * amount of deriving picks a winner, so [cycleSection] asks. What that records is a
+ * *subtraction* — "set this edge aside" — never an ordering someone typed in. Asserting an
+ * order is `project_dependencies`, and that is MCO-302's editor, not this page.
  */
 fun roadmapPage(
     user: TokenProfile,
@@ -65,11 +80,104 @@ fun roadmapPage(
             if (roadmap.isEmpty()) {
                 roadmapEmptyState(roadmap.worldId)
             } else {
+                // Above the table: a loop makes the ordering below it a guess, so saying so
+                // after the fact would be the wrong way round (MCO-460).
+                cycleSection(roadmap)
                 roadmapTable(roadmap)
             }
         }
     }
 }
+
+/**
+ * The loops in this world, and the question only a person can answer (MCO-460).
+ *
+ * Two farms that each consume a farm-scale amount of the other's output is not bad data — both
+ * edges are derived from real demand and both are true. What it is, is a sequencing decision:
+ * which one do you build first, knowing you will hand-gather the other's input until it runs.
+ *
+ * The page has already broken each loop at its smallest claim so the table below never shows
+ * two projects each blocking the other. That guess is stated rather than hidden — a roadmap
+ * that quietly picked an order would be a roadmap you could not trust the rest of.
+ */
+private fun FlowContent.cycleSection(roadmap: Roadmap) {
+    if (roadmap.cycles.isEmpty() && roadmap.resolvedOrders.isEmpty()) return
+
+    div("roadmap-cycles") {
+        id = "roadmap-cycles"
+        span("section-label") { +"Circular supply" }
+
+        roadmap.cycles.forEach { cycle -> cyclePrompt(roadmap.worldId, cycle) }
+        roadmap.resolvedOrders.forEach { order -> resolvedOrderRow(roadmap.worldId, order) }
+    }
+}
+
+/** One unanswered loop: what it is, what was assumed, and the alternatives. */
+private fun FlowContent.cyclePrompt(worldId: Int, cycle: RoadmapCycle) {
+    div("roadmap-cycles__item") {
+        p("roadmap-cycles__lead") {
+            +cycle.projectNames.joinToString(" and ")
+            +" each supply the other. Which comes first?"
+        }
+        p("roadmap-cycles__assumed") {
+            +"Assuming "
+            strong { +cycle.breaking.firstProjectName }
+            +" for now — its "
+            +cycle.breaking.claimText()
+            +" is the smaller claim, so it is the easier one to cover by hand."
+        }
+        div("roadmap-cycles__options") {
+            cycle.options.forEach { option ->
+                form(classes = "roadmap-cycles__option") {
+                    method = FormMethod.post
+                    action = "/worlds/$worldId/roadmap/cycle-order"
+                    hiddenInput { name = "first"; value = option.firstProjectId.toString() }
+                    hiddenInput { name = "waiting"; value = option.waitingProjectId.toString() }
+                    button(classes = "btn btn--sm ${if (option == cycle.breaking) "btn--secondary" else "btn--ghost"}") {
+                        type = ButtonType.submit
+                        +"${option.firstProjectName} first"
+                    }
+                    span("roadmap-cycles__option-note") {
+                        +"sets aside ${option.claimText()} from ${option.waitingProjectName}"
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** A loop somebody has already settled — visible so it can be changed or undone. */
+private fun FlowContent.resolvedOrderRow(worldId: Int, order: RoadmapCycleOrder) {
+    div("roadmap-cycles__resolved") {
+        p("roadmap-cycles__resolved-text") {
+            +"You put "
+            strong { +order.firstProjectName }
+            +" before "
+            strong { +order.waitingProjectName }
+            +"."
+        }
+        form(classes = "roadmap-cycles__resolved-undo") {
+            method = FormMethod.post
+            action = "/worlds/$worldId/roadmap/cycle-order/clear"
+            hiddenInput { name = "first"; value = order.firstProjectId.toString() }
+            hiddenInput { name = "waiting"; value = order.waitingProjectId.toString() }
+            button(classes = "btn btn--sm btn--ghost") {
+                type = ButtonType.submit
+                +"Undo"
+            }
+        }
+    }
+}
+
+/**
+ * "2,400 Gunpowder", or "the dependency" when the edge is a declared row with no item.
+ *
+ * A declared `project_dependencies` edge carries no quantity by design, so this must not
+ * invent one — see [RoadmapCycleOption.quantity].
+ */
+private fun RoadmapCycleOption.claimText(): String =
+    if (quantity != null && itemName != null) "%,d %s".format(quantity, itemName)
+    else "the dependency"
 
 /** "12 projects · 3 blocked · 4 layers deep" — straight off the model's own statistics. */
 private fun roadmapSummary(roadmap: Roadmap): String {

--- a/webapp/mc-web/src/main/resources/db/migration/V2_60_0__roadmap_cycle_order.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_60_0__roadmap_cycle_order.sql
@@ -1,0 +1,42 @@
+-- MCO-460: which of two mutually-supplying farms comes first.
+--
+-- Farm supply edges (MCO-288) are derived from real data: producer produces what consumer
+-- demands. Two farms that each consume a farm-scale amount of the other's output therefore
+-- close a genuine loop, and both edges are true. The cobblestone farm really does need
+-- gunpowder; the witch farm really does need cobblestone. There is no bad data to clean up —
+-- the cycle is a fact about the world, and the resolution is a sequencing decision a human
+-- makes.
+--
+-- Most such loops are broken before they get here, by the farm-scale threshold (MCO-401):
+-- an edge carrying less than the world's threshold is a footnote, not a prerequisite, and is
+-- not drawn at all. What survives is two farms genuinely waiting on each other, and only a
+-- person can say which to build first.
+--
+-- ## What a row means
+--
+-- One row sets aside one derived supply edge: "the consumer comes first, so this edge does
+-- not sequence the pair." It never adds an ordering — `project_dependencies` is where a
+-- declared prerequisite lives (MCO-302). This is the opposite operation, and the two must not
+-- be conflated: a row here is a *subtraction* from the derived graph.
+--
+-- Scoped to a pair rather than to a cycle. A cycle's membership changes as demand changes,
+-- so keying on the cycle would invalidate the answer every time a plan is re-derived, whereas
+-- "cobblestone before witch" stays true until the user says otherwise.
+CREATE TABLE roadmap_cycle_order (
+    id SERIAL PRIMARY KEY,
+    world_id INTEGER NOT NULL REFERENCES world (id) ON DELETE CASCADE,
+    -- The project the user said comes first. Its demand on the other is set aside.
+    consumer_project_id INTEGER NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    -- The project whose output the consumer is no longer sequenced behind.
+    producer_project_id INTEGER NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    -- One answer per ordered pair. Choosing the other direction replaces this row rather than
+    -- adding a second, or the pair would have both edges set aside and no ordering at all.
+    UNIQUE (consumer_project_id, producer_project_id),
+    -- A project cannot come before itself, and a self-supply edge is already excluded upstream.
+    CONSTRAINT roadmap_cycle_order_distinct CHECK (consumer_project_id <> producer_project_id)
+);
+
+-- The edge query filters by world and then by pair, in that order.
+CREATE INDEX idx_roadmap_cycle_order_world ON roadmap_cycle_order (world_id);

--- a/webapp/mc-web/src/main/resources/static/styles/pages/roadmap.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/roadmap.css
@@ -8,6 +8,93 @@
     margin-bottom: var(--space-5);
 }
 
+/* MCO-460 — circular supply. Sits above the table because a loop makes the ordering below it
+   a guess; saying so afterwards would be the wrong way round. Bordered rather than tinted
+   like a warning: this is a question about the world, not an error in it. */
+.roadmap-cycles {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    padding: var(--space-4);
+    margin-bottom: var(--space-5);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    border-radius: var(--radius);
+    background: var(--bg-surface);
+}
+
+.roadmap-cycles__item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.roadmap-cycles__lead {
+    margin: 0;
+    font-family: var(--font-ui);
+    font-size: var(--text-ui);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+/* The assumption is stated plainly, at body weight — a roadmap that quietly picked an order
+   would be one you could not trust the rest of. */
+.roadmap-cycles__assumed {
+    margin: 0;
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    max-width: 70ch;
+}
+
+.roadmap-cycles__options {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.roadmap-cycles__option {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+}
+
+.roadmap-cycles__option-note {
+    font-family: var(--font-body);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+/* An answered pair. Quieter than an open question, but never hidden — an ordering you cannot
+   see is one you cannot change. */
+.roadmap-cycles__resolved {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    flex-wrap: wrap;
+    padding-top: var(--space-2);
+    border-top: 1px solid var(--border);
+}
+
+.roadmap-cycles__resolved-text {
+    margin: 0;
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+}
+
+@media (max-width: 768px) {
+    /* The button and its explanation stack; at 375px they do not fit on one line and the
+       note is the half that wraps into illegibility. */
+    .roadmap-cycles__option {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: var(--space-1);
+    }
+}
+
 .roadmap-title__name {
     font-family: var(--font-ui);
     font-size: var(--text-xl);

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/world/roadmap/RoadmapCyclesTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/world/roadmap/RoadmapCyclesTest.kt
@@ -1,0 +1,270 @@
+package app.mcorg.pipeline.world.roadmap
+
+import app.mcorg.domain.model.project.ProjectResourceEdge
+import app.mcorg.domain.model.project.ProjectState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * MCO-460 — loops in the derived dependency graph.
+ *
+ * The shape throughout is the one Even hit on the dogfood world: the cobblestone farm needs
+ * gunpowder for TNT, the witch farm produces gunpowder, the witch farm needs cobblestone, the
+ * cobblestone farm produces cobblestone. Both edges true, neither one a mistake.
+ */
+class RoadmapCyclesTest {
+
+    private val cobbleFarm = 1
+    private val witchFarm = 2
+    private val storageHall = 3
+    private val perimeter = 4
+
+    /** The world default (MCO-401). Every fixture claim above is comfortably over it. */
+    private val threshold = 1_728
+
+    private fun detect(edges: List<ProjectResourceEdge>) = RoadmapCycles.detect(edges, threshold)
+
+    private fun edge(
+        consumerId: Int,
+        consumerName: String,
+        producerId: Int,
+        producerName: String,
+        itemName: String? = "Cobblestone",
+        quantity: Long? = 1_000,
+        producerState: ProjectState = ProjectState.ACTIVE,
+    ) = ProjectResourceEdge(
+        consumerId = consumerId,
+        consumerName = consumerName,
+        consumerState = ProjectState.ACTIVE,
+        producerId = producerId,
+        producerName = producerName,
+        itemName = itemName,
+        producerState = producerState,
+        quantity = quantity,
+    )
+
+    /** Cobble needs 2,400 gunpowder from Witch; Witch needs 75,151 cobblestone from Cobble. */
+    private fun theLoop() = listOf(
+        edge(cobbleFarm, "Cobblestone Farm", witchFarm, "Witch Hut Farm", "Gunpowder", 2_400),
+        edge(witchFarm, "Witch Hut Farm", cobbleFarm, "Cobblestone Farm", "Cobblestone", 75_151),
+    )
+
+    // ---- detection -------------------------------------------------------------------
+
+    @Test
+    fun `two farms supplying each other are one cycle`() {
+        val cycles = detect(theLoop())
+
+        assertEquals(1, cycles.size)
+        assertEquals(listOf(cobbleFarm, witchFarm), cycles.single().projectIds.sorted())
+    }
+
+    @Test
+    fun `an ordinary chain is not a cycle`() {
+        val chain = listOf(
+            edge(storageHall, "Storage Hall", cobbleFarm, "Cobblestone Farm"),
+            edge(cobbleFarm, "Cobblestone Farm", perimeter, "Perimeter"),
+        )
+
+        assertTrue(detect(chain).isEmpty())
+    }
+
+    @Test
+    fun `no edges means no cycles`() {
+        assertTrue(detect(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `a project downstream of a cycle is not named as part of it`() {
+        // The point of detecting rather than inferring. Storage Hall depends on the cobble
+        // farm, so the old "whatever BFS could not place" reading swept it in with the loop.
+        val edges = theLoop() + edge(storageHall, "Storage Hall", cobbleFarm, "Cobblestone Farm")
+
+        val cycle = detect(edges).single()
+
+        assertEquals(listOf(cobbleFarm, witchFarm), cycle.projectIds.sorted())
+        assertTrue(storageHall !in cycle.projectIds, "it merely depends on a cycle member")
+    }
+
+    @Test
+    fun `a three-farm loop is one cycle, not three`() {
+        val edges = listOf(
+            edge(1, "A", 2, "B", "Iron", 5_000),
+            edge(2, "B", 3, "C", "Redstone", 6_000),
+            edge(3, "C", 1, "A", "Cobblestone", 7_000),
+        )
+
+        val cycle = detect(edges).single()
+
+        assertEquals(listOf(1, 2, 3), cycle.projectIds.sorted())
+        assertEquals(3, cycle.options.size, "any of the three edges would break it")
+    }
+
+    @Test
+    fun `two separate loops are reported separately`() {
+        val edges = theLoop() + listOf(
+            edge(10, "Gold Farm", 11, "Ice Farm", "Ice", 9_000),
+            edge(11, "Ice Farm", 10, "Gold Farm", "Gold", 8_000),
+        )
+
+        assertEquals(2, detect(edges).size)
+    }
+
+    // ---- the guess -------------------------------------------------------------------
+
+    @Test
+    fun `the loop breaks at its smallest claim`() {
+        val cycle = detect(theLoop()).single()
+
+        // 2,400 gunpowder is the cheaper of the two to do by hand, so the cobblestone farm
+        // stops waiting on the witch farm and comes first.
+        assertEquals(cobbleFarm, cycle.breaking.firstProjectId)
+        assertEquals(witchFarm, cycle.breaking.waitingProjectId)
+        assertEquals("Gunpowder", cycle.breaking.itemName)
+        assertEquals(2_400, cycle.breaking.quantity)
+    }
+
+    @Test
+    fun `both directions are offered so the guess can be overridden`() {
+        val cycle = detect(theLoop()).single()
+
+        assertEquals(
+            listOf(cobbleFarm to witchFarm, witchFarm to cobbleFarm),
+            cycle.options.map { it.firstProjectId to it.waitingProjectId }.sortedBy { it.first },
+        )
+    }
+
+    @Test
+    fun `the guess does not move when the edges arrive in another order`() {
+        val forward = detect(theLoop()).single()
+        val reversed = detect(theLoop().reversed()).single()
+
+        assertEquals(forward.breaking, reversed.breaking, "a reload must not reshuffle the page")
+    }
+
+    @Test
+    fun `equal claims break on project id rather than arbitrarily`() {
+        val tied = listOf(
+            edge(witchFarm, "Witch Hut Farm", cobbleFarm, "Cobblestone Farm", "Cobblestone", 5_000),
+            edge(cobbleFarm, "Cobblestone Farm", witchFarm, "Witch Hut Farm", "Gunpowder", 5_000),
+        )
+
+        val cycle = detect(tied).single()
+
+        assertEquals(cobbleFarm, cycle.breaking.firstProjectId, "lowest id wins, deterministically")
+    }
+
+    @Test
+    fun `a declared dependency is never the guess while a derived edge will do`() {
+        // A null quantity is a project_dependencies row — a person wrote "dig the perimeter
+        // first". Breaking the loop there would override their decision to tidy up a loop
+        // they did not create, even though it looks like the smallest claim.
+        val edges = listOf(
+            edge(cobbleFarm, "Cobblestone Farm", perimeter, "Perimeter", itemName = null, quantity = null),
+            edge(perimeter, "Perimeter", cobbleFarm, "Cobblestone Farm", "Cobblestone", 40_000),
+        )
+
+        val cycle = detect(edges).single()
+
+        assertEquals(perimeter, cycle.breaking.firstProjectId, "the derived edge is the one to set aside")
+        assertEquals(40_000, cycle.breaking.quantity)
+    }
+
+    // ---- the threshold settles the lopsided ones (MCO-460) --------------------------
+
+    @Test
+    fun `a loop resting on a footnote is broken without asking`() {
+        // Even's actual case: 20 gunpowder against 75,151 cobblestone. Both edges true, but
+        // one is an evening's hand-gathering and the other is the largest job in the world.
+        val lopsided = listOf(
+            edge(cobbleFarm, "Cobblestone Farm", witchFarm, "Witch Hut Farm", "Gunpowder", 20),
+            edge(witchFarm, "Witch Hut Farm", cobbleFarm, "Cobblestone Farm", "Cobblestone", 75_151),
+        )
+
+        val cycle = detect(lopsided).single()
+
+        assertTrue(!cycle.needsAnAnswer, "the threshold answered it; nobody needs interrupting")
+        assertEquals(cobbleFarm, cycle.breaking.firstProjectId, "but it is still broken")
+    }
+
+    @Test
+    fun `a balanced loop is still a question`() {
+        val cycle = detect(theLoop()).single()
+
+        assertTrue(cycle.needsAnAnswer, "2,400 gunpowder is farm-scale; no principle picks a winner")
+    }
+
+    @Test
+    fun `a footnote losing to a declared dependency needs no answer`() {
+        // Someone said "dig the perimeter first"; the perimeter happens to want 40 cobblestone
+        // back. The two rules compose into the obvious outcome without anyone being asked: the
+        // footnote is the one set aside, so the human's declared order survives intact.
+        val edges = listOf(
+            edge(cobbleFarm, "Cobblestone Farm", perimeter, "Perimeter", itemName = null, quantity = null),
+            edge(perimeter, "Perimeter", cobbleFarm, "Cobblestone Farm", "Cobblestone", 40),
+        )
+
+        val cycle = detect(edges).single()
+
+        assertEquals(perimeter, cycle.breaking.firstProjectId, "the 40 cobblestone gives way")
+        assertTrue(!cycle.needsAnAnswer, "and the declared dependency is honoured, silently")
+    }
+
+    @Test
+    fun `a declared dependency against a farm-scale claim is a question`() {
+        // Now the derived side is real work, so setting either aside is a judgement call and
+        // the declared row is the one the rules refuse to overrule on their own.
+        val edges = listOf(
+            edge(cobbleFarm, "Cobblestone Farm", perimeter, "Perimeter", itemName = null, quantity = null),
+            edge(perimeter, "Perimeter", cobbleFarm, "Cobblestone Farm", "Cobblestone", 40_000),
+        )
+
+        val cycle = detect(edges).single()
+
+        assertEquals(perimeter, cycle.breaking.firstProjectId, "still never the declared row")
+        assertTrue(cycle.needsAnAnswer, "but 40,000 cobblestone is not something to drop quietly")
+    }
+
+    @Test
+    fun `a loop of only declared dependencies still breaks somewhere`() {
+        // Nothing else is available, so the rule yields rather than leaving the page
+        // contradicting itself.
+        val edges = listOf(
+            edge(1, "A", 2, "B", itemName = null, quantity = null),
+            edge(2, "B", 1, "A", itemName = null, quantity = null),
+        )
+
+        val cycle = detect(edges).single()
+
+        assertEquals(1, cycle.breaking.firstProjectId)
+    }
+
+    @Test
+    fun `several items between the same pair are one dependency`() {
+        // Otherwise the witch farm needing cobblestone, sand and gravel would offer three
+        // identical "witch farm comes first" options.
+        val edges = listOf(
+            edge(cobbleFarm, "Cobblestone Farm", witchFarm, "Witch Hut Farm", "Gunpowder", 2_400),
+            edge(witchFarm, "Witch Hut Farm", cobbleFarm, "Cobblestone Farm", "Cobblestone", 75_151),
+            edge(witchFarm, "Witch Hut Farm", cobbleFarm, "Cobblestone Farm", "Gravel", 12_000),
+        )
+
+        val cycle = detect(edges).single()
+
+        assertEquals(2, cycle.options.size)
+        assertEquals(
+            75_151,
+            cycle.options.single { it.firstProjectId == witchFarm }.quantity,
+            "the largest claim represents the pair",
+        )
+    }
+
+    @Test
+    fun `a self-supplying project is not a cycle`() {
+        // Excluded upstream in SQL, but the detector must not invent one either.
+        val edges = listOf(edge(cobbleFarm, "Cobblestone Farm", cobbleFarm, "Cobblestone Farm"))
+
+        assertTrue(detect(edges).isEmpty())
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSupplySurfacingIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/FarmSupplySurfacingIT.kt
@@ -84,16 +84,21 @@ class FarmSupplySurfacingIT : WithUser() {
     }
 
     @Test
-    fun `a farm that is not running yet shows the partial-dependency notice, not a supplied row`() = testApplication {
+    fun `a farm that is not running yet reads as a prerequisite, not a supplied row`() = testApplication {
         setupRoutes()
         setProjectState(farmId, ProjectState.ACTIVE)
 
         val body = client.get("/worlds/$worldId/projects/$consumerId") { addAuthCookie(this) }.bodyAsText()
 
         assertContains(body, "plan-pending-farms")
-        assertContains(body, "32 Iron Ingot will come from")
         assertContains(body, "Iron Farm")
-        assertContains(body, "once it is running")
+        // MCO-461 turned MCO-299's promise into an ordering fact. The promise is still here as
+        // the explanation, but the relationship leads — a *notice* is what let MCO-294 offer to
+        // import this same farm again right beside it.
+        assertContains(body, "Prerequisites")
+        assertContains(body, "comes first")
+        assertContains(body, "32 Iron Ingot")
+        assertContains(body, "by hand until it is running")
         assertFalse(body.contains("Collect from farms"), "the item is still manual work")
     }
 

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/RoadmapCycleIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/world/RoadmapCycleIT.kt
@@ -1,0 +1,237 @@
+package app.mcorg.presentation.handler.world
+
+import app.mcorg.domain.model.minecraft.MinecraftVersion
+import app.mcorg.domain.model.project.ProjectState
+import app.mcorg.pipeline.DatabaseSteps
+import app.mcorg.pipeline.Result
+import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.world.CreateWorldInput
+import app.mcorg.pipeline.world.CreateWorldStep
+import app.mcorg.pipeline.world.roadmap.GetWorldRoadMapStep
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExtendWith
+import app.mcorg.test.WithUser
+import app.mcorg.test.postgres.DatabaseTestExtension
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * MCO-460 — the gunpowder/cobblestone shape, end to end against the real queries.
+ *
+ * `RoadmapCyclesTest` covers the detection arithmetic on constructed edges. This covers what
+ * only the database can answer: that the farm-scale threshold actually reaches the SQL, that a
+ * surviving loop is reported as a cycle rather than as two contradicting rows, and that a saved
+ * ordering removes the edge on both surfaces.
+ */
+@Tag("database")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(DatabaseTestExtension::class)
+class RoadmapCycleIT : WithUser() {
+
+    private val version = MinecraftVersion.Release(1, 21, 4)
+
+    // ---- the reported shape ----------------------------------------------------------
+
+    @Test
+    fun `a loop resting on a footnote is settled without asking`() = runBlocking {
+        // Even's case: the cobblestone farm needs 20 gunpowder for TNT, the witch farm makes
+        // gunpowder, and that used to be an edge exactly as strong as 75,151 cobblestone.
+        val world = createWorld("Threshold world")
+        val cobble = createProject(world, "Cobblestone Farm")
+        val witch = createProject(world, "Witch Hut Farm")
+
+        addProduction(cobble, "minecraft:cobblestone", "Cobblestone")
+        addProduction(witch, "minecraft:gunpowder", "Gunpowder")
+        addDemand(cobble, "minecraft:gunpowder", "Gunpowder", 20)
+        addDemand(witch, "minecraft:cobblestone", "Cobblestone", 75_151)
+
+        val roadmap = (GetWorldRoadMapStep(world).process(Unit) as Result.Success).value
+
+        // The footnote is the edge set aside to break the loop, so it comes off the table with
+        // it — one graph behind every claim. Small edges are only ever dropped when they are
+        // load-bearing in a cycle; a Beacon needing 32 iron keeps its edge (GetWorldRoadMapStepTest).
+        assertEquals(
+            listOf("Witch Hut Farm" to "Cobblestone Farm"),
+            roadmap.edges.map { it.fromNodeName to it.toNodeName },
+            "the farm-scale claim is what sequences the pair",
+        )
+        // But the loop it closes is settled on the threshold, without interrupting anyone.
+        assertTrue(
+            roadmap.cycles.isEmpty(),
+            "20 gunpowder against 75,151 cobblestone is not a judgement call: ${roadmap.cycles}",
+        )
+        // The ordering claims agree: the witch farm waits, the cobblestone farm does not.
+        assertEquals(0, roadmap.nodes.single { it.projectName == "Cobblestone Farm" }.layer)
+        assertEquals(1, roadmap.nodes.single { it.projectName == "Witch Hut Farm" }.layer)
+    }
+
+    @Test
+    fun `two farm-scale claims both ways is reported as a cycle`() = runBlocking {
+        val world = createWorld("Real cycle world")
+        val cobble = createProject(world, "Cobblestone Farm")
+        val witch = createProject(world, "Witch Hut Farm")
+
+        addProduction(cobble, "minecraft:cobblestone", "Cobblestone")
+        addProduction(witch, "minecraft:gunpowder", "Gunpowder")
+        // Both above the 1,728 default, so no principle picks a winner.
+        addDemand(cobble, "minecraft:gunpowder", "Gunpowder", 2_400)
+        addDemand(witch, "minecraft:cobblestone", "Cobblestone", 75_151)
+
+        val roadmap = (GetWorldRoadMapStep(world).process(Unit) as Result.Success).value
+
+        val cycle = roadmap.cycles.single()
+        assertEquals(listOf("Cobblestone Farm", "Witch Hut Farm"), cycle.projectNames)
+        assertEquals(2, cycle.options.size, "either farm could be the one to go first")
+        assertEquals("Cobblestone Farm", cycle.breaking.firstProjectName, "the smaller claim gives way")
+
+        // AC 1, and the part that is easy to half-fix: it is not enough for the *layers* to
+        // disagree while the columns still say each blocks the other. Every claim on the page
+        // comes off one graph.
+        val layers = roadmap.nodes.associate { it.projectName to it.layer }
+        assertEquals(0, layers.getValue("Cobblestone Farm"))
+        assertEquals(1, layers.getValue("Witch Hut Farm"))
+
+        val cobbleNode = roadmap.nodes.single { it.projectName == "Cobblestone Farm" }
+        val witchNode = roadmap.nodes.single { it.projectName == "Witch Hut Farm" }
+        assertTrue(!cobbleNode.isBlocked, "it is at depth 0; it cannot also be blocked")
+        assertTrue(cobbleNode.blockingProjectIds.isEmpty())
+        assertTrue(witchNode.isBlocked, "and the one that waits says so")
+        assertEquals(listOf(cobbleNode.projectId), witchNode.blockingProjectIds)
+
+        assertEquals(
+            listOf("Witch Hut Farm" to "Cobblestone Farm"),
+            roadmap.edges.map { it.fromNodeName to it.toNodeName },
+            "the set-aside edge is off the table too, not just out of the layering",
+        )
+    }
+
+    @Test
+    fun `a saved ordering removes the edge and closes the question`() = runBlocking {
+        val world = createWorld("Ordered cycle world")
+        val cobble = createProject(world, "Cobblestone Farm")
+        val witch = createProject(world, "Witch Hut Farm")
+
+        addProduction(cobble, "minecraft:cobblestone", "Cobblestone")
+        addProduction(witch, "minecraft:gunpowder", "Gunpowder")
+        addDemand(cobble, "minecraft:gunpowder", "Gunpowder", 2_400)
+        addDemand(witch, "minecraft:cobblestone", "Cobblestone", 75_151)
+
+        // The user picks the other direction than the guess: the witch farm goes first.
+        saveOrder(world, first = witch, waiting = cobble)
+
+        val roadmap = (GetWorldRoadMapStep(world).process(Unit) as Result.Success).value
+
+        assertTrue(roadmap.cycles.isEmpty(), "answered, so no longer an open question")
+        assertEquals(
+            listOf("Witch Hut Farm" to "Cobblestone Farm"),
+            roadmap.resolvedOrders.map { it.firstProjectName to it.waitingProjectName },
+            "but still visible, or it could never be changed",
+        )
+        assertTrue(
+            roadmap.edges.none { it.fromNodeName == "Witch Hut Farm" },
+            "the witch farm no longer waits on anything: ${roadmap.edges.map { it.fromNodeName to it.toNodeName }}",
+        )
+        assertEquals(0, roadmap.nodes.single { it.projectName == "Witch Hut Farm" }.layer)
+        assertEquals(1, roadmap.nodes.single { it.projectName == "Cobblestone Farm" }.layer)
+    }
+
+    @Test
+    fun `an operational farm is nobody's prerequisite`() = runBlocking {
+        // MCO-287's rule, unchanged by any of this: DONE supplies now, so it cannot be in a
+        // loop with what it supplies.
+        val world = createWorld("Done farm world")
+        val cobble = createProject(world, "Cobblestone Farm", state = ProjectState.DONE)
+        val witch = createProject(world, "Witch Hut Farm")
+
+        addProduction(cobble, "minecraft:cobblestone", "Cobblestone")
+        addProduction(witch, "minecraft:gunpowder", "Gunpowder")
+        addDemand(cobble, "minecraft:gunpowder", "Gunpowder", 2_400)
+        addDemand(witch, "minecraft:cobblestone", "Cobblestone", 75_151)
+
+        val roadmap = (GetWorldRoadMapStep(world).process(Unit) as Result.Success).value
+
+        assertTrue(
+            roadmap.nodes.single { it.projectName == "Witch Hut Farm" }.blockingProjectIds.isEmpty(),
+            "a running cobblestone farm blocks nothing",
+        )
+    }
+
+    // ---- fixtures --------------------------------------------------------------------
+
+    private fun createWorld(name: String): Int = runBlocking {
+        val result = CreateWorldStep(user).process(
+            CreateWorldInput(name = name, description = "test", version = version)
+        )
+        (result as Result.Success).value
+    }
+
+    private fun createProject(
+        worldId: Int,
+        name: String,
+        state: ProjectState = ProjectState.ACTIVE,
+    ): Int = runBlocking {
+        val result = DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO projects (name, world_id, description, type, stage, state, location_x, location_y, location_z, location_dimension) " +
+                    "VALUES (?, ?, '', 'FARMING', 'PLANNING', ?, 0, 0, 0, 'OVERWORLD') RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setString(1, name)
+                stmt.setInt(2, worldId)
+                stmt.setString(3, state.name)
+            }
+        ).process(Unit)
+        (result as Result.Success).value
+    }
+
+    private fun addProduction(projectId: Int, itemId: String, name: String) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO project_productions (project_id, item_id, name, rate_per_hour) VALUES (?, ?, ?, 1000)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+                stmt.setString(3, name)
+            }
+        ).process(Unit)
+    }
+
+    /**
+     * Writes materialised plan demand directly (MCO-316's `project_demand`).
+     *
+     * The roadmap derives missing demand itself, but that needs an ingested Minecraft graph
+     * this test has no reason to build — the question here is what the edge query does with
+     * demand, not how demand is produced.
+     */
+    private fun addDemand(projectId: Int, itemId: String, itemName: String, quantity: Long) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO project_demand (project_id, item_id, item_name, quantity, activity_group, node_status) " +
+                    "VALUES (?, ?, ?, ?, 'GATHER', 'RAW_GATHER')"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, projectId)
+                stmt.setString(2, itemId)
+                stmt.setString(3, itemName)
+                stmt.setLong(4, quantity)
+            }
+        ).process(Unit)
+    }
+
+    private fun saveOrder(worldId: Int, first: Int, waiting: Int) = runBlocking {
+        DatabaseSteps.update<Unit>(
+            sql = SafeSQL.insert(
+                "INSERT INTO roadmap_cycle_order (world_id, consumer_project_id, producer_project_id) VALUES (?, ?, ?)"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, worldId)
+                stmt.setInt(2, first)
+                stmt.setInt(3, waiting)
+            }
+        ).process(Unit)
+    }
+}


### PR DESCRIPTION
Closes MCO-460. Closes MCO-461 (its remaining half — fix 1 shipped in #417).

> The cobblestone farm requires **20 gunpowder** (for TNT). The witch farm produces gunpowder. The witch farm requires cobblestone. The cobblestone farm produces cobblestone.

Both edges derived from real demand, both true — so the roadmap drew each project as blocked by the other, while `calculateLayers` said in its own doc comment that cycles "are not supposed to exist". They exist. Nothing enforced that rule because nothing could.

## Detected, not inferred

`RoadmapCycles` runs Tarjan's SCC over the edge graph. Reading a loop back out of *what BFS failed to place* does not work as a diagnosis — everything downstream of a loop is also unplaced, so that set names innocent projects as members. A test pins exactly that.

## The threshold breaks most loops, and only loops

**20 gunpowder is not a prerequisite; 75,151 cobblestone is.** MCO-401's farm-scale line already encodes that judgement per world, so a loop containing a sub-threshold claim breaks there and never reaches the user.

It fires **only inside a detected loop**, not in the edge query. A Beacon needing 32 iron from the Iron Farm is a perfectly good dependency with nothing contradictory about it; thresholding every edge to solve a problem that only arises in loops would quietly delete most of the roadmap. The first pass did put it in SQL — five existing tests said so, and that is why they are untouched in this diff.

Two rules compose underneath it:

- **A declared `project_dependencies` row is never the edge given up** while a derived one will do. Overriding somebody's explicit "dig the perimeter first" to tidy a loop they did not create is the wrong way round.
- So a footnote losing to a declared dependency resolves **silently, in favour of the human's declaration**.

## What survives is a question, and it gets asked

Two farms each needing a farm-scale amount of the other: no principle picks a winner. The roadmap breaks it at the smaller claim so the page is never self-contradictory, **says so in as many words**, and offers both directions.

```
CIRCULAR SUPPLY
Cobblestone Farm and Witch Hut Farm each supply the other. Which comes first?
Assuming Cobblestone Farm for now — its 2,400 Gunpowder is the smaller claim,
so it is the easier one to cover by hand.
  [Cobblestone Farm first]  sets aside 2,400 Gunpowder from Witch Hut Farm
  [Witch Hut Farm first]    sets aside 75,151 Cobblestone from Cobblestone Farm
```

`roadmap_cycle_order` (V2_60_0) records the answer as a **subtraction** — "set this edge aside" — never an asserted ordering. Asserting one is `project_dependencies`, which is MCO-302's job. Answered pairs stay visible with an Undo, or the choice could never be changed.

**The whole page derives from one graph.** Fixing only the layering left the table reading *"Cobblestone Farm · layer 0 · depends on Witch Hut Farm — BLOCKING"* — MCO-318's complaint returning on a second surface. The browser caught that; the tests as first written did not, so the IT now asserts `isBlocked` / `blockingProjectIds` / edges rather than layer numbers alone.

## MCO-461's other half

MCO-299 shipped the relationship as a promise — *"63,213 Redstone Dust will come from Witch Hut Farm once it is running"*. True and useful, but not an **ordering fact**, which is why MCO-294 could offer to import that same farm again right beside it. #417 stopped the contradiction; the page now states the relationship:

```
PREREQUISITES
Witch Hut Farm comes first — it makes 2,400 Gunpowder this build needs.
Gather it by hand until it is running.
```

It reads `GetFarmSupplyEdgesStep` — the roadmap's own edges — so the project page and the roadmap cannot disagree about what blocks what, and it inherits the cycle ordering for free. Two independent derivations of "is this a prerequisite" is the bug, not the fix.

Also fixes a pre-existing miss the reframing made visible: `itemsPhrase` printed "2400" beside the roll-up's "2,400".

## Tests

- 18 unit (`RoadmapCyclesTest`) — detection, the guess and its determinism, the declared-dependency rule, and the threshold's two outcomes.
- 4 ITs (`RoadmapCycleIT`) — the gunpowder/cobblestone shape end to end, including that a saved ordering removes the edge on both surfaces.
- **1010 unit / 533 database**, green.

One caveat: `RoadmapCycleIT` writes `project_demand` directly, because the roadmap's `fillMissingDemand` needs an ingested Minecraft graph the test has no reason to build. The question under test is what the edge query does with demand, not how demand is derived — the browser pass covers that path.

## Verified in the running app

Prompt, both override directions, Undo, and the project page following the choice. Screenshots taken at desktop width; the cycle panel stacks at 375 via its own media query.

No `preview` label — verified locally; happy to add one if you want the eyeball on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)