### PR TITLE
MCO-308: resolve an idea's placed block ids the way the schematic door does

### DIFF
--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
@@ -450,7 +450,7 @@ data class MapSchematicToMaterialsStep(
         val flat = if (regions.isEmpty()) {
             resolve(input.items, byId)
         } else {
-            ResolvedMaterials(
+            PlacedMaterials(
                 requirements = sumRequirements(regions.map { it.requirements }),
                 placedCounts = regions.map { it.placedCounts }.reduce { acc, next ->
                     (acc.keys + next.keys).associateWith { (acc[it] ?: 0) + (next[it] ?: 0) }
@@ -482,130 +482,20 @@ data class MapSchematicToMaterialsStep(
         )
     }
 
-    /** One region's — or the whole file's — block counts, resolved to gathered items. */
-    private fun resolve(counts: Map<String, Int>, byId: Map<String, Item>): ResolvedMaterials {
-        // Fluids first, because they are the one case where the cell count is not the amount
-        // to gather: a bucket is reusable, so 4,013 water cells are one water bucket carried
-        // and refilled. The cell count is kept as [SchematicMaterials.placedCounts] so the
-        // review screen can still show it — see FLUID_PLACEMENTS.
-        val fluidCells = LinkedHashMap<Item, Int>()
-        counts.forEach { (blockId, amount) ->
-            val bucketId = FLUID_PLACEMENTS[blockId] ?: return@forEach
-            val bucket = byId[bucketId] ?: return@forEach
-            fluidCells[bucket] = (fluidCells[bucket] ?: 0) + amount
-        }
-
-        // A schematic stores placed block-state ids; some are gathered as a different
-        // item (birch_wall_sign -> birch_sign) and some are not a material at all
-        // (an extended piston's head). Normalize, then merge amounts for block ids that
-        // collapse onto the same item (e.g. a build with both a sign and a wall sign).
-        val resolved = counts.entries
-            .filter { (blockId, _) -> blockId !in FLUID_PLACEMENTS }
-            .mapNotNull { (blockId, amount) -> resolveMaterial(blockId, byId)?.let { it to amount } }
-
-        // One bucket per fluid, on top of any the build stores as real items.
-        val byItem = LinkedHashMap<Item, Int>()
-        resolved.forEach { (item, amount) -> byItem[item] = (byItem[item] ?: 0) + amount }
-        fluidCells.keys.forEach { bucket -> byItem[bucket] = (byItem[bucket] ?: 0) + 1 }
-
-        return ResolvedMaterials(
-            requirements = byItem.map { (item, amount) -> item to amount },
-            placedCounts = fluidCells.entries.associate { (bucket, cells) -> bucket.id to cells },
-        )
-    }
+    /**
+     * One region's — or the whole file's — block counts, resolved to gathered items.
+     *
+     * The rules themselves live in `PlacedBlocks.kt`, shared with the idea door (MCO-308).
+     * The only thing this door decides for itself is what to do with an id the version's
+     * catalog does not have: drop it. A `.litematic` is often saved on a newer version than
+     * the world it is being imported into, and one unrecognised id is not a reason to refuse
+     * a file — the idea door, whose version range was already checked, reports it instead.
+     */
+    private fun resolve(counts: Map<String, Int>, byId: Map<String, Item>): PlacedMaterials =
+        resolvePlacedCells(counts, byId)
 
     private fun sumRequirements(lists: List<List<Pair<Item, Int>>>): List<Pair<Item, Int>> =
         sumRequirementLists(lists)
-
-    private data class ResolvedMaterials(
-        val requirements: List<Pair<Item, Int>>,
-        val placedCounts: Map<String, Int>,
-    )
-
-    /**
-     * Resolves a schematic block-state id to the item a player actually gathers, or
-     * null when the cell is not a material (dropped).
-     *
-     * Order:
-     * 1. [isDropped] — placed forms that are not a material of their own (an extended
-     *    piston's head, potted plants counted as the pot+plant elsewhere, candle cakes,
-     *    silverfish-infested blocks).
-     * 2. [REDIRECTS] — explicit block -> item for placed forms whose gathered item has a
-     *    different id: crops to their seed/produce (carrots -> carrot, cocoa ->
-     *    cocoa_beans), tool/effect placements to their material (dirt_path/farmland
-     *    -> dirt, redstone_wire -> redstone, wall_torch -> torch), and filled block states
-     *    to the block you place (lava_cauldron -> cauldron).
-     * 3. *wall* variants — drop the "_wall_" infix when that yields a real item
-     *    (birch_wall_sign -> birch_sign, dead_horn_coral_wall_fan -> dead_horn_coral_fan).
-     * 4. Otherwise resolve by the id itself, or drop when the version has no such item.
-     *
-     * Fluids never reach here — they are handled ahead of it, since their amount is capped
-     * at one bucket rather than taken from the cell count (see [FLUID_PLACEMENTS]).
-     *
-     * Truly non-obtainable blocks (budding_amethyst) are intentionally left to resolve to
-     * nothing and surface as a BLOCKED row rather than a wrong guess. Placed *effect* blocks
-     * whose material is a separate cell already counted plus a reusable tool (fire,
-     * soul_fire, bubble_column, the portals) are dropped as non-materials — see [isDropped].
-     */
-    private fun resolveMaterial(blockId: String, byId: Map<String, Item>): Item? {
-        if (isDropped(blockId)) return null
-        REDIRECTS[blockId]?.let { target -> byId[target]?.let { return it } }
-        if ("_wall_" in blockId) {
-            byId[blockId.replace("_wall_", "_")]?.let { return it }
-        }
-        return byId[blockId]
-    }
-
-    private fun isDropped(blockId: String): Boolean {
-        if (blockId in NON_MATERIAL_BLOCKS) return true
-        val name = blockId.substringAfter(':')
-        return name.startsWith("potted_") || name.startsWith("infested_") || name.endsWith("candle_cake")
-    }
-
-    companion object {
-        /**
-         * Placed block-state ids whose gathered item has a *different* id. Crops resolve
-         * to the seed/produce you plant or harvest; tool/effect placements resolve to the
-         * material left behind. The target must still exist in the version's catalog to be
-         * used (else the block falls through to its own id / a BLOCKED row).
-         */
-        private val REDIRECTS = mapOf(
-            // crops / growth -> seed or produce item
-            "minecraft:carrots" to "minecraft:carrot",
-            "minecraft:potatoes" to "minecraft:potato",
-            "minecraft:beetroots" to "minecraft:beetroot_seeds",
-            "minecraft:cocoa" to "minecraft:cocoa_beans",
-            "minecraft:melon_stem" to "minecraft:melon_seeds",
-            "minecraft:attached_melon_stem" to "minecraft:melon_seeds",
-            "minecraft:pumpkin_stem" to "minecraft:pumpkin_seeds",
-            "minecraft:attached_pumpkin_stem" to "minecraft:pumpkin_seeds",
-            "minecraft:cave_vines" to "minecraft:glow_berries",
-            "minecraft:cave_vines_plant" to "minecraft:glow_berries",
-            "minecraft:kelp_plant" to "minecraft:kelp",
-            "minecraft:bamboo_sapling" to "minecraft:bamboo",
-            "minecraft:sweet_berry_bush" to "minecraft:sweet_berries",
-            "minecraft:tall_seagrass" to "minecraft:seagrass",
-            "minecraft:twisting_vines_plant" to "minecraft:twisting_vines",
-            "minecraft:weeping_vines_plant" to "minecraft:weeping_vines",
-            "minecraft:big_dripleaf_stem" to "minecraft:big_dripleaf",
-            "minecraft:pitcher_crop" to "minecraft:pitcher_pod",
-            "minecraft:torchflower_crop" to "minecraft:torchflower_seeds",
-            // placed tool/effect forms -> the material gathered
-            "minecraft:dirt_path" to "minecraft:dirt",
-            "minecraft:farmland" to "minecraft:dirt",
-            "minecraft:redstone_wire" to "minecraft:redstone",
-            "minecraft:tripwire" to "minecraft:string",
-            "minecraft:suspicious_sand" to "minecraft:sand",
-            "minecraft:suspicious_gravel" to "minecraft:gravel",
-            "minecraft:wall_torch" to "minecraft:torch",
-            // A filled cauldron is a block *state* of the cauldron, not an item of its own
-            // (there is no lava_cauldron item). What you gather is the cauldron; the bucket
-            // that fills it is a reusable tool, like the flint & steel behind a fire cell.
-            "minecraft:lava_cauldron" to "minecraft:cauldron",
-            "minecraft:water_cauldron" to "minecraft:cauldron",
-            "minecraft:powder_snow_cauldron" to "minecraft:cauldron",
-        )
-    }
 }
 
 private data class MapSchematicToProjectStep(

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -43,8 +43,21 @@ data class IdeaForImport(
     val name: String,
     val description: String,
     val category: IdeaCategory,
+    /**
+     * What to gather — already resolved out of placed forms by [ValidateItemIdsStep].
+     *
+     * Not the ids the idea recorded. An idea captured from a schematic carries placed
+     * block-state ids, and every consumer past this point wants the gathered item (MCO-308).
+     */
     val requirements: Map<Item, Int>,
     val production: Map<Item, Int>,
+    /**
+     * Fluid cell counts, keyed by bucket id — review-time context, not persisted (MCO-396).
+     *
+     * The requirement is one reusable bucket; this is the number of cells it fills, so the
+     * review screen can say "1 water bucket, placed 4,013×" and stay reconcilable.
+     */
+    val placedCounts: Map<String, Int> = emptyMap(),
     /**
      * Produced item ids this world's version does not have (MCO-456). Dropped from
      * [production] and reported, never fatal — see [ValidateItemIdsStep].
@@ -92,12 +105,10 @@ suspend fun ApplicationCall.handleReviewIdeaImport() {
 
     handlePipeline(
         onSuccess = { idea: IdeaForImport ->
-            // Same treatment as the schematic door for placed cells (MCO-396): drop the ones
-            // that are not a material, and turn a fluid into the bucket you carry. Without
-            // this the idea door would offer water as a row and the plan would call it
-            // creative-only, which is how it read before MCO-319.
-            val materials = normalizePlacedBlocks(idea.requirements, items)
-            val requirements = materials.requirements.toMap()
+            // Already resolved by ValidateItemIdsStep, through the same tables the schematic
+            // door reads (MCO-396, MCO-308) — placed forms are the gathered item, fluids are
+            // one bucket, non-materials are gone. Nothing to normalize a second time here.
+            val requirements = idea.requirements
             respondHtml(
                 importReviewPage(
                     user = user,
@@ -105,7 +116,7 @@ suspend fun ApplicationCall.handleReviewIdeaImport() {
                     worldName = getWorldName(worldId),
                     projectName = idea.name,
                     requirements = requirements,
-                    placedCounts = materials.placedCounts,
+                    placedCounts = idea.placedCounts,
                     warnings = computeImportWarnings(worldId, requirements),
                     unrecordableProductions = idea.unrecordableProductions,
                     // Only the idea door offers this (MCO-457). A schematic is a file of blocks
@@ -409,26 +420,35 @@ internal fun ratesForImport(modes: List<IdeaProductionMode>, chosenModeName: Str
 }
 
 
+/**
+ * Turns an idea's recorded ids into the items this world would actually gather.
+ *
+ * The requirement side runs the **same** placed-cell resolution the schematic door does
+ * (MCO-308): an idea captured from a schematic records placed block-state ids, and taking
+ * them verbatim put rows on the gathering list that no source produces — 592 `Redstone Wire
+ * (Block)`, which MCO-305's warning strip then had to call creative-only. It is not; it is
+ * 592 redstone. Resolving here rather than at capture time is deliberate: the tables resolve
+ * *against a version catalog*, and an idea spans a version range, so the same idea honestly
+ * resolves differently in two worlds.
+ *
+ * An id nothing claims is still a validation error, unlike the schematic door which drops it.
+ * The version range was already checked by [ValidateVersionRangeStep], so reaching here with
+ * an id outside the catalog means the idea and the world genuinely disagree.
+ */
 internal data class ValidateItemIdsStep(val availableIds: List<Item>) : Step<Pair<BasicIdeaInfo, Map<String, Int>>, AppFailure, IdeaForImport> {
     override suspend fun process(input: Pair<BasicIdeaInfo, Map<String, Int>>): Result<AppFailure, IdeaForImport> {
         val (ideaInfo, requirements) = input
-        val mappedRequirements = mutableMapOf<Item, Int>()
         val mappedProduction = mutableMapOf<Item, Int>()
         val unrecordable = mutableListOf<String>()
         val errors = mutableListOf<ValidationFailure>()
 
-        for ((itemId, amount) in requirements) {
-            // Air is dropped, not reported (MCO-305) — an idea recorded from a schematic can
-            // carry millions of air cells, and nobody has ever wanted them on a gathering list.
-            if (itemId in NON_MATERIAL_FILL) continue
-
-            val item = availableIds.find { it.id == itemId }
-
-            if (item == null) {
-                errors.add(ValidationFailure.CustomValidation("requirements", "Item ID $itemId is not available in the world version"))
-            } else {
-                mappedRequirements[item] = amount
-            }
+        // Air and the other non-materials are dropped, not reported (MCO-305) — an idea
+        // recorded from a schematic can carry millions of air cells, and nobody has ever
+        // wanted them on a gathering list.
+        val resolved = resolvePlacedCells(requirements, availableIds.associateBy { it.id })
+        val mappedRequirements = resolved.requirements.toMap()
+        resolved.unknown.forEach { itemId ->
+            errors.add(ValidationFailure.CustomValidation("requirements", "Item ID $itemId is not available in the world version"))
         }
 
         // An unknown *production* id is reported, not refused (MCO-456). It used to be a
@@ -456,6 +476,7 @@ internal data class ValidateItemIdsStep(val availableIds: List<Item>) : Step<Pai
                     category = ideaInfo.category,
                     requirements = mappedRequirements,
                     production = mappedProduction,
+                    placedCounts = resolved.placedCounts,
                     unrecordableProductions = unrecordable.sorted(),
                 )
             )

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/PlacedBlocks.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/PlacedBlocks.kt
@@ -3,22 +3,25 @@ package app.mcorg.pipeline.project
 import app.mcorg.domain.model.minecraft.Item
 
 /**
- * What a *placed* cell costs, for both import doors (MCO-396).
+ * What a *placed* cell costs, for both import doors (MCO-396, MCO-308).
  *
  * A schematic and an idea can both name ids that occupy space in a build without being a
- * thing you gather. There are two honest answers and this file holds the tables for each:
+ * thing you gather. There are three honest answers and this file holds the tables for each:
  *
  * * **Nothing at all** ([NON_MATERIAL_FILL], [NON_MATERIAL_BLOCKS]) — air, an extended
  *   piston's head, a nether portal. The material is either absent or already counted as a
  *   separate cell, so the row is dropped and never mentioned.
  * * **A reusable tool** ([FLUID_PLACEMENTS]) — water, lava, powder snow. What you carry is a
  *   bucket, so the row becomes one bucket and the cell count is kept aside as context.
+ * * **A different item** ([REDIRECTS], the `_wall_` rule) — placed redstone dust is redstone,
+ *   a wall sign is a sign, farmland is dirt. Same material, different id once placed.
  *
- * These lists used to disagree with the warning-side list in `ImportWarnings.kt`: the
- * schematic mapper dropped five ids while the warning side merely *warned* about eleven. The
- * six in the gap (the fluids and the portals) therefore survived into the project and landed
- * in the plan as `Blocked: … — no feasible source found` — MCO-319 relabelled them without
- * changing that. One set of tables, read by both doors, is what stops that recurring.
+ * [resolvePlacedCells] applies all three and is the **only** entry point either door uses.
+ * That single reader is the point of the file. These lists used to disagree with the
+ * warning-side list in `ImportWarnings.kt` (MCO-396), and the redirects above were private to
+ * the schematic mapper while the idea door took recorded ids verbatim (MCO-308) — so an idea
+ * captured from a schematic offered 592 `Redstone Wire (Block)` and the plan called them
+ * creative-only. Both bugs were one table with two readers.
  */
 
 /**
@@ -74,40 +77,152 @@ val FLUID_PLACEMENTS = mapOf(
 )
 
 /**
- * Applies the two tables above to an already-resolved requirement map — the idea import door.
+ * Placed block-state ids whose gathered item has a *different* id.
  *
- * The schematic door does this inside [MapSchematicToMaterialsStep], where it is interleaved
- * with the block-state redirects and the `_wall_` handling that only a schematic needs. This
- * is the subset an idea can hit: an idea's requirements are catalog items, not block states,
- * so the ids either match one of these tables or they are already what you gather.
- *
- * Resolving the *rest* of an idea's placed block ids the way the schematic path does is
- * MCO-308 and deliberately not attempted here.
+ * Crops resolve to the seed/produce you plant or harvest; tool/effect placements resolve to
+ * the material left behind. The target must still exist in the version's catalog to be used —
+ * otherwise the block falls through to its own id, and from there to a BLOCKED row, which is
+ * a truthful "you cannot get this here" rather than a promise of an item the version lacks.
  */
-fun normalizePlacedBlocks(requirements: Map<Item, Int>, catalog: List<Item>): SchematicMaterials {
-    val byId = catalog.associateBy { it.id }
+private val REDIRECTS = mapOf(
+    // crops / growth -> seed or produce item
+    "minecraft:carrots" to "minecraft:carrot",
+    "minecraft:potatoes" to "minecraft:potato",
+    "minecraft:beetroots" to "minecraft:beetroot_seeds",
+    "minecraft:cocoa" to "minecraft:cocoa_beans",
+    "minecraft:melon_stem" to "minecraft:melon_seeds",
+    "minecraft:attached_melon_stem" to "minecraft:melon_seeds",
+    "minecraft:pumpkin_stem" to "minecraft:pumpkin_seeds",
+    "minecraft:attached_pumpkin_stem" to "minecraft:pumpkin_seeds",
+    "minecraft:cave_vines" to "minecraft:glow_berries",
+    "minecraft:cave_vines_plant" to "minecraft:glow_berries",
+    "minecraft:kelp_plant" to "minecraft:kelp",
+    "minecraft:bamboo_sapling" to "minecraft:bamboo",
+    "minecraft:sweet_berry_bush" to "minecraft:sweet_berries",
+    "minecraft:tall_seagrass" to "minecraft:seagrass",
+    "minecraft:twisting_vines_plant" to "minecraft:twisting_vines",
+    "minecraft:weeping_vines_plant" to "minecraft:weeping_vines",
+    "minecraft:big_dripleaf_stem" to "minecraft:big_dripleaf",
+    "minecraft:pitcher_crop" to "minecraft:pitcher_pod",
+    "minecraft:torchflower_crop" to "minecraft:torchflower_seeds",
+    // placed tool/effect forms -> the material gathered
+    "minecraft:dirt_path" to "minecraft:dirt",
+    "minecraft:farmland" to "minecraft:dirt",
+    "minecraft:redstone_wire" to "minecraft:redstone",
+    "minecraft:tripwire" to "minecraft:string",
+    "minecraft:suspicious_sand" to "minecraft:sand",
+    "minecraft:suspicious_gravel" to "minecraft:gravel",
+    "minecraft:wall_torch" to "minecraft:torch",
+    // A filled cauldron is a block *state* of the cauldron, not an item of its own (there is
+    // no lava_cauldron item). What you gather is the cauldron; the bucket that fills it is a
+    // reusable tool, like the flint & steel behind a fire cell.
+    "minecraft:lava_cauldron" to "minecraft:cauldron",
+    "minecraft:water_cauldron" to "minecraft:cauldron",
+    "minecraft:powder_snow_cauldron" to "minecraft:cauldron",
+)
+
+/** What one placed cell costs — the four answers [resolvePlacedCell] can give. */
+sealed interface PlacedCell {
+    /** Not a material: air, an extended piston's head, a portal. Never mentioned again. */
+    data object Dropped : PlacedCell
+
+    /** A reusable tool. The amount is one bucket, whatever the cell count says. */
+    data class Fluid(val bucket: Item) : PlacedCell
+
+    /** An ordinary material, in the amount the cells give. */
+    data class Material(val item: Item) : PlacedCell
+
+    /**
+     * This version's catalog has no such item, and no rule above claimed it.
+     *
+     * A case rather than a null because the two doors disagree about it. A schematic drops it
+     * — the file may have been saved on a later version, and one stray id is not worth
+     * refusing an upload over. An idea reports it as a validation error: its version range
+     * was checked before this point, so an id outside the catalog means the idea and the
+     * world genuinely disagree and someone should hear about it.
+     */
+    data object Unknown : PlacedCell
+}
+
+/** A resolved cell list: what to gather, the fluid cell counts, and what nothing claimed. */
+data class PlacedMaterials(
+    val requirements: List<Pair<Item, Int>>,
+    val placedCounts: Map<String, Int> = emptyMap(),
+    val unknown: List<String> = emptyList(),
+)
+
+/** True for cells that are not a material of their own and carry no decision. */
+fun isDroppedPlacement(blockId: String): Boolean {
+    if (blockId in NON_MATERIAL_BLOCKS) return true
+    val name = blockId.substringAfter(':')
+    return name.startsWith("potted_") || name.startsWith("infested_") || name.endsWith("candle_cake")
+}
+
+/**
+ * Resolves one placed block-state id to the item a player actually gathers.
+ *
+ * Order:
+ * 1. [isDroppedPlacement] — placed forms that are not a material of their own (an extended
+ *    piston's head, potted plants counted as the pot+plant elsewhere, candle cakes,
+ *    silverfish-infested blocks).
+ * 2. [FLUID_PLACEMENTS] — a fluid is the bucket you carry, and only ever one of them. A fluid
+ *    never falls through to the generic path even when the version has no bucket for it
+ *    (powder snow before 1.17): keeping the fluid id would put back exactly the row this
+ *    exists to remove.
+ * 3. [REDIRECTS] — explicit block -> item for placed forms whose gathered item has a
+ *    different id.
+ * 4. *wall* variants — drop the `_wall_` infix when that yields a real item
+ *    (birch_wall_sign -> birch_sign, dead_horn_coral_wall_fan -> dead_horn_coral_fan).
+ * 5. Otherwise the id itself, or [PlacedCell.Unknown] when the version has no such item.
+ *
+ * Truly non-obtainable blocks (budding_amethyst) are intentionally left to resolve to
+ * themselves and surface as a BLOCKED row rather than a wrong guess. That row is what the
+ * MCO-305 warning strip is *for*; steps 3 and 4 are what stop it being crowded out by rows a
+ * player would read as nonsense — 592 "Redstone Wire (Block)" flagged as needing creative
+ * mode, when what they need is 592 redstone.
+ */
+fun resolvePlacedCell(blockId: String, byId: Map<String, Item>): PlacedCell {
+    if (isDroppedPlacement(blockId)) return PlacedCell.Dropped
+    FLUID_PLACEMENTS[blockId]?.let { bucketId ->
+        return byId[bucketId]?.let { PlacedCell.Fluid(it) } ?: PlacedCell.Dropped
+    }
+    REDIRECTS[blockId]?.let { target -> byId[target]?.let { return PlacedCell.Material(it) } }
+    if ("_wall_" in blockId) {
+        byId[blockId.replace("_wall_", "_")]?.let { return PlacedCell.Material(it) }
+    }
+    return byId[blockId]?.let { PlacedCell.Material(it) } ?: PlacedCell.Unknown
+}
+
+/**
+ * Resolves a whole cell-count map — the one entry point both import doors call (MCO-308).
+ *
+ * Amounts are **summed** onto the resolved item, not assigned, because resolution collapses
+ * ids: a build with both a sign and a wall sign, or with redstone dust placed *and* stored in
+ * a chest, must ask for the total rather than whichever id happened to come last.
+ *
+ * Fluids are appended after the ordinary materials so a review list reads with the build's own
+ * ids first, and their cell counts are returned separately — one bucket is the amount to
+ * gather, but "placed 4,013×" is what keeps that number reconcilable against Litematica.
+ */
+fun resolvePlacedCells(counts: Map<String, Int>, byId: Map<String, Item>): PlacedMaterials {
     val byItem = LinkedHashMap<Item, Int>()
     val fluidCells = LinkedHashMap<Item, Int>()
+    val unknown = mutableListOf<String>()
 
-    requirements.forEach { (item, amount) ->
-        if (item.id in NON_MATERIAL_BLOCKS) return@forEach
-
-        // A fluid never falls through to the generic path, even when the version has no
-        // bucket for it (powder snow before 1.17). Keeping the fluid id would put back
-        // exactly the row this exists to remove — the schematic door filters the same way.
-        val placement = FLUID_PLACEMENTS[item.id]
-        if (placement != null) {
-            byId[placement]?.let { bucket -> fluidCells[bucket] = (fluidCells[bucket] ?: 0) + amount }
-            return@forEach
+    counts.forEach { (blockId, amount) ->
+        when (val cell = resolvePlacedCell(blockId, byId)) {
+            is PlacedCell.Dropped -> Unit
+            is PlacedCell.Unknown -> unknown.add(blockId)
+            is PlacedCell.Fluid -> fluidCells[cell.bucket] = (fluidCells[cell.bucket] ?: 0) + amount
+            is PlacedCell.Material -> byItem[cell.item] = (byItem[cell.item] ?: 0) + amount
         }
-
-        byItem[item] = (byItem[item] ?: 0) + amount
     }
 
     fluidCells.keys.forEach { bucket -> byItem[bucket] = (byItem[bucket] ?: 0) + 1 }
 
-    return SchematicMaterials(
+    return PlacedMaterials(
         requirements = byItem.map { (item, amount) -> item to amount },
         placedCounts = fluidCells.entries.associate { (bucket, cells) -> bucket.id to cells },
+        unknown = unknown,
     )
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/PlacedBlocksTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/PlacedBlocksTest.kt
@@ -7,11 +7,11 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
- * MCO-396 — the idea door's half of the placed-cell rules.
+ * The placed-cell rules both import doors read (MCO-396, MCO-308).
  *
- * The schematic door exercises the same tables through `MapSchematicToMaterialsStepTest`.
- * This covers the subset an idea can hit, where requirements are catalog items rather than
- * block states.
+ * `MapSchematicToMaterialsStepTest` exercises the same tables through the schematic step and
+ * `ImportIdeaPipelineTest` through the idea step; this covers the rules themselves, including
+ * the cases only one door used to reach.
  */
 class PlacedBlocksTest {
 
@@ -26,62 +26,129 @@ class PlacedBlocksTest {
         "minecraft:lava_bucket",
         "minecraft:powder_snow_bucket",
         "minecraft:oak_planks",
+        "minecraft:redstone",
+        "minecraft:redstone_wire",
+        "minecraft:birch_sign",
+        "minecraft:birch_wall_sign",
+        "minecraft:dirt",
+        "minecraft:farmland",
+        "minecraft:carrot",
+        "minecraft:carrots",
+        "minecraft:cauldron",
+        "minecraft:budding_amethyst",
+        "minecraft:potted_cactus",
     ).map { Item(it, it.substringAfterLast(':')) }
 
-    private fun item(id: String) = catalog.single { it.id == id }
+    private val byId = catalog.associateBy { it.id }
 
-    private fun normalize(vararg rows: Pair<String, Int>) =
-        normalizePlacedBlocks(rows.associate { (id, amount) -> item(id) to amount }, catalog)
+    private fun resolve(vararg rows: Pair<String, Int>) = resolvePlacedCells(rows.toMap(), byId)
+
+    private fun PlacedMaterials.ids() = requirements.associate { it.first.id to it.second }
+
+    @Test
+    fun `placed redstone dust is redstone, not an unobtainable block`() {
+        // The MCO-308 report, verbatim: idea #3 offered 592 `Redstone Wire (Block)` and the
+        // warning strip called them creative-only. They are 592 redstone.
+        val result = resolve("minecraft:redstone_wire" to 592)
+
+        assertEquals(mapOf("minecraft:redstone" to 592), result.ids())
+        assertTrue(result.unknown.isEmpty())
+    }
+
+    @Test
+    fun `a wall sign is a sign`() {
+        val result = resolve("minecraft:birch_wall_sign" to 1)
+
+        assertEquals(mapOf("minecraft:birch_sign" to 1), result.ids())
+    }
+
+    @Test
+    fun `two placed forms of the same material sum rather than overwrite`() {
+        // The reason resolution sums: both ids are real, and both are dirt.
+        val result = resolve("minecraft:farmland" to 40, "minecraft:dirt" to 8)
+
+        assertEquals(mapOf("minecraft:dirt" to 48), result.ids())
+    }
+
+    @Test
+    fun `a redirect the version lacks falls through to the block itself`() {
+        // Better a BLOCKED row naming something real than a promise of an item this version
+        // has never had.
+        val narrow = catalog.filterNot { it.id == "minecraft:carrot" }.associateBy { it.id }
+
+        val result = resolvePlacedCells(mapOf("minecraft:carrots" to 9), narrow)
+
+        assertEquals(mapOf("minecraft:carrots" to 9), result.requirements.associate { it.first.id to it.second })
+    }
+
+    @Test
+    fun `potted plants and other non-materials are dropped`() {
+        val result = resolve(
+            "minecraft:potted_cactus" to 3,
+            "minecraft:nether_portal" to 24,
+            "minecraft:air" to 9_389_854,
+            "minecraft:oak_planks" to 5,
+        )
+
+        assertEquals(mapOf("minecraft:oak_planks" to 5), result.ids())
+        assertTrue(result.unknown.isEmpty())
+    }
+
+    @Test
+    fun `a genuinely unobtainable block resolves to itself and is left to the warning strip`() {
+        val result = resolve("minecraft:budding_amethyst" to 4)
+
+        assertEquals(mapOf("minecraft:budding_amethyst" to 4), result.ids())
+    }
+
+    @Test
+    fun `an id no rule and no catalog claims is reported, not silently dropped`() {
+        val result = resolve("minecraft:copper_golem_statue" to 2, "minecraft:oak_planks" to 1)
+
+        assertEquals(listOf("minecraft:copper_golem_statue"), result.unknown)
+        assertEquals(mapOf("minecraft:oak_planks" to 1), result.ids())
+    }
 
     @Test
     fun `a fluid becomes one bucket and keeps its cell count aside`() {
-        val result = normalize("minecraft:water" to 4000, "minecraft:oak_planks" to 12)
+        val result = resolve("minecraft:water" to 4000, "minecraft:oak_planks" to 12)
 
-        assertEquals(
-            mapOf("minecraft:water_bucket" to 1, "minecraft:oak_planks" to 12),
-            result.requirements.associate { it.first.id to it.second },
-        )
+        assertEquals(mapOf("minecraft:oak_planks" to 12, "minecraft:water_bucket" to 1), result.ids())
         assertEquals(mapOf("minecraft:water_bucket" to 4000), result.placedCounts)
     }
 
     @Test
     fun `source and flowing cells count as the same fluid`() {
-        val result = normalize("minecraft:water" to 900, "minecraft:flowing_water" to 13)
+        val result = resolve("minecraft:water" to 900, "minecraft:flowing_water" to 13)
 
         assertEquals(1, result.requirements.single().second)
         assertEquals(mapOf("minecraft:water_bucket" to 913), result.placedCounts)
     }
 
     @Test
-    fun `portals and air are dropped without a word`() {
-        val result = normalize(
-            "minecraft:nether_portal" to 24,
-            "minecraft:air" to 9_389_854,
-            "minecraft:oak_planks" to 5,
-        )
+    fun `a fluid whose bucket the version lacks is dropped rather than invented`() {
+        val narrow = catalog.filterNot { it.id == "minecraft:powder_snow_bucket" }.associateBy { it.id }
+
+        val result = resolvePlacedCells(mapOf("minecraft:powder_snow" to 2, "minecraft:oak_planks" to 5), narrow)
 
         assertEquals(listOf("minecraft:oak_planks"), result.requirements.map { it.first.id })
+        assertNull(result.placedCounts["minecraft:powder_snow_bucket"])
+        assertTrue(result.unknown.isEmpty())
+    }
+
+    @Test
+    fun `a filled cauldron is the cauldron you place`() {
+        val result = resolve("minecraft:water_cauldron" to 1)
+
+        assertEquals(mapOf("minecraft:cauldron" to 1), result.ids())
         assertTrue(result.placedCounts.isEmpty())
     }
 
     @Test
-    fun `a fluid whose bucket the version lacks is dropped rather than invented`() {
-        val narrow = catalog.filterNot { it.id == "minecraft:powder_snow_bucket" }
-
-        val result = normalizePlacedBlocks(
-            mapOf(item("minecraft:powder_snow") to 2, item("minecraft:oak_planks") to 5),
-            narrow,
-        )
-
-        assertEquals(listOf("minecraft:oak_planks"), result.requirements.map { it.first.id })
-        assertNull(result.placedCounts["minecraft:powder_snow_bucket"])
-    }
-
-    @Test
     fun `an ordinary list passes through untouched`() {
-        val result = normalize("minecraft:oak_planks" to 64)
+        val result = resolve("minecraft:oak_planks" to 64)
 
-        assertEquals(listOf("minecraft:oak_planks" to 64), result.requirements.map { it.first.id to it.second })
+        assertEquals(mapOf("minecraft:oak_planks" to 64), result.ids())
         assertTrue(result.placedCounts.isEmpty())
     }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
@@ -62,6 +62,7 @@ class ImportIdeaReviewIT : WithUser() {
     private var wideIdeaId: Int = 0
     private var multiModeIdeaId: Int = 0
     private var unknownProductionIdeaId: Int = 0
+    private var placedIdeaId: Int = 0
 
     @BeforeAll
     fun setup() {
@@ -83,6 +84,18 @@ class ImportIdeaReviewIT : WithUser() {
         addRequirement(airyIdeaId, "minecraft:air", 9_389_854)
         addRequirement(airyIdeaId, "minecraft:water", 12)
         addRequirement(airyIdeaId, "minecraft:oak_planks", 64)
+
+        // MCO-308, from the report: an idea captured from a schematic records *placed* ids.
+        // Both are real catalog entries, which is why they used to survive validation and
+        // land on the gathering list as rows no source produces.
+        seedItem("minecraft:redstone_wire", "Redstone Wire (Block)")
+        seedItem("minecraft:birch_sign", "Birch Sign")
+        seedItem("minecraft:birch_wall_sign", "Birch Wall Sign (Block)")
+        placedIdeaId = createIdea("Ghast Farm Wiring")
+        addRequirement(placedIdeaId, "minecraft:redstone_wire", 592)
+        addRequirement(placedIdeaId, "minecraft:birch_wall_sign", 1)
+        addRequirement(placedIdeaId, "minecraft:redstone", 8)
+        addRequirement(placedIdeaId, "minecraft:oak_planks", 64)
 
         // MCO-397: a curated "slow to gather" row, which must stay off the strip.
         seedItem("minecraft:elytra", "Elytra")
@@ -200,6 +213,57 @@ class ImportIdeaReviewIT : WithUser() {
         assertFalse(body.contains("minecraft:water="), "the fluid id itself must not be a row")
         assertContains(body, "placed 12×", message = "the schematic's own number stays visible")
         assertFalse(body.contains("Not really materials"), "the warning kind is gone entirely")
+    }
+
+    @Test
+    fun `placed block ids reach the review screen as the item you gather`() = testApplication {
+        // MCO-308. The idea door used to take recorded ids verbatim, so `Redstone Wire
+        // (Block)` x592 and `Birch Wall Sign (Block)` x1 arrived as rows — and MCO-305's strip
+        // correctly, uselessly, called them creative-only. Nothing produces redstone_wire; what
+        // the user needs is 592 redstone, which is an ordinary ask.
+        setupRoutes()
+
+        val response = client.get("/ideas/$placedIdeaId/import/review?worldId=$worldId") {
+            addAuthCookie(this)
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        // 592 placed + 8 already in item form: resolution sums onto the item, never overwrites.
+        assertContains(body, "minecraft:redstone=600", message = "placed dust and stored dust are one row")
+        assertContains(body, "minecraft:birch_sign=1", message = "a wall sign is a sign")
+        assertFalse(body.contains("minecraft:redstone_wire"), "the placed id must not survive")
+        assertFalse(body.contains("minecraft:birch_wall_sign"), "nor the wall variant")
+        assertFalse(
+            body.contains("not obtainable in survival"),
+            "and with them gone the strip has nothing left to warn about",
+        )
+    }
+
+    @Test
+    fun `a placed id resolved away is gathered under its real item on import`() = testApplication {
+        // The review screen posts back what it rendered, so the project gets the resolved rows.
+        setupRoutes()
+        val client = createClient { followRedirects = false }
+
+        val response = client.post("/ideas/$placedIdeaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "worldId=$worldId&name=Wiring&" + materials(
+                    "minecraft:redstone" to 600,
+                    "minecraft:birch_sign" to 1,
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val projectId = response.headers["Location"]!!.substringAfterLast("/").toInt()
+
+        assertEquals(
+            listOf("minecraft:birch_sign" to 1, "minecraft:redstone" to 600),
+            readRequirements(projectId).sortedBy { it.first },
+        )
     }
 
     @Test


### PR DESCRIPTION
Closes [MCO-308](https://linear.app/evegul/issue/MCO-308/idea-import-resolve-placed-block-ids-to-their-gathered-item-like-the).

An idea captured from a schematic records *placed* block-state ids, and the idea import took them verbatim. Nothing produces `minecraft:redstone_wire`, so idea #3 put 592 `Redstone Wire (Block)` and one `Birch Wall Sign (Block)` on the gathering list, and MCO-305's warning strip flagged them as needing creative mode. True, and useless — what the build needs is 592 redstone.

## What changed

MCO-396 had already lifted the *non-material* and *fluid* tables into `PlacedBlocks.kt`; the block-state redirects were still private to `MapSchematicToMaterialsStep`. This moves `REDIRECTS`, the `_wall_` infix rule and `isDropped` there too, behind a single `resolvePlacedCells(counts, byId)` that is now the only entry point either import door uses:

- `MapSchematicToMaterialsStep.resolve` collapses to a call to it (~110 lines removed; its private `ResolvedMaterials` folded into the shared `PlacedMaterials`).
- `ValidateItemIdsStep` calls it where an idea's raw ids first become `Item`s, so the review screen, the warnings and the created project all see gathered items.
- The review handler's second normalization pass is gone; `IdeaForImport` carries the resolved requirements plus `placedCounts`.

## Decisions worth a look

**Import-time, not capture-time** — as the issue leaned. The tables resolve against a *version catalog* and an idea spans a version range, so the same idea legitimately resolves differently in two worlds; fixing the stored data once would have to pick one.

**An unclaimed id is a `PlacedCell.Unknown` case, not a null** — the two doors genuinely disagree about it. A schematic drops it (a `.litematic` is often saved on a newer version, and one stray id shouldn't refuse an upload); an idea reports it as a validation error, since its version range was already checked. Collapsing that to "return null" would have silently changed the idea door's behaviour.

**Knock-on fix:** `ValidateItemIdsStep` used to *assign* amounts, which is wrong once resolution collapses ids. 592 placed dust + 8 stored dust now sums to 600 redstone instead of keeping whichever came last.

## Tests

1017 unit + 535 database, all passing.

- `PlacedBlocksTest` rewritten against the shared resolver — 12 cases, including the two reported rows, a redirect whose target the version lacks, and unknown-vs-dropped.
- Two new `ImportIdeaReviewIT` cases driving the real review GET and import POST.
- The schematic door's existing 24 tests pass **unchanged**, which is the useful signal that the lift didn't alter its behaviour.

No `preview` label — nothing to eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)