### PR TITLE
MCO-322: mark what a schematic is stocked with, apart from what it places

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/minecraft/Litematica.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/minecraft/Litematica.kt
@@ -20,6 +20,13 @@ data class Litematica(
     val size: Triple<Int, Int, Int>,
     val items: Map<String, Int>,
     val regions: List<LitematicaRegion> = emptyList(),
+    /**
+     * The part of [items] that the build is stocked with, per the same invariant (MCO-322).
+     *
+     * See [LitematicaRegion.containerItems] for what this is and why it is a *subset* of the
+     * total rather than a separate list.
+     */
+    val containerItems: Map<String, Int> = emptyMap(),
 )
 
 /**
@@ -34,4 +41,25 @@ data class Litematica(
 data class LitematicaRegion(
     val name: String,
     val items: Map<String, Int>,
+    /**
+     * How much of [items] came out of a container rather than the block palette (MCO-322).
+     *
+     * Litematica saves the contents of every chest, hopper, dispenser and dropper along with
+     * the blocks, and both used to land in [items] indistinguishable from each other. What is
+     * in those containers is normally **part of the build**, deliberately saved with it: the
+     * filter items a sorter needs, the redstone a shulker loader loads, the carved pumpkins
+     * that keep wither skeletons from despawning. A stocked container is the rule, not someone
+     * forgetting to empty a chest.
+     *
+     * The split is still worth keeping, because the two halves are different kinds of ask.
+     * Placed blocks are the structure and their count follows from its shape; container
+     * contents are consumables and stock, they occupy no volume, and their quantity is
+     * whatever scale the original builder worked at. A real perimeter farm's list was 70%
+     * carved pumpkins and a shulker loader's was 96% redstone — both correct, and both worth
+     * seeing as stock rather than reading as structure.
+     *
+     * A **subset of [items], not a sibling of it.** Nothing is excluded on this basis;
+     * reading it as a separate list would double-count every stocked chest.
+     */
+    val containerItems: Map<String, Int> = emptyMap(),
 )

--- a/webapp/mc-nbt/src/main/kotlin/app/mcorg/nbt/util/LitematicaReader.kt
+++ b/webapp/mc-nbt/src/main/kotlin/app/mcorg/nbt/util/LitematicaReader.kt
@@ -88,6 +88,7 @@ object LitematicaReader {
             size = metadata.size,
             items = regionData.items,
             regions = regionData.regions,
+            containerItems = regionData.containerItems,
         )
 
         return Result.success(litematica)
@@ -103,6 +104,7 @@ object LitematicaReader {
     data class LitematicaRegionData(
         val items: Map<String, Int>,
         val regions: List<LitematicaRegion>,
+        val containerItems: Map<String, Int> = emptyMap(),
     )
 
     private fun CompoundTag.extractMetadata(): LitematicaMetadata {
@@ -138,16 +140,20 @@ object LitematicaReader {
      */
     private fun CompoundTag.extractRegionData(): LitematicaRegionData {
         val items = mutableMapOf<String, Int>()
+        val containerItems = mutableMapOf<String, Int>()
         val regions = mutableListOf<LitematicaRegion>()
 
         this.value.forEach { (regionName, tag) ->
             if (tag is CompoundTag) {
-                val regionItems = tag.extractSingleRegionData()
-                if (regionItems.isNotEmpty()) {
-                    regions.add(LitematicaRegion(regionName, regionItems))
+                val region = tag.extractSingleRegionData()
+                if (region.items.isNotEmpty()) {
+                    regions.add(LitematicaRegion(regionName, region.items, region.containerItems))
                 }
-                regionItems.forEach { (itemName, itemCount) ->
+                region.items.forEach { (itemName, itemCount) ->
                     items[itemName] = items.getOrDefault(itemName, 0) + itemCount
+                }
+                region.containerItems.forEach { (itemName, itemCount) ->
+                    containerItems[itemName] = containerItems.getOrDefault(itemName, 0) + itemCount
                 }
             }
         }
@@ -155,27 +161,41 @@ object LitematicaReader {
         return LitematicaRegionData(
             items = items,
             regions = regions,
+            containerItems = containerItems,
         )
     }
 
-    private fun CompoundTag.extractSingleRegionData(): Map<String, Int> {
+    /**
+     * One region's counts, with the two sources kept apart (MCO-322).
+     *
+     * [items] is the total — placed blocks plus container contents — because that is what the
+     * material list has always meant and every caller already reads it that way. [containerItems]
+     * says how much of that total is what the build is stocked with rather than what it places,
+     * so the review screen can mark it. Both are wanted; they are just different kinds of ask.
+     */
+    private data class RegionCounts(
+        val items: Map<String, Int>,
+        val containerItems: Map<String, Int>,
+    )
+
+    private fun CompoundTag.extractSingleRegionData(): RegionCounts {
         // Get the palette (list of block types)
         val palette = this.getBlockStatePalette()
 
         // Get the size of the region
         // Litematica dimensions can be negative (indicating region direction); absolute value gives block count
         val size = this.value[Keys.SIZE] as? CompoundTag
-        val x = (size?.value?.get("x") as? IntTag)?.value?.absoluteValue ?: return emptyMap()
-        val y = (size?.value?.get("y") as? IntTag)?.value?.absoluteValue ?: return emptyMap()
-        val z = (size?.value?.get("z") as? IntTag)?.value?.absoluteValue ?: return emptyMap()
+        val x = (size?.value?.get("x") as? IntTag)?.value?.absoluteValue ?: return RegionCounts(emptyMap(), emptyMap())
+        val y = (size?.value?.get("y") as? IntTag)?.value?.absoluteValue ?: return RegionCounts(emptyMap(), emptyMap())
+        val z = (size?.value?.get("z") as? IntTag)?.value?.absoluteValue ?: return RegionCounts(emptyMap(), emptyMap())
         val totalBlocks = x.toLong() * y * z
-        if (totalBlocks > Int.MAX_VALUE) return emptyMap()
+        if (totalBlocks > Int.MAX_VALUE) return RegionCounts(emptyMap(), emptyMap())
         val totalBlocksInt = totalBlocks.toInt()
 
         // Get the packed block states
         val blockStatesTag = this.value[Keys.BLOCK_STATES] as? LongListTag
         if (blockStatesTag == null || palette.isEmpty()) {
-            return emptyMap()
+            return RegionCounts(emptyMap(), emptyMap())
         }
 
         val blockStates = blockStatesTag.value
@@ -230,12 +250,16 @@ object LitematicaReader {
             }
         }
 
-        getItemsInInventories()
-            .forEach { item ->
-                blockCounts[item.key] = blockCounts.getOrDefault(item.key, 0) + item.value
-            }
+        // Container contents are folded into the total — that is what the material list has
+        // always meant, and a stocked container is normally part of the build rather than
+        // clutter. The map is kept so the review screen can say which part of a row is stock
+        // the build carries rather than a block it places (MCO-322).
+        val containerItems = getItemsInInventories()
+        containerItems.forEach { (itemName, itemCount) ->
+            blockCounts[itemName] = blockCounts.getOrDefault(itemName, 0) + itemCount
+        }
 
-        return blockCounts
+        return RegionCounts(items = blockCounts, containerItems = containerItems)
     }
 
     private fun CompoundTag.getItemsInInventories(): Map<String, Int> {

--- a/webapp/mc-nbt/src/test/kotlin/app/mcorg/nbt/util/LitematicaReaderTest.kt
+++ b/webapp/mc-nbt/src/test/kotlin/app/mcorg/nbt/util/LitematicaReaderTest.kt
@@ -236,6 +236,69 @@ class LitematicaReaderTest {
         }
     }
 
+    /**
+     * A one-block region whose block is also a container holding [stocked] (MCO-322).
+     *
+     * Litematica writes container contents as a `TileEntities` list of compounds, each with an
+     * `Items` list of `{id, Count}`. That is the shape being asserted against, so it is written
+     * by hand here rather than borrowed from a fixture.
+     */
+    private fun DataOutputStream.writeStockedRegion(
+        name: String,
+        block: String,
+        stocked: List<Pair<String, Int>>,
+    ) {
+        writeCompoundEntry(name) {
+            writeCompoundEntry("Size") {
+                writeIntEntry("x", 1)
+                writeIntEntry("y", 1)
+                writeIntEntry("z", 1)
+            }
+            writePaletteEntry(block)
+            writeByte(12)            // LongListTag
+            writeUTF("BlockStates")
+            writeInt(1)
+            writeLong(1L)
+            // TileEntities: ListTag of CompoundTag
+            writeByte(9)
+            writeUTF("TileEntities")
+            writeByte(10)
+            writeInt(1)
+            // one tile entity, holding an Items list
+            writeByte(9)
+            writeUTF("Items")
+            writeByte(10)
+            writeInt(stocked.size)
+            stocked.forEach { (id, count) ->
+                writeStringEntry("id", id)
+                writeByte(1)         // ByteTag
+                writeUTF("Count")
+                writeByte(count)
+                writeByte(0)         // end of this item compound
+            }
+            writeByte(0)             // end of the tile-entity compound
+        }
+    }
+
+    private fun stockedFile() = buildRootCompound {
+        writeCompoundEntry("Metadata") {
+            writeStringEntry("Name", "Stocked sorter")
+            writeStringEntry("Author", "tester")
+            writeCompoundEntry("EnclosingSize") {
+                writeIntEntry("x", 1)
+                writeIntEntry("y", 1)
+                writeIntEntry("z", 1)
+            }
+        }
+        writeCompoundEntry("Regions") {
+            writeStockedRegion(
+                "Sorter",
+                "minecraft:hopper",
+                listOf("minecraft:redstone" to 32, "minecraft:hopper" to 4),
+            )
+        }
+    }
+
     private fun twoRegionFile() = buildRootCompound {
         writeCompoundEntry("Metadata") {
             writeStringEntry("Name", "Two parter")
@@ -324,5 +387,76 @@ class LitematicaReaderTest {
 
     fun getFileAsStream(filePath: String = defaultFile) =
         this::class.java.classLoader.getResourceAsStream(filePath)!!
+
+
+    // --- container contents vs placed structure (MCO-322) ---
+
+    @Test
+    fun `container contents are reported apart from the blocks they sit in`() {
+        val lit = TestUtils.assertResultSuccess(LitematicaReader.readLitematica(stockedFile()))
+
+        assertEquals(mapOf("minecraft:redstone" to 32, "minecraft:hopper" to 4), lit.containerItems)
+    }
+
+    @Test
+    fun `container contents stay part of the total`() {
+        // The split marks rows; it does not remove them. A stocked container is normally part
+        // of the build — filter items, fuel, what a farm consumes — so the material list still
+        // means "everything this costs".
+        val lit = TestUtils.assertResultSuccess(LitematicaReader.readLitematica(stockedFile()))
+
+        // One hopper placed plus four in the container, and the stocked redstone.
+        assertEquals(5, lit.items["minecraft:hopper"])
+        assertEquals(32, lit.items["minecraft:redstone"])
+    }
+
+    @Test
+    fun `a region carries its own container contents`() {
+        val lit = TestUtils.assertResultSuccess(LitematicaReader.readLitematica(stockedFile()))
+
+        assertEquals(
+            mapOf("minecraft:redstone" to 32, "minecraft:hopper" to 4),
+            lit.regions.single().containerItems,
+        )
+    }
+
+    @Test
+    fun `a schematic with empty containers reports none`() {
+        val lit = TestUtils.assertResultSuccess(LitematicaReader.readLitematica(twoRegionFile()))
+
+        assertTrue(lit.containerItems.isEmpty())
+        assertTrue(lit.regions.all { it.containerItems.isEmpty() })
+    }
+
+    @Test
+    fun `a real stocked schematic reports what it is loaded with`() {
+        // Compact_AB_Tilable_2x_Shulker_Loader is 96% container contents — 3,165 redstone and
+        // 125 shulker boxes. That is not clutter someone forgot to clear: it is what a shulker
+        // loader loads, and it is exactly the case the review screen needs to be able to name.
+        val lit = TestUtils.assertResultSuccess(
+            LitematicaReader.readLitematica(
+                getFileAsStream("litematica/Compact_AB_Tilable_2x_Shulker_Loader.litematic")
+            )
+        )
+
+        assertEquals(3165, lit.containerItems["minecraft:redstone"])
+        assertEquals(125, lit.containerItems["minecraft:shulker_box"])
+        // A subset of the total, never a separate list.
+        lit.containerItems.forEach { (id, stocked) ->
+            assertTrue(
+                lit.items.getValue(id) >= stocked,
+                "$id: container count $stocked must not exceed the total ${lit.items[id]}",
+            )
+        }
+    }
+
+    @Test
+    fun `a real schematic with nothing stored reports no container contents`() {
+        val lit = TestUtils.assertResultSuccess(
+            LitematicaReader.readLitematica(getFileAsStream("litematica/WiskeProSorter.litematic"))
+        )
+
+        assertTrue(lit.containerItems.isEmpty())
+    }
 
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/CreateProjectFromSchematicPipeline.kt
@@ -70,6 +70,7 @@ data class SchematicProject(
     val requirements: Map<Item, Int>,
     val placedCounts: Map<String, Int> = emptyMap(),
     val regions: List<ResolvedRegion> = emptyList(),
+    val containerCounts: Map<String, Int> = emptyMap(),
 )
 
 /**
@@ -84,6 +85,15 @@ data class SchematicMaterials(
     val requirements: List<Pair<Item, Int>>,
     val placedCounts: Map<String, Int> = emptyMap(),
     val regions: List<ResolvedRegion> = emptyList(),
+    /**
+     * How much of each row is stock the build carries rather than blocks it places (MCO-322).
+     *
+     * Keyed by item id, and a **subset** of [requirements] — never a list of its own. Also
+     * review-time context only: what you gather is the total, and nothing here changes it.
+     * Stocked containers are normal and usually deliberate, so this marks rows, never filters
+     * them.
+     */
+    val containerCounts: Map<String, Int> = emptyMap(),
 )
 
 /**
@@ -97,6 +107,8 @@ data class ResolvedRegion(
     val name: String,
     val requirements: List<Pair<Item, Int>>,
     val placedCounts: Map<String, Int> = emptyMap(),
+    /** This region's share of [SchematicMaterials.containerCounts] (MCO-322). */
+    val containerCounts: Map<String, Int> = emptyMap(),
     /**
      * The file this region came from, or null when the import was a single file (MCO-414).
      *
@@ -134,6 +146,7 @@ suspend fun ApplicationCall.handleReviewSchematic() {
                     requirements = project.requirements,
                     placedCounts = project.placedCounts,
                     regions = project.regions,
+                    containerCounts = project.containerCounts,
                     warnings = computeImportWarnings(worldId, project.requirements),
                 )
             )
@@ -373,6 +386,7 @@ data class MapSchematicFilesToMaterialsStep(
                         name = parsed.stem,
                         requirements = materials.requirements,
                         placedCounts = materials.placedCounts,
+                        containerCounts = materials.containerCounts,
                         sourceFile = parsed.stem,
                     )
                 )
@@ -385,6 +399,7 @@ data class MapSchematicFilesToMaterialsStep(
                 requirements = sumRequirementLists(perFile.map { it.second.requirements }),
                 placedCounts = sumPlacedCounts(perFile.map { it.second.placedCounts }),
                 regions = regions,
+                containerCounts = sumPlacedCounts(perFile.map { it.second.containerCounts }),
             )
         )
     }
@@ -435,7 +450,14 @@ data class MapSchematicToMaterialsStep(
         val regions = input.regions.mapNotNull { region ->
             val resolved = resolve(region.items, byId)
             resolved.takeIf { it.requirements.isNotEmpty() }
-                ?.let { ResolvedRegion(region.name, it.requirements, it.placedCounts) }
+                ?.let {
+                    ResolvedRegion(
+                        name = region.name,
+                        requirements = it.requirements,
+                        placedCounts = it.placedCounts,
+                        containerCounts = containerCounts(region.containerItems, byId),
+                    )
+                }
         }
 
         // The flat list is the sum over regions, not a second resolution of the flattened
@@ -458,6 +480,15 @@ data class MapSchematicToMaterialsStep(
             )
         }
 
+        // Same sum-over-regions rule as the flat list, for the same reason: the review screen
+        // totals the region rows, so a container count derived any other way would disagree
+        // with the rows it is annotating.
+        val fromContainers = if (regions.isEmpty()) {
+            containerCounts(input.containerItems, byId)
+        } else {
+            sumPlacedCounts(regions.map { it.containerCounts })
+        }
+
         val requirements = flat.requirements
 
         if (requirements.isEmpty()) {
@@ -478,8 +509,26 @@ data class MapSchematicToMaterialsStep(
                 requirements = requirements,
                 placedCounts = flat.placedCounts,
                 regions = regions,
+                containerCounts = fromContainers,
             )
         )
+    }
+
+    /**
+     * The container half of a region, resolved to item ids (MCO-322).
+     *
+     * Run through the **same** resolution as the total rather than taken verbatim, because the
+     * two have to agree about what a row *is*. A region that places farmland and stocks dirt
+     * has one `dirt` row, and the container share of it is only meaningful if both halves
+     * resolved `farmland` to `dirt` the same way. For real container contents this is close to
+     * identity — a chest holds items, not block states — but "close to" is not a thing to build
+     * a subset relationship on.
+     */
+    private fun containerCounts(containerItems: Map<String, Int>, byId: Map<String, Item>): Map<String, Int> {
+        if (containerItems.isEmpty()) return emptyMap()
+        return resolvePlacedCells(containerItems, byId)
+            .requirements
+            .associate { (item, amount) -> item.id to amount }
     }
 
     /**
@@ -524,6 +573,7 @@ private data class MapSchematicToProjectStep(
                 materials.requirements.toMap(),
                 materials.placedCounts,
                 materials.regions,
+                materials.containerCounts,
             )
         )
     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -85,6 +85,7 @@ fun importReviewPage(
     hiddenFields: Map<String, String> = emptyMap(),
     placedCounts: Map<String, Int> = emptyMap(),
     regions: List<ResolvedRegion> = emptyList(),
+    containerCounts: Map<String, Int> = emptyMap(),
     warnings: ImportWarnings = ImportWarnings(),
     unrecordableProductions: List<String> = emptyList(),
     offerAlreadyBuilt: Boolean = false,
@@ -151,7 +152,7 @@ fun importReviewPage(
 
                 alreadyBuiltControl(offerAlreadyBuilt)
 
-                materialsSection(requirements, emptySet(), placedCounts, regions, warnings)
+                materialsSection(requirements, emptySet(), placedCounts, regions, containerCounts, warnings)
 
                 div("import-review__actions") {
                     button(classes = "btn btn--primary") {
@@ -268,6 +269,7 @@ private fun FlowContent.materialsSection(
     excluded: Set<String>,
     placedCounts: Map<String, Int>,
     regions: List<ResolvedRegion>,
+    containerCounts: Map<String, Int>,
     warnings: ImportWarnings,
 ) {
     div("import-review__materials") {
@@ -282,11 +284,12 @@ private fun FlowContent.materialsSection(
         warningStrip(warnings)
         materialsSummary(groups, allRows)
         sectionsLead(groups, regions.mapNotNull { it.sourceFile }.distinct().size)
+        stockedLead(allRows, containerCounts)
         groups.forEachIndexed { index, group ->
             if (group.name == null) {
-                materialsTable(index, group.rows, excluded, placedCounts, warnings)
+                materialsTable(index, group.rows, excluded, placedCounts, containerCounts, warnings)
             } else {
-                regionGroup(index, group, excluded, placedCounts, warnings)
+                regionGroup(index, group, excluded, placedCounts, containerCounts, warnings)
             }
         }
 
@@ -318,6 +321,50 @@ private fun FlowContent.sectionsLead(groups: List<MaterialGroup>, fileCount: Int
             +"This schematic is built from ${groups.size} sections. "
         }
         +"Untick one to leave it out of the import, or open it to choose materials one at a time."
+    }
+}
+
+/**
+ * Says, once and above the rows, how much of this list is stock rather than structure.
+ *
+ * The per-row chip is the detail; this is the part that is actually readable. The reported case
+ * was a 519,844-unit import whose largest row — 362,706 carved pumpkins, 70% of the total — was
+ * what that wither farm consumes, and a chip on one row of hundreds is not how anyone finds
+ * that out. The claim worth making up front is *most of this is not the building*.
+ *
+ * Deliberately not phrased as a problem. Stocked containers are normal and usually intended —
+ * the same fixture set has a shulker loader that is 96% redstone, which is simply what a shulker
+ * loader is for. The line reports a proportion and stops; the reader decides whether they want
+ * that much of it.
+ *
+ * A line, not the `!` strip. MCO-397 cut that strip back to creative-only rows — the one kind
+ * that asks for a decision before the import lands. Nothing here is wrong, so a warning icon
+ * would repeat exactly the mistake MCO-397 undid.
+ *
+ * Silent below a fifth of the list. A sorter's filter items are container contents too, and
+ * every redstone build has some; announcing a 2% share would turn a real distinction into
+ * chrome that appears on every import and is read on none.
+ */
+private fun FlowContent.stockedLead(allRows: List<Pair<Item, Int>>, containerCounts: Map<String, Int>) {
+    if (containerCounts.isEmpty()) return
+
+    val total = allRows.sumOf { it.second.toLong() }
+    if (total <= 0) return
+
+    // Against the rows actually on screen, so the share and the list agree. A container count
+    // for a row that resolution dropped is not part of what the user is being shown.
+    val shown = allRows.map { it.first.id }.toSet()
+    val stocked = containerCounts.filterKeys { it in shown }.values.sumOf { it.toLong() }
+    if (stocked <= 0) return
+
+    val percent = (stocked * 100 / total).toInt()
+    if (percent < 20) return
+
+    p("import-review__stocked-lead") {
+        +"$percent% of this list (${"%,d".format(stocked)} items) is what the build is stocked "
+        +"with — filter items, fuel, whatever it consumes — rather than blocks it places. That is "
+        +"normal for a farm or a sorter, but the amount is the original builder's, so it is worth "
+        +"a look before you gather it."
     }
 }
 
@@ -525,6 +572,7 @@ private fun FlowContent.regionGroup(
     group: MaterialGroup,
     excluded: Set<String>,
     placedCounts: Map<String, Int>,
+    containerCounts: Map<String, Int>,
     warnings: ImportWarnings,
 ) {
     val blocks = group.rows.sumOf { it.second.toLong() }
@@ -545,7 +593,47 @@ private fun FlowContent.regionGroup(
                 span("import-review__region-toggle--open") { +"Hide materials ▴" }
             }
         }
-        materialsTable(index, group.rows, excluded, placedCounts, warnings)
+        materialsTable(index, group.rows, excluded, placedCounts, containerCounts, warnings)
+    }
+}
+
+/**
+ * Says how much of a row is stock the build carries rather than blocks it places (MCO-322).
+ *
+ * Litematica saves chest, hopper, dispenser and dropper contents alongside the blocks, and the
+ * material list has always merged the two. What is in those containers is normally deliberate —
+ * the filter items a sorter needs, the redstone a shulker loader loads, the carved pumpkins that
+ * keep wither skeletons from despawning. This does not mark a mistake, and must not read as
+ * though it does.
+ *
+ * It is worth marking because the two are different kinds of ask. Placed blocks are structure
+ * and their count follows from its shape; stock is consumable, occupies no volume, and its
+ * quantity is whatever scale the original builder worked at — a fine thing to want less of. A
+ * real perimeter farm's list was 70% carved pumpkins and a shulker loader's 96% redstone, both
+ * entirely correct and both easy to mistake for structure at a glance.
+ *
+ * **Marked, never excluded.** A chip in the same register as MCO-396's `placed N×`: a fact about
+ * where a number came from, sitting next to the number, with no control attached and nothing
+ * unchecked on its behalf.
+ *
+ * Two shapes, because "all of it" and "some of it" are different facts. A row that is entirely
+ * stock says so plainly; a partly-stocked row gives the count, since "12 in containers" against
+ * a quantity of 40 is what tells you the other 28 are structure.
+ */
+private fun FlowContent.containerMarker(item: Item, amount: Int, fromContainers: Int?) {
+    if (fromContainers == null || fromContainers <= 0) return
+
+    val all = fromContainers >= amount
+    span("import-review__stocked") {
+        attributes["title"] = if (all) {
+            "Every ${item.name} here is container contents — what the build is stocked with " +
+                "rather than a block it places. Filter items, fuel and consumables normally " +
+                "arrive this way."
+        } else {
+            "${"%,d".format(fromContainers)} of these were in containers when the schematic was " +
+                "saved; the rest are placed blocks."
+        }
+        +if (all) "in containers" else "${"%,d".format(fromContainers)} in containers"
     }
 }
 
@@ -554,6 +642,7 @@ private fun FlowContent.materialsTable(
     rows: List<Pair<Item, Int>>,
     excluded: Set<String>,
     placedCounts: Map<String, Int>,
+    containerCounts: Map<String, Int>,
     warnings: ImportWarnings,
 ) {
     div("import-review__table-wrap") {
@@ -608,6 +697,7 @@ private fun FlowContent.materialsTable(
                                     +"placed ${"%,d".format(cells)}×"
                                 }
                             }
+                            containerMarker(item, amount, containerCounts[item.id])
                         }
                         td {
                             attributes["data-label"] = "Quantity"

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -361,7 +361,10 @@ private fun FlowContent.stockedLead(allRows: List<Pair<Item, Int>>, containerCou
     if (percent < 20) return
 
     p("import-review__stocked-lead") {
-        +"$percent% of this list (${"%,d".format(stocked)} items) is what the build is stocked "
+        // "units", not "items" — [materialsSummary] renders "13 items" a line above this,
+        // meaning distinct materials. Using the same word for a quantity sum would put two
+        // different counts of "items" an inch apart on the same screen.
+        +"$percent% of this list (${"%,d".format(stocked)} units) is what the build is stocked "
         +"with — filter items, fuel, whatever it consumes — rather than blocks it places. That is "
         +"normal for a farm or a sorter, but the amount is the original builder's, so it is worth "
         +"a look before you gather it."

--- a/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
@@ -399,4 +399,15 @@
     .import-review__region-toggle {
         margin-left: auto;
     }
+
+    /* The stacked card gives the item cell one narrow column, and a row carrying both the
+       amber flag and a container count overflows it — "125 in contai…" clipped at 375px.
+       Its own line, left-aligned with the name above it, rather than a nowrap span competing
+       for the same inch. Kept to the marker: the flag chip is short enough to sit inline. */
+    .import-review__stocked {
+        display: block;
+        margin-left: 0;
+        margin-top: var(--space-1);
+        white-space: normal;
+    }
 }

--- a/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
@@ -133,6 +133,18 @@
     cursor: help;
 }
 
+/* MCO-322 — how much of a row is stock the build carries rather than blocks it places. Same
+   footnote weight as .import-review__placed, and for the same reason: nothing is wrong with
+   the row, it is included, and the only thing being said is where the number came from. */
+.import-review__stocked {
+    margin-left: var(--space-2);
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    white-space: nowrap;
+    cursor: help;
+}
+
 .import-review__summary {
     display: flex;
     align-items: baseline;
@@ -207,6 +219,17 @@
 }
 
 .import-review__sections-lead {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    margin: 0;
+    max-width: 70ch;
+}
+
+/* MCO-322 — the "most of this is stock, not structure" line. Reads as a lead, not a warning:
+   the callout treatment is reserved for creative-only rows (MCO-397), and a stocked container
+   is normal and usually intended, not something wrong with the file. */
+.import-review__stocked-lead {
     font-family: var(--font-body);
     font-size: var(--text-sm);
     color: var(--text-muted);

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/MapSchematicToMaterialsStepTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/MapSchematicToMaterialsStepTest.kt
@@ -348,4 +348,81 @@ class MapSchematicToMaterialsStepTest {
         val result = MapSchematicToMaterialsStep(catalog).process(litematica(mapOf("minecraft:piston_head" to 1)))
         assertTrue(result is Result.Failure)
     }
+
+    // --- stock vs structure (MCO-322) ---
+
+    private fun stocked(
+        items: Map<String, Int>,
+        containerItems: Map<String, Int>,
+        regions: List<LitematicaRegion> = emptyList(),
+    ): SchematicMaterials = runBlocking {
+        val result = MapSchematicToMaterialsStep(catalog).process(
+            Litematica("Build", "", "", Triple(1, 1, 1), items, regions, containerItems)
+        )
+        assertIs<Result.Success<SchematicMaterials>>(result)
+        result.value
+    }
+
+    @Test
+    fun `container contents are reported as a share of the row, not a row of their own`() {
+        val result = stocked(
+            items = mapOf("minecraft:redstone" to 3165, "minecraft:oak_planks" to 40),
+            containerItems = mapOf("minecraft:redstone" to 3165),
+        )
+
+        assertEquals(
+            mapOf("minecraft:redstone" to 3165, "minecraft:oak_planks" to 40),
+            result.requirements.associate { it.first.id to it.second },
+            "the total is unchanged — stock is marked, never removed",
+        )
+        assertEquals(mapOf("minecraft:redstone" to 3165), result.containerCounts)
+    }
+
+    @Test
+    fun `a partly stocked row keeps the placed part out of the container count`() {
+        // One hopper placed, four more sitting in it. The row is five; only four are stock.
+        val result = stocked(
+            items = mapOf("minecraft:oak_planks" to 5),
+            containerItems = mapOf("minecraft:oak_planks" to 4),
+        )
+
+        assertEquals(5, result.requirements.single().second)
+        assertEquals(4, result.containerCounts["minecraft:oak_planks"])
+    }
+
+    @Test
+    fun `stored items resolve the same way placed ones do`() {
+        // A chest of carrots and a field of planted ones are the same row, so the container
+        // share is only meaningful if both halves went through the same resolution.
+        val result = stocked(
+            items = mapOf("minecraft:carrots" to 9, "minecraft:carrot" to 30),
+            containerItems = mapOf("minecraft:carrot" to 30),
+        )
+
+        assertEquals(mapOf("minecraft:carrot" to 39), result.requirements.associate { it.first.id to it.second })
+        assertEquals(mapOf("minecraft:carrot" to 30), result.containerCounts)
+    }
+
+    @Test
+    fun `container counts sum over regions like the flat list does`() {
+        val result = stocked(
+            items = mapOf("minecraft:redstone" to 30),
+            containerItems = mapOf("minecraft:redstone" to 30),
+            regions = listOf(
+                LitematicaRegion("North", mapOf("minecraft:redstone" to 20), mapOf("minecraft:redstone" to 20)),
+                LitematicaRegion("South", mapOf("minecraft:redstone" to 10), mapOf("minecraft:redstone" to 10)),
+            ),
+        )
+
+        assertEquals(mapOf("minecraft:redstone" to 30), result.containerCounts)
+        assertEquals(listOf(20, 10), result.regions.map { it.containerCounts.getValue("minecraft:redstone") })
+    }
+
+    @Test
+    fun `a schematic with empty containers reports no container counts`() {
+        val result = stocked(mapOf("minecraft:oak_planks" to 5), emptyMap())
+
+        assertTrue(result.containerCounts.isEmpty())
+    }
+
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/CreateProjectFromSchematicIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/CreateProjectFromSchematicIT.kt
@@ -280,6 +280,60 @@ class CreateProjectFromSchematicIT : WithUser() {
         assertEquals(before, countProjects(worldId), "review must not create anything")
     }
 
+    @Test
+    fun `a stocked schematic marks what it is loaded with, all the way from the file`() = testApplication {
+        // MCO-322, end to end on a real file. `litematica-test.litematic` is a compact shulker
+        // loader whose containers hold 3,165 redstone and 125 shulker boxes — 96% of its list.
+        // That is not clutter: it is what a shulker loader loads. Before this, those quantities
+        // were indistinguishable from placed blocks the moment the reader merged the two maps.
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/from-schematic/review") {
+            addAuthCookie(this)
+            setBody(multipart(fileName = "loader.litematic", bytes = litematicBytes))
+        }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertTrue(body.contains("in containers"), "the stocked rows are marked")
+        assertTrue(body.contains("import-review__stocked-lead"), "and the share is stated above the list")
+        assertTrue(
+            body.contains("rather than blocks it places"),
+            "phrased as what the build carries, not as a problem with the file",
+        )
+    }
+
+    @Test
+    fun `stocked rows are marked but never excluded`() = testApplication {
+        // The distinction is information, not a filter. Every row still arrives checked, and
+        // the material list still totals everything the build costs.
+        setupRoutes()
+
+        val response = client.post("/worlds/$worldId/projects/from-schematic/review") {
+            addAuthCookie(this)
+            setBody(multipart(fileName = "loader.litematic", bytes = litematicBytes))
+        }
+
+        val body = response.bodyAsText()
+        val litematica = (LitematicaReader.readLitematica(litematicBytes) as Result.Success).value
+        val stockedRedstone = litematica.containerItems.getValue("minecraft:redstone")
+        // Placed dust resolves onto the same row as stored dust (MCO-308), so the rendered
+        // amount is both halves — which is the point: one row, and the chip says how much of
+        // it is stock.
+        val expectedRedstone = litematica.items.getValue("minecraft:redstone") +
+            (litematica.items["minecraft:redstone_wire"] ?: 0)
+
+        assertTrue(stockedRedstone > 0, "fixture sanity: this file is stocked")
+        assertTrue(
+            body.contains("minecraft:redstone=$expectedRedstone"),
+            "the row carries the full amount, stock included",
+        )
+        assertTrue(
+            expectedRedstone >= stockedRedstone,
+            "the container count is a share of the row, never larger than it",
+        )
+    }
+
     // -------------------------------------------------------------------------
     // Several files as one import (MCO-414)
     // -------------------------------------------------------------------------

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPageTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPageTest.kt
@@ -296,6 +296,11 @@ class ImportReviewPageTest {
 
         assertContains(html, "import-review__stocked-lead")
         assertContains(html, "96% of this list")
+        assertContains(
+            html,
+            "3,165 units",
+            message = "units, not items — the summary above already uses 'items' for distinct materials",
+        )
         assertContains(html, "rather than blocks it places")
     }
 

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPageTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPageTest.kt
@@ -27,6 +27,7 @@ class ImportReviewPageTest {
         requirements: Map<Item, Int>,
         regions: List<ResolvedRegion> = emptyList(),
         placedCounts: Map<String, Int> = emptyMap(),
+        containerCounts: Map<String, Int> = emptyMap(),
     ) = importReviewPage(
         user = user,
         worldId = 1,
@@ -35,6 +36,7 @@ class ImportReviewPageTest {
         requirements = requirements,
         placedCounts = placedCounts,
         regions = regions,
+        containerCounts = containerCounts,
     )
 
     private val frame = ResolvedRegion(
@@ -250,4 +252,76 @@ class ImportReviewPageTest {
         assertContains(html, "This schematic is built from 2 sections")
         assertFalse(html.contains("are being imported as one project"))
     }
+
+    // --- stock vs structure (MCO-322) ---
+
+    @Test
+    fun `a fully stocked row is marked as container contents`() {
+        val html = render(
+            requirements = mapOf(item("redstone") to 3165, item("oak_planks") to 40),
+            containerCounts = mapOf("minecraft:redstone" to 3165),
+        )
+
+        assertContains(html, "in containers")
+        // Marked, not struck: the row is still checked and still in the list.
+        assertContains(html, "minecraft:redstone=3165")
+    }
+
+    @Test
+    fun `a partly stocked row says how much of it is stock`() {
+        val html = render(
+            requirements = mapOf(item("hopper") to 40),
+            containerCounts = mapOf("minecraft:hopper" to 12),
+        )
+
+        assertContains(html, "12 in containers", message = "the count is what tells you the other 28 are structure")
+    }
+
+    @Test
+    fun `a row with nothing in containers carries no marker`() {
+        val html = render(requirements = mapOf(item("oak_planks") to 40))
+
+        assertFalse(html.contains("in containers"))
+        assertFalse(html.contains("import-review__stocked"))
+    }
+
+    @Test
+    fun `a mostly stocked list says so above the rows`() {
+        // The reported case in miniature: most of what looks like a build is what it is stocked
+        // with. The chip is on one row of many; this is the part that gets read.
+        val html = render(
+            requirements = mapOf(item("redstone") to 3165, item("oak_planks") to 100),
+            containerCounts = mapOf("minecraft:redstone" to 3165),
+        )
+
+        assertContains(html, "import-review__stocked-lead")
+        assertContains(html, "96% of this list")
+        assertContains(html, "rather than blocks it places")
+    }
+
+    @Test
+    fun `the lead reports a proportion rather than warning about one`() {
+        // A stocked container is normal — a shulker loader full of redstone is what a shulker
+        // loader is. The callout treatment stays reserved for creative-only rows (MCO-397).
+        val html = render(
+            requirements = mapOf(item("redstone") to 3165, item("oak_planks") to 100),
+            containerCounts = mapOf("minecraft:redstone" to 3165),
+        )
+
+        assertContains(html, "That is normal for a farm or a sorter")
+        assertFalse(html.contains("callout__icon"), "no warning icon for something that is not wrong")
+    }
+
+    @Test
+    fun `a build with only a few filter items says nothing at all`() {
+        // Every sorter has some. Announcing a 2% share would put this line on every import.
+        val html = render(
+            requirements = mapOf(item("oak_planks") to 1000, item("redstone") to 20),
+            containerCounts = mapOf("minecraft:redstone" to 20),
+        )
+
+        assertFalse(html.contains("import-review__stocked-lead"), "below the threshold, the lead is silent")
+        assertContains(html, "in containers", message = "but the row itself is still marked")
+    }
+
 }


### PR DESCRIPTION
Closes [MCO-322](https://linear.app/evegul/issue/MCO-322/mark-container-contents-separately-from-placed-structure-in-the-import).

`LitematicaReader.extractSingleRegionData` folded tile-entity `Items` into the block-palette counts and returned one map, so anything in a chest, hopper, dispenser or dropper became indistinguishable from a placed block. The review screen then presented both as one flat list of "materials to gather".

## What changed

Both maps already existed — the merge was the only place the distinction was lost.

- **`mc-nbt` / `mc-domain`** — `Litematica` and `LitematicaRegion` carry `containerItems`; `items` stays the merged total, so the documented invariant and every existing caller are untouched.
- **`mc-web`** — container contents are resolved through the **same** `resolvePlacedCells` as the total (MCO-308), not taken verbatim. A region that places farmland and stocks dirt has one `dirt` row, and the container share of it only means anything if both halves resolved the same way. `SchematicMaterials`/`ResolvedRegion` carry the split to the review page.
- **Review screen** — a per-row chip in the same footnote register as MCO-396's `placed N×`, plus one lead line when stock is ≥20% of the list.

## Marked, never excluded

A stocked container is normally deliberate and part of the build: the filter items a sorter needs, the redstone a shulker loader loads, the carved pumpkins that keep wither skeletons from despawning.

The fixtures make the point — `Compact_AB_Tilable_2x_Shulker_Loader` is **96% container contents** (3,165 redstone, 125 shulker boxes), which is simply what a shulker loader *is*. What earns the mark is not that the contents are suspect but that stock and structure are different kinds of ask: stock occupies no volume, and its quantity is the original builder's scale rather than the build's shape.

So this is a chip and a line, not the `!` strip — MCO-397 cut that back to creative-only rows, and nothing here is wrong.

## Verified in the browser

Uploaded the fixture to a real world and looked at the result. 3 of 13 rows marked:

| Item | Marker | Quantity |
|---|---|---|
| Redstone Dust | `3,165 in containers` | 3172 |
| Shulker Box | `SLOW TO GATHER` · `125 in containers` | 127 |
| Stick | `in containers` (all of it) | 34 |
| Block of Iron, Observer, Hopper, … | — | 30, 17, 12, … |

The Redstone row shows the MCO-308 interaction in the wild: 3,165 stocked + 7 placed `redstone_wire` = 3172, one row, chip saying how much is stock.

**Two defects that only showed up on screen** (second commit):

- The summary renders "13 items" (distinct materials) one line above the lead, which said "3,324 items" (a quantity sum) — two different counts of "items" an inch apart. Now "units"; pinned by a test.
- At 375px a row carrying both the amber flag and a container count clipped to "125 in contai…". The marker now takes its own line below 768px. Desktop unchanged.

## Tests

1028 unit + 537 database, all passing.

- Parser split on hand-built NBT and on both real fixtures (one stocked, one not), including the subset invariant.
- Mapper resolution, partial rows, and per-region summing.
- Rendered chip and lead, including that the lead stays silent below the threshold.
- End-to-end upload — mc-web's own IT fixture turns out to be that same 96%-stocked loader, so the real case was already in the suite.

No `preview` label — verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
