### PR TITLE
MCO-463: modes have a kind, and a build-time variant carries its own material list

### DIFF
--- a/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/idea/IdeaProduction.kt
+++ b/webapp/mc-domain/src/main/kotlin/app/mcorg/domain/model/idea/IdeaProduction.kt
@@ -1,13 +1,58 @@
 package app.mcorg.domain.model.idea
 
 /**
- * One way an idea can be run, and what it produces that way.
+ * Whether a mode is chosen when you *build* a design or while you *run* it (MCO-463).
+ *
+ * The discriminator is not switchability, it is **what the mode changes**. That distinction is the
+ * whole reason this type exists, so it is worth stating plainly rather than leaving to the two
+ * names:
+ *
+ * | | changes | fixed at |
+ * |---|---|---|
+ * | [RUNTIME] | what the farm supplies | never — flip it whenever you like |
+ * | [BUILD_TIME] | what it supplies **and what it costs to build** | import; changing it means rebuilding |
+ *
+ * A nether fortress farm's wither-skeleton filter is [RUNTIME]: flip the lever and nothing about
+ * the build changes. A cobblestone farm's *single module / 4 modules* is [BUILD_TIME]: the 4-module
+ * variant costs roughly four times the materials, and it is a different schematic.
+ */
+enum class IdeaModeKind {
+    /** Chosen once, when the thing is built. Carries its own [IdeaProductionMode.requirements]. */
+    BUILD_TIME,
+
+    /**
+     * Switchable on the built farm. Never carries requirements — a runtime mode by definition does
+     * not change what the build cost. These are the modes MCO-413 follows to the project.
+     */
+    RUNTIME,
+    ;
+
+    companion object {
+        /**
+         * What an unrecognised or absent value means.
+         *
+         * [RUNTIME], because every mode entered before MCO-463 was answered under a form that only
+         * ever described ways of *running* a farm. Reading those as build-time would attribute a
+         * choice to their authors that they were never offered. Matches the column default.
+         */
+        val Default = RUNTIME
+
+        fun fromOrDefault(value: String?): IdeaModeKind =
+            entries.firstOrNull { it.name == value } ?: Default
+    }
+}
+
+/**
+ * One way an idea can be run or built, and what that costs and produces.
  *
  * A farm that can be run more than one way produces different things at different rates depending
  * on how: an ice farm at full speed or slowed for lag, a nether fortress farm with a
  * wither-skeleton filter on or off. Modes are flat rather than combinations of axes — the
  * six-mode fortress farm is rare enough that listing six modes beats a model that multiplies
- * dimensions for every farm that has none.
+ * dimensions for every farm that has none. MCO-463 found a second multiplying case (2 axes × 2)
+ * and kept flat anyway; it is the [kind] that cannot be flattened away, since a farm mixing a
+ * build-time axis with a runtime one produces a list where some entries are switchable and some
+ * are not.
  *
  * Most ideas have exactly one mode. [isImplicit] marks the one created for them without asking,
  * so the UI can keep saying nothing about modes until there are two.
@@ -21,8 +66,24 @@ data class IdeaProductionMode(
      * measured how fast. A missing rate is information; an invented one is not.
      */
     val rates: Map<String, Int?>,
+    val kind: IdeaModeKind = IdeaModeKind.Default,
+    /**
+     * What this variant costs to build, item id -> quantity — populated only for [BUILD_TIME]
+     * modes, and only by the reads that ask for it.
+     *
+     * A whole list, not a delta against the idea's base list: a build-time variant arrives as its
+     * own `.litematic`, so a complete list is what the front door produces. When this is
+     * non-empty it *replaces* the idea's base material list rather than adding to it.
+     *
+     * Empty is therefore ambiguous on purpose — it means either "runtime mode, no such thing" or
+     * "this read did not fetch requirements". Callers that need the distinction have [kind].
+     */
+    val requirements: Map<String, Int> = emptyMap(),
 ) {
     val isImplicit: Boolean get() = name == DEFAULT_MODE_NAME
+
+    /** Whether this mode is fixed when the design is built rather than switchable afterwards. */
+    val isBuildTime: Boolean get() = kind == IdeaModeKind.BUILD_TIME
 
     companion object {
         /**
@@ -32,6 +93,18 @@ data class IdeaProductionMode(
         const val DEFAULT_MODE_NAME = "Default"
     }
 }
+
+/**
+ * The build-time modes among these, in author order — the ones an import has to make a choice
+ * between, because each costs something different to build.
+ */
+fun List<IdeaProductionMode>.buildTimeModes(): List<IdeaProductionMode> = filter { it.isBuildTime }
+
+/**
+ * The runtime modes among these — the ones that follow an import to the project and stay
+ * switchable there (MCO-413).
+ */
+fun List<IdeaProductionMode>.runtimeModes(): List<IdeaProductionMode> = filterNot { it.isBuildTime }
 
 /**
  * The best rate any of [modes] achieves for [itemId], with the mode that achieves it.

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/CreateIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/CreateIdeaPipeline.kt
@@ -12,6 +12,7 @@ import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.SafeSQL
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.idea.commonsteps.IdeaProductionModeInput
+import app.mcorg.pipeline.idea.commonsteps.replaceBaseRequirements
 import app.mcorg.pipeline.idea.commonsteps.replaceIdeaProductionModes
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
@@ -108,7 +109,10 @@ data class CreateIdeaStep(val userId: Int) : Step<CreateIdeaInput, AppFailure.Da
                             }
                         }
 
-                        if (input.itemRequirements.isNotEmpty()) {
+                        // Skipped when build-time modes carry their own lists: those replace the
+                        // base list rather than adding to it (MCO-463), and keeping both would
+                        // leave a list belonging to none of the variants.
+                        if (input.itemRequirements.isNotEmpty() && !input.productionModes.replaceBaseRequirements()) {
                             val requirementResult = DatabaseSteps.batchUpdate<Pair<String, Int>>(
                                 SafeSQL.insert("""
                                     INSERT INTO idea_item_requirements (idea_id, item_id, quantity) VALUES (?, ?, ?)

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/commonsteps/IdeaProductionSteps.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/commonsteps/IdeaProductionSteps.kt
@@ -1,5 +1,6 @@
 package app.mcorg.pipeline.idea.commonsteps
 
+import app.mcorg.domain.model.idea.IdeaModeKind
 import app.mcorg.domain.model.idea.IdeaProductionMode
 import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
@@ -19,7 +20,36 @@ data class IdeaProductionModeInput(
     val name: String,
     /** Item id -> rate, or null where the author knows what it makes but not how fast. */
     val rates: Map<String, Int?>,
-)
+    val kind: IdeaModeKind = IdeaModeKind.Default,
+    /**
+     * What this variant costs to build, item id -> quantity. Meaningful only for
+     * [IdeaModeKind.BUILD_TIME] modes; a runtime mode does not change what the build cost, so a
+     * non-empty map here on a runtime mode is a caller error and is dropped rather than stored
+     * (see [requirementsToStore]).
+     */
+    val requirements: Map<String, Int> = emptyMap(),
+) {
+    /**
+     * The requirements this mode should actually own, which is none unless it is build-time.
+     *
+     * Enforced here rather than by a database constraint: a CHECK cannot see across to
+     * `idea_production_modes.kind`, and the invariant has exactly two write paths, both of which
+     * come through this file.
+     */
+    val requirementsToStore: Map<String, Int>
+        get() = if (kind == IdeaModeKind.BUILD_TIME) requirements else emptyMap()
+}
+
+/**
+ * Whether these modes carry their own material lists, and so *replace* the idea's base list.
+ *
+ * The base list (`mode_id IS NULL`) and build-time mode lists are alternatives, never both: an
+ * idea either has one list, or one per build-time variant. Write paths ask this before inserting a
+ * base list, so an idea that describes its variants does not also keep a list belonging to none of
+ * them.
+ */
+fun List<IdeaProductionModeInput>.replaceBaseRequirements(): Boolean =
+    any { it.requirementsToStore.isNotEmpty() }
 
 /**
  * Replaces an idea's production modes wholesale.
@@ -30,8 +60,10 @@ data class IdeaProductionModeInput(
  * written inside the caller's transaction, so the churn costs nothing and the alternative would be
  * a merge whose only purpose is preserving surrogate ids nothing references.
  *
- * Modes with no rates are dropped: a named way of running a farm that produces nothing is a form
- * artefact, not a fact about the farm.
+ * Modes with nothing in them are dropped: a named way of running a farm that produces nothing is a
+ * form artefact, not a fact about the farm. Since MCO-463 "nothing" means neither rates *nor*
+ * requirements — a build-time variant whose output nobody timed is still a real variant, because
+ * it still says what building it costs.
  *
  * Modes that resolve to the *same* name are merged rather than inserted twice, which would violate
  * `UNIQUE (idea_id, name)` and roll the whole publish back. The form rejects this case with a
@@ -53,19 +85,22 @@ suspend fun replaceIdeaProductionModes(
     ).process(ideaId)
     if (cleared is Result.Failure) return cleared
 
-    val populated = modes.filter { it.rates.isNotEmpty() }.mergeByResolvedName()
+    val populated = modes
+        .filter { it.rates.isNotEmpty() || it.requirementsToStore.isNotEmpty() }
+        .mergeByResolvedName()
     if (populated.isEmpty()) return Result.success(Unit)
 
     populated.forEachIndexed { index, mode ->
         val modeIdResult = DatabaseSteps.query<Unit, Int?>(
             SafeSQL.insert(
-                "INSERT INTO idea_production_modes (idea_id, name, position) VALUES (?, ?, ?) RETURNING id"
+                "INSERT INTO idea_production_modes (idea_id, name, position, kind) VALUES (?, ?, ?, ?) RETURNING id"
             ),
             parameterSetter = { statement, _ ->
                 statement.setInt(1, ideaId)
                 // Already resolved by mergeByResolvedName — blank became DEFAULT_MODE_NAME there.
                 statement.setString(2, mode.name)
                 statement.setInt(3, index)
+                statement.setString(4, mode.kind.name)
             },
             resultMapper = { rs -> if (rs.next()) rs.getInt("id") else null },
             transactionConnection = connection,
@@ -88,6 +123,26 @@ suspend fun replaceIdeaProductionModes(
             transactionConnection = connection,
         ).process(mode.rates.toList())
         if (rates is Result.Failure) return rates
+
+        // A build-time mode's own material list, replacing the idea's base list rather than adding
+        // to it (V2_61_0). Runtime modes never reach here — requirementsToStore is empty for them.
+        val requirements = mode.requirementsToStore
+        if (requirements.isNotEmpty()) {
+            val stored = DatabaseSteps.batchUpdate<Pair<String, Int>>(
+                SafeSQL.insert(
+                    "INSERT INTO idea_item_requirements (idea_id, item_id, quantity, mode_id) VALUES (?, ?, ?, ?)"
+                ),
+                parameterSetter = { statement, (itemId, quantity) ->
+                    statement.setInt(1, ideaId)
+                    statement.setString(2, itemId)
+                    statement.setInt(3, quantity)
+                    statement.setInt(4, modeId)
+                },
+                chunkSize = 500,
+                transactionConnection = connection,
+            ).process(requirements.toList())
+            if (stored is Result.Failure) return stored
+        }
     }
 
     return Result.success(Unit)
@@ -100,6 +155,15 @@ suspend fun replaceIdeaProductionModes(
  * collision rather than two rows the unique index would reject. Where both carry the same item, the
  * higher rate wins and a measured rate beats an unmeasured one — a null here means "never timed",
  * not "zero", so it must never displace a real number.
+ *
+ * Two further fields merge since MCO-463, on the same "take the stronger claim" reading:
+ *
+ *  - **kind** — [IdeaModeKind.BUILD_TIME] wins. It is the claim that carries consequences (its own
+ *    material list, a choice forced at import), and silently demoting it to runtime would drop
+ *    requirements on the floor at the next write.
+ *  - **requirements** — the larger quantity wins, per item. Same argument as rates: two modes
+ *    claiming one name claim to be one variant, and under-stating what it costs to build is the
+ *    more expensive way to be wrong.
  */
 internal fun List<IdeaProductionModeInput>.mergeByResolvedName(): List<IdeaProductionModeInput> =
     fold(LinkedHashMap<String, IdeaProductionModeInput>()) { acc, mode ->
@@ -118,50 +182,116 @@ internal fun List<IdeaProductionModeInput>.mergeByResolvedName(): List<IdeaProdu
                     else -> maxOf(current, rate)
                 }
             }
-            existing.copy(rates = rates)
+            val requirements = existing.requirements.toMutableMap()
+            mode.requirements.forEach { (itemId, quantity) ->
+                requirements[itemId] = maxOf(requirements[itemId] ?: 0, quantity)
+            }
+            val kind = if (existing.kind == IdeaModeKind.BUILD_TIME || mode.kind == IdeaModeKind.BUILD_TIME) {
+                IdeaModeKind.BUILD_TIME
+            } else {
+                existing.kind
+            }
+            existing.copy(rates = rates, requirements = requirements, kind = kind)
         }
         acc
     }.values.toList()
 
-/** An idea's production modes, in the author's order, each with its rates. */
+/**
+ * An idea's production modes, in the author's order, each with its rates, kind and — for build-time
+ * modes — its own material list.
+ *
+ * Two queries rather than one. A second `LEFT JOIN` onto `idea_item_requirements` would multiply
+ * rows (every rate against every requirement: five rates and three hundred materials is fifteen
+ * hundred rows to rebuild two maps from). The maps would still come out right, since duplicates
+ * collapse on insert, but paying a cartesian product to avoid a round trip on a handful of rows is
+ * the wrong trade — and the join that reads correct but computes nonsense is exactly the kind of
+ * thing nobody revisits later.
+ */
 data class GetIdeaProductionModesStep(val ideaId: Int) :
     Step<Unit, AppFailure.DatabaseError, List<IdeaProductionMode>> {
 
-    override suspend fun process(input: Unit): Result<AppFailure.DatabaseError, List<IdeaProductionMode>> =
-        DatabaseSteps.query<Unit, List<IdeaProductionMode>>(
-            sql = SafeSQL.select(
-                """
-                SELECT m.id, m.name, m.position, r.item_id, r.rate_per_hour
-                FROM idea_production_modes m
-                LEFT JOIN idea_production_rates r ON r.mode_id = m.id
-                WHERE m.idea_id = ?
-                ORDER BY m.position, m.id, r.item_id
-                """.trimIndent()
-            ),
-            parameterSetter = { statement, _ -> statement.setInt(1, ideaId) },
-            resultMapper = { rs ->
-                // LEFT JOIN so a mode with no rates still arrives; the row then carries a null
-                // item and contributes nothing but the mode itself.
-                val byId = linkedMapOf<Int, IdeaProductionMode>()
-                while (rs.next()) {
-                    val id = rs.getInt("id")
-                    val mode = byId.getOrPut(id) {
-                        IdeaProductionMode(
-                            id = id,
-                            name = rs.getString("name"),
-                            position = rs.getInt("position"),
-                            rates = emptyMap(),
-                        )
-                    }
-                    val itemId = rs.getString("item_id")
-                    if (itemId != null) {
-                        // getInt returns 0 for SQL NULL, and 0 is not what a missing rate means —
-                        // wasNull is the only way to tell "unmeasured" from a real zero.
-                        val rate = rs.getInt("rate_per_hour").takeUnless { rs.wasNull() }
-                        byId[id] = mode.copy(rates = mode.rates + (itemId to rate))
-                    }
-                }
-                byId.values.toList()
+    override suspend fun process(input: Unit): Result<AppFailure.DatabaseError, List<IdeaProductionMode>> {
+        val ratesResult = ratesQuery.process(Unit)
+        val modes = when (ratesResult) {
+            is Result.Success -> ratesResult.value
+            is Result.Failure -> return ratesResult
+        }
+        // Only build-time modes can own a material list, so an idea with none — every idea in the
+        // bank before MCO-463 — costs exactly the one query it always did.
+        if (modes.none { it.isBuildTime }) return Result.success(modes)
+
+        val requirementsResult = requirementsQuery.process(Unit)
+        val requirements = when (requirementsResult) {
+            is Result.Success -> requirementsResult.value
+            is Result.Failure -> return requirementsResult
+        }
+        return Result.success(
+            modes.map { mode ->
+                val own = requirements[mode.id]
+                if (own == null) mode else mode.copy(requirements = own)
             }
-        ).process(Unit)
+        )
+    }
+
+    private val ratesQuery = DatabaseSteps.query<Unit, List<IdeaProductionMode>>(
+        sql = SafeSQL.select(
+            """
+            SELECT m.id, m.name, m.position, m.kind, r.item_id, r.rate_per_hour
+            FROM idea_production_modes m
+            LEFT JOIN idea_production_rates r ON r.mode_id = m.id
+            WHERE m.idea_id = ?
+            ORDER BY m.position, m.id, r.item_id
+            """.trimIndent()
+        ),
+        parameterSetter = { statement, _ -> statement.setInt(1, ideaId) },
+        resultMapper = { rs ->
+            // LEFT JOIN so a mode with no rates still arrives; the row then carries a null
+            // item and contributes nothing but the mode itself. Since MCO-463 that is a real
+            // case rather than a degenerate one — a build-time variant can state what it costs
+            // without anyone having timed what it makes.
+            val byId = linkedMapOf<Int, IdeaProductionMode>()
+            while (rs.next()) {
+                val id = rs.getInt("id")
+                val mode = byId.getOrPut(id) {
+                    IdeaProductionMode(
+                        id = id,
+                        name = rs.getString("name"),
+                        position = rs.getInt("position"),
+                        rates = emptyMap(),
+                        kind = IdeaModeKind.fromOrDefault(rs.getString("kind")),
+                    )
+                }
+                val itemId = rs.getString("item_id")
+                if (itemId != null) {
+                    // getInt returns 0 for SQL NULL, and 0 is not what a missing rate means —
+                    // wasNull is the only way to tell "unmeasured" from a real zero.
+                    val rate = rs.getInt("rate_per_hour").takeUnless { rs.wasNull() }
+                    byId[id] = mode.copy(rates = mode.rates + (itemId to rate))
+                }
+            }
+            byId.values.toList()
+        }
+    )
+
+    /** Mode id -> that build-time mode's material list. */
+    private val requirementsQuery = DatabaseSteps.query<Unit, Map<Int, Map<String, Int>>>(
+        sql = SafeSQL.select(
+            """
+            SELECT r.mode_id, r.item_id, r.quantity
+            FROM idea_item_requirements r
+            JOIN idea_production_modes m ON m.id = r.mode_id
+            WHERE m.idea_id = ?
+            ORDER BY r.quantity DESC
+            """.trimIndent()
+        ),
+        parameterSetter = { statement, _ -> statement.setInt(1, ideaId) },
+        resultMapper = { rs ->
+            val byMode = mutableMapOf<Int, MutableMap<String, Int>>()
+            while (rs.next()) {
+                byMode.getOrPut(rs.getInt("mode_id")) { linkedMapOf() }[rs.getString("item_id")] =
+                    rs.getInt("quantity")
+            }
+            byMode
+        }
+    )
 }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/createfragments/ParseLitematicaToIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/createfragments/ParseLitematicaToIdeaPipeline.kt
@@ -27,7 +27,24 @@ import kotlinx.coroutines.withContext
 import kotlinx.html.stream.createHTML
 import kotlinx.io.readByteArray
 
+/**
+ * Parses uploaded `.litematic` files into material rows for the create form.
+ *
+ * ## Whose list is being filled
+ *
+ * `?mode=<index>` names a **build-time** variant's own list (MCO-463) \u2014 the 4-module farm is its
+ * own download, so it gets its own upload and its own rows. Without the parameter the rows fill the
+ * idea's single base list, which is every idea that has no build-time variants and the only shape
+ * that existed before MCO-463.
+ *
+ * The index is positional and re-assigned on every save (see `buildStageJson`), so it is carried
+ * through here rather than interpreted: this handler only needs to know which block asked.
+ */
 suspend fun ApplicationCall.handleParseLitematica() {
+    // Whatever the block put in its URL, reduced to digits. The value ends up in a field name, so
+    // a hand-edited `?mode=x"><script>` must not reach the markup \u2014 and a non-numeric index would
+    // not match a mode block on parse anyway.
+    val modeIndex = request.queryParameters["mode"]?.takeIf { it.isNotBlank() && it.all(Char::isDigit) }
     val input = receiveMultipart()
 
     handlePipeline(
@@ -42,10 +59,17 @@ suspend fun ApplicationCall.handleParseLitematica() {
                 .joinToString("") { (itemId, qty) ->
                     val itemName = allItems[itemId]?.name ?: itemId
                     createHTML().li("item-req") {
-                        id = "item-req-$itemId"
+                        // Scoped by mode: the same item appears in several variants' lists, and
+                        // duplicate ids would make the de-duplication lookup pick the wrong row.
+                        id = if (modeIndex == null) "item-req-$itemId" else "item-req-$modeIndex-$itemId"
+                        attributes["data-item-id"] = itemId
                         +"$itemName \u00d7 $qty"
                         hiddenInput {
-                            name = "itemRequirements[$itemId]"
+                            name = if (modeIndex == null) {
+                                "itemRequirements[$itemId]"
+                            } else {
+                                "modeRequirements[$modeIndex][$itemId]"
+                            }
                             value = qty.toString()
                         }
                         button(classes = "btn btn--ghost btn--sm") {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DeserializeDraftStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DeserializeDraftStep.kt
@@ -2,6 +2,7 @@ package app.mcorg.pipeline.idea.draft
 
 import app.mcorg.domain.model.idea.Author
 import app.mcorg.domain.model.idea.IdeaCategory
+import app.mcorg.domain.model.idea.IdeaModeKind
 import app.mcorg.domain.model.idea.IdeaDifficulty
 import app.mcorg.domain.model.idea.IdeaDraft
 import app.mcorg.domain.model.idea.schema.CategoryValue
@@ -22,6 +23,18 @@ import kotlinx.serialization.json.Json
 data class DraftProductionMode(
     val name: String = "",
     val rates: Map<String, Int?> = emptyMap(),
+    /**
+     * Whether this is a way of *running* the design or a way of *building* it (MCO-463).
+     *
+     * Defaults to runtime so a draft saved before this field existed deserialises to what its
+     * author meant — the form only ever asked about running a farm.
+     */
+    val kind: IdeaModeKind = IdeaModeKind.Default,
+    /**
+     * This variant's own material list, from its own `.litematic` upload(s). Build-time only; a
+     * runtime mode does not change what the build cost.
+     */
+    val requirements: Map<String, Int> = emptyMap(),
 )
 
 @Serializable
@@ -102,7 +115,14 @@ object DeserializeDraftStep : Step<IdeaDraft, AppFailure.ValidationError, Create
                 testData = null,
                 itemRequirements = data.itemRequirements ?: emptyMap(),
                 productionModes = data.productionModes.orEmpty()
-                    .map { IdeaProductionModeInput(name = it.name, rates = it.rates) },
+                    .map {
+                        IdeaProductionModeInput(
+                            name = it.name,
+                            rates = it.rates,
+                            kind = it.kind,
+                            requirements = it.requirements,
+                        )
+                    },
                 categoryData = categoryData ?: emptyMap()
             )
         )

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/DraftHandlers.kt
@@ -27,6 +27,7 @@ import kotlinx.html.h1
 import kotlinx.html.id
 import kotlinx.html.stream.createHTML
 import app.mcorg.domain.model.idea.Author
+import app.mcorg.domain.model.idea.IdeaModeKind
 import app.mcorg.domain.model.idea.IdeaCategory
 import app.mcorg.domain.model.idea.schema.CategoryField
 import app.mcorg.domain.model.idea.schema.CategoryValue
@@ -360,19 +361,58 @@ internal fun buildStageJson(stage: DraftWizardStage, params: Parameters): String
                 }
                 .groupBy({ it.first }, { it.second to it.third })
 
-            // A mode with no rates says nothing about the farm, so it does not survive the form.
-            val modes = ratesByMode.keys.sortedBy { it.toIntOrNull() ?: Int.MAX_VALUE }
+            // modeRequirements[i][<item id>] is one line of a *build-time* variant's own material
+            // list, parsed from that variant's own .litematic upload (MCO-463). Same index space as
+            // the rates above — one mode block owns both.
+            val requirementsByMode = params.names()
+                .filter { it.startsWith("modeRequirements[") }
+                .mapNotNull { key ->
+                    val body = key.removePrefix("modeRequirements[")
+                    val index = body.substringBefore("]", missingDelimiterValue = "")
+                    val itemId = body.substringAfter("][", missingDelimiterValue = "").removeSuffix("]")
+                    val quantity = params[key]?.trim()?.toIntOrNull()
+                    // Unlike a rate, a blank or malformed *quantity* carries no reading: "some
+                    // cobblestone" is not a material list. Drop the row rather than storing a zero.
+                    if (index.isBlank() || itemId.isBlank() || quantity == null || quantity <= 0) null
+                    else Triple(index, itemId, quantity)
+                }
+                .groupBy({ it.first }, { it.second to it.third })
+
+            val kinds = params.names()
+                .filter { it.startsWith("productionMode[") && it.endsWith("][kind]") }
+                .associate { key ->
+                    key.removePrefix("productionMode[").removeSuffix("][kind]") to
+                        IdeaModeKind.fromOrDefault(params[key])
+                }
+
+            // A mode with no rates says nothing about the farm, so it does not survive the form —
+            // unless it is a build-time variant carrying a material list, which says what building
+            // it costs even when nobody timed what it makes (MCO-463).
+            val modes = (ratesByMode.keys + requirementsByMode.keys)
+                .sortedBy { it.toIntOrNull() ?: Int.MAX_VALUE }
             // Written even when empty (MCO-418). UpdateDraftStep merges with `data || ?::jsonb`, so
             // an omitted key is not "no change", it is "keep what was there" — and clearing the last
             // production row was therefore unsaveable: the rows came back on reload and published.
             // An author correcting a rate they got wrong has to be able to remove it.
             putJsonArray("productionModes") {
                 modes.forEach { index ->
+                    val kind = kinds[index] ?: IdeaModeKind.Default
                     addJsonObject {
                         put("name", names[index] ?: "")
+                        put("kind", kind.name)
                         putJsonObject("rates") {
                             ratesByMode[index].orEmpty().forEach { (itemId, rate) ->
                                 if (rate == null) put(itemId, JsonNull) else put(itemId, rate)
+                            }
+                        }
+                        // Only a build-time mode owns a list. Dropping a runtime mode's stray rows
+                        // here as well as at the write path keeps the draft honest: a mode switched
+                        // from build-time back to runtime should not keep materials it no longer
+                        // claims, and reloading the form would otherwise show them again.
+                        val requirements = requirementsByMode[index].orEmpty()
+                        if (kind == IdeaModeKind.BUILD_TIME && requirements.isNotEmpty()) {
+                            putJsonObject("requirements") {
+                                requirements.forEach { (itemId, quantity) -> put(itemId, quantity) }
                             }
                         }
                     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/RevertIdeaToDraftStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/RevertIdeaToDraftStep.kt
@@ -44,14 +44,25 @@ class RevertIdeaToDraftStep : Step<RevertIdeaToDraftInput, AppFailure, Int> {
                         '{}'
                     )::text AS item_requirements,
                     COALESCE(
+                        -- kind and requirements ride along for the same reason rates do: publishing
+                        -- the draft replaces the idea wholesale, so a key missing here is deleted
+                        -- rather than left alone. Reverting a four-variant farm to a draft and
+                        -- saving it would otherwise flatten it back to one nameless mode.
                         (SELECT json_agg(
-                                    json_build_object('name', m.name, 'rates', COALESCE(m.rates, '{}'::json))
+                                    json_build_object(
+                                        'name', m.name,
+                                        'kind', m.kind,
+                                        'rates', COALESCE(m.rates, '{}'::json),
+                                        'requirements', COALESCE(m.requirements, '{}'::json)
+                                    )
                                     ORDER BY m.position, m.id
                                 )
                          FROM (
-                             SELECT pm.id, pm.name, pm.position,
+                             SELECT pm.id, pm.name, pm.position, pm.kind,
                                     (SELECT json_object_agg(r.item_id, r.rate_per_hour)
-                                     FROM idea_production_rates r WHERE r.mode_id = pm.id) AS rates
+                                     FROM idea_production_rates r WHERE r.mode_id = pm.id) AS rates,
+                                    (SELECT json_object_agg(mr.item_id, mr.quantity)
+                                     FROM idea_item_requirements mr WHERE mr.mode_id = pm.id) AS requirements
                              FROM idea_production_modes pm
                              WHERE pm.idea_id = i.id
                          ) m),

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/RevertIdeaToDraftStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/RevertIdeaToDraftStep.kt
@@ -36,8 +36,11 @@ class RevertIdeaToDraftStep : Step<RevertIdeaToDraftInput, AppFailure, Int> {
                 SELECT
                     i.category_data::text AS category_data,
                     COALESCE(
+                        -- Base list only; build-time modes carry theirs alongside the mode
+                        -- (MCO-463, V2_61_0), and json_object_agg over both would collapse four
+                        -- variants onto one key per item.
                         (SELECT json_object_agg(item_id, quantity)
-                         FROM idea_item_requirements WHERE idea_id = i.id),
+                         FROM idea_item_requirements WHERE idea_id = i.id AND mode_id IS NULL),
                         '{}'
                     )::text AS item_requirements,
                     COALESCE(

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/UpdateExistingIdeaStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/draft/UpdateExistingIdeaStep.kt
@@ -7,6 +7,7 @@ import app.mcorg.domain.pipeline.Step
 import app.mcorg.pipeline.DatabaseSteps
 import app.mcorg.pipeline.Result
 import app.mcorg.pipeline.SafeSQL
+import app.mcorg.pipeline.idea.commonsteps.replaceBaseRequirements
 import app.mcorg.pipeline.idea.commonsteps.replaceIdeaProductionModes
 import app.mcorg.pipeline.failure.AppFailure
 import app.mcorg.pipeline.idea.CreateIdeaInput
@@ -59,8 +60,11 @@ class UpdateExistingIdeaStep : Step<UpdateExistingIdeaInput, AppFailure.Database
                             connection
                         ).process(input.ideaId)
 
-                        // Insert new item requirements
-                        if (input.createInput.itemRequirements.isNotEmpty()) {
+                        // Insert new item requirements — the base list, and only when no build-time
+                        // mode carries one of its own (MCO-463: those replace the base list).
+                        if (input.createInput.itemRequirements.isNotEmpty() &&
+                            !input.createInput.productionModes.replaceBaseRequirements()
+                        ) {
                             val requirementResult = DatabaseSteps.batchUpdate<Pair<String, Int>>(
                                 SafeSQL.insert("INSERT INTO idea_item_requirements (idea_id, item_id, quantity) VALUES (?, ?, ?)"),
                                 parameterSetter = { stmt, (itemId, quantity) ->

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/single/GetIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/single/GetIdeaPipeline.kt
@@ -68,6 +68,11 @@ private val GetIdeaMaterialsStep = DatabaseSteps.query<Int, List<IdeaMaterial>>(
                     ) AS item_name
                 FROM idea_item_requirements r
                 WHERE r.idea_id = ?
+                  -- The idea's base list only. Build-time modes own their own lists (MCO-463,
+                  -- V2_61_0) and reading both together would sum four variants of one farm into a
+                  -- material list describing none of them. Those lists arrive with the modes, on
+                  -- IdeaProductionMode.requirements.
+                  AND r.mode_id IS NULL
                 ORDER BY r.quantity DESC
             """.trimIndent()),
     parameterSetter = { statement, ideaId -> statement.setInt(1, ideaId) },

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaProductionsStep.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/idea/validators/ValidateIdeaProductionsStep.kt
@@ -62,8 +62,25 @@ data class ValidateIdeaProductionsStep(
             }
             .groupBy({ it.first }, { it.second })
 
-        // Only modes that carry rates survive the save, so only those can collide or hold a bad id.
-        return itemsByMode.mapValues { (index, items) -> (names[index] ?: "") to items }
+        // A build-time variant survives the save on its material list alone, with no rates at all
+        // (MCO-463) — so it can collide on name, and leaving it out here would let two variants
+        // both called "4 modules" reach the unique index and roll back the publish.
+        //
+        // Its material ids are deliberately *not* added to the item check: they come from parsing a
+        // .litematic against the catalog, not from a text field someone typed, and an id that is in
+        // the file but not in this version range is MCO-305's warning to make at import, not a
+        // reason to refuse to save the design.
+        val requirementModes = params.names()
+            .filter { it.startsWith("modeRequirements[") }
+            .mapNotNull { key ->
+                key.removePrefix("modeRequirements[").substringBefore("]", missingDelimiterValue = "")
+                    .takeIf { it.isNotBlank() }
+            }
+            .toSet()
+
+        return (itemsByMode.keys + requirementModes).associateWith { index ->
+            (names[index] ?: "") to itemsByMode[index].orEmpty()
+        }
     }
 
     private fun duplicateNameErrors(modes: Map<String, Pair<String, List<String>>>): List<ValidationFailure> {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -10,6 +10,7 @@ import app.mcorg.domain.model.project.ProjectType
 import app.mcorg.event.IdeaImported
 import app.mcorg.event.eventBus
 import app.mcorg.domain.model.idea.IdeaProductionMode
+import app.mcorg.domain.model.idea.buildTimeModes
 import app.mcorg.pipeline.idea.commonsteps.GetIdeaProductionModesStep
 import app.mcorg.pipeline.Result
 import app.mcorg.domain.pipeline.Step
@@ -24,6 +25,7 @@ import app.mcorg.presentation.handler.handlePipeline
 import io.ktor.server.response.respond
 import io.ktor.http.Parameters
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.encodeURLParameter
 import app.mcorg.presentation.utils.getWorldName
 import app.mcorg.presentation.utils.respondHtml
 import app.mcorg.presentation.templated.dsl.pages.importReviewPage
@@ -63,7 +65,53 @@ data class IdeaForImport(
      * [production] and reported, never fatal — see [ValidateItemIdsStep].
      */
     val unrecordableProductions: List<String> = emptyList(),
+    /**
+     * The ways this design can be *built*, in the author's order, when there is more than one
+     * (MCO-463). Empty for every idea with a single material list, which is most of them.
+     *
+     * A choice between these is a choice of what the project will cost, so it belongs on the
+     * review screen rather than being made silently.
+     */
+    val buildTimeModes: List<String> = emptyList(),
+    /** Which of [buildTimeModes] the requirements and rates above were read from. */
+    val chosenBuildTimeMode: String? = null,
 )
+
+/**
+ * Which idea to import, and — when it can be built more than one way — which way (MCO-463).
+ *
+ * [buildTimeMode] names a mode rather than carrying its id because the id is a surrogate nothing
+ * else references: `replaceIdeaProductionModes` deletes and re-inserts every mode on each save, so
+ * an id in a URL would go stale the next time the author edited the design. Names are unique per
+ * idea and stable across a save that did not rename them.
+ */
+internal data class ImportSelection(val ideaId: Int, val buildTimeMode: String? = null)
+
+/** Names the chosen build-time variant, on the review GET and on the import POST alike. */
+internal const val BUILD_TIME_MODE_PARAM = "buildTimeMode"
+
+/**
+ * The review URL for one build-time variant, carrying everything the current one carries.
+ *
+ * Every other parameter has to survive the switch — the world, a `forTask` dependency, and an
+ * MCO-459 batch queue — because picking a variant is a step *inside* a review, not a way out of
+ * one. Dropping the queue here would strand someone halfway through a seven-design batch.
+ */
+private fun reviewHrefFor(
+    ideaId: Int,
+    worldId: Int,
+    taskId: Int?,
+    queue: ImportQueue?,
+    mode: String,
+): String = buildString {
+    append(Link.Ideas.single(ideaId)).append("/import/review")
+    append("?worldId=").append(worldId)
+    taskId?.let { append("&forTask=").append(it) }
+    queue?.hiddenFields()?.forEach { (key, value) ->
+        append('&').append(key).append('=').append(value.encodeURLParameter())
+    }
+    append('&').append(BUILD_TIME_MODE_PARAM).append('=').append(mode.encodeURLParameter())
+}
 
 /**
  * Step one of an idea import (MCO-306): show what the idea would create, before creating it.
@@ -85,6 +133,7 @@ suspend fun ApplicationCall.handleReviewIdeaImport() {
         )
 
     val taskId = request.queryParameters["forTask"]?.toIntOrNull()
+    val chosenBuildTimeMode = request.queryParameters[BUILD_TIME_MODE_PARAM]?.takeIf { it.isNotBlank() }
     val items = GetItemsInWorldVersionStep.process(worldId).getOrNull() ?: emptyList()
 
     // A batch started from a plan's suggestion list (MCO-459), or null for every other door
@@ -125,10 +174,20 @@ suspend fun ApplicationCall.handleReviewIdeaImport() {
                     // built rather than re-typing them into the MCO-298 form.
                     offerAlreadyBuilt = true,
                     wizard = wizard,
+                    // Which way this design is being built, when there is more than one way
+                    // (MCO-463). Picking a different one re-runs this GET, so the material list,
+                    // the warnings and the totals below all move together — the list on screen is
+                    // always the list for the selected variant.
+                    buildTimeModes = idea.buildTimeModes,
+                    chosenBuildTimeMode = idea.chosenBuildTimeMode,
+                    reviewHref = { mode -> reviewHrefFor(ideaId, worldId, taskId, queue, mode) },
                     action = Link.Ideas.single(ideaId) + "/import",
                     hiddenFields = buildMap {
                         put("worldId", worldId.toString())
                         taskId?.let { put("forTask", it.toString()) }
+                        // The POST has to import the variant the user was looking at, not the
+                        // default one it would otherwise re-derive.
+                        idea.chosenBuildTimeMode?.let { put(BUILD_TIME_MODE_PARAM, it) }
                         // Carried so the POST can hand the user to the next step without
                         // re-deriving the batch from anywhere but the form it came from.
                         if (wizard != null) putAll(queue!!.hiddenFields())
@@ -139,7 +198,7 @@ suspend fun ApplicationCall.handleReviewIdeaImport() {
     ) {
         ValidateWorldMemberRole<Pair<Int, Int>>(user, Role.ADMIN, worldId).run(worldId to ideaId)
         ValidateVersionRangeStep.run(worldId to ideaId)
-        val ideaData = GetIdeaForImportStep.run(ideaId)
+        val ideaData = GetIdeaForImportStep.run(ImportSelection(ideaId, chosenBuildTimeMode))
         ValidateItemIdsStep(items).run(ideaData)
     }
 }
@@ -164,6 +223,7 @@ suspend fun ApplicationCall.handleImportIdea() {
         }
 
     val taskId = (submitted["forTask"] ?: parameters["forTask"])?.toIntOrNull()
+    val chosenBuildTimeMode = submitted[BUILD_TIME_MODE_PARAM]?.takeIf { it.isNotBlank() }
 
     val queue = ImportQueue.from(
         submitted[ImportQueue.QUEUE_PARAM] ?: request.queryParameters[ImportQueue.QUEUE_PARAM],
@@ -196,7 +256,11 @@ suspend fun ApplicationCall.handleImportIdea() {
     ) {
         ValidateWorldMemberRole<Pair<Int, Int>>(user, Role.ADMIN, worldId).run(worldId to ideaId)
         ValidateVersionRangeStep.run(worldId to ideaId)
-        val ideaData = GetIdeaForImportStep.run(ideaId)
+        // The variant the user was looking at when they submitted. Re-read rather than trusted
+        // blind: GetIdeaForImportStep falls back to the author's first if the name no longer
+        // matches a build-time mode, which is what happens when the design was edited between the
+        // review being rendered and this POST.
+        val ideaData = GetIdeaForImportStep.run(ImportSelection(ideaId, chosenBuildTimeMode))
         val validatedIdea = ValidateItemIdsStep(items).run(ideaData)
         val reviewedIdea = ApplyReviewedRequirementsStep(submitted, items, alreadyBuilt).run(validatedIdea)
         val projectId = CreateProjectFromIdeaStep(worldId, taskId, alreadyBuilt).run(reviewedIdea)
@@ -332,8 +396,11 @@ data class BasicIdeaInfo(
 )
 
 private val GetIdeaForImportStep = DatabaseSteps.transaction { connection ->
-    object : Step<Int, AppFailure.DatabaseError, Pair<BasicIdeaInfo, Map<String, Int>>> {
-        override suspend fun process(input: Int): Result<AppFailure.DatabaseError, Pair<BasicIdeaInfo, Map<String, Int>>> {
+    object : Step<ImportSelection, AppFailure.DatabaseError, Triple<BasicIdeaInfo, Map<String, Int>, BuildTimeChoice>> {
+        override suspend fun process(
+            selection: ImportSelection,
+        ): Result<AppFailure.DatabaseError, Triple<BasicIdeaInfo, Map<String, Int>, BuildTimeChoice>> {
+            val input = selection.ideaId
             val ideaInfo = DatabaseSteps.query<Int, BasicIdeaInfo>(
                 sql = SafeSQL.select("""
                     SELECT id, name, description, category
@@ -392,27 +459,68 @@ private val GetIdeaForImportStep = DatabaseSteps.transaction { connection ->
             if (modes is Result.Failure) {
                 return Result.Failure(modes.error)
             }
+            val allModes = modes.getOrNull()!!
+            val buildTime = allModes.buildTimeModes()
 
-            val info = ideaInfo.getOrNull()!!.copy(productionRate = ratesForImport(modes.getOrNull()!!))
-            return Result.Success(Pair(info, requirementInfo.getOrNull()!!))
+            // Which variant is being imported. The author's first is the default rather than the
+            // fastest or the largest: `position` is explicitly the author's ordering and not a
+            // ranking, and defaulting to the biggest producer would quietly commit someone to the
+            // 4-module build and its 4x material bill. The review screen shows the choice either
+            // way, so a neutral, predictable default beats a clever one.
+            val chosen = buildTime.firstOrNull { it.name == selection.buildTimeMode }
+                ?: buildTime.firstOrNull()
+
+            // A build-time variant's own list *replaces* the base list (V2_61_0), so this is a
+            // choice between lists rather than a merge.
+            val requirements = if (chosen != null && chosen.requirements.isNotEmpty()) {
+                chosen.requirements
+            } else {
+                requirementInfo.getOrNull()!!
+            }
+
+            val info = ideaInfo.getOrNull()!!.copy(
+                productionRate = ratesForImport(allModes, chosen?.name),
+            )
+            return Result.Success(
+                Triple(
+                    info,
+                    requirements,
+                    BuildTimeChoice(buildTime.map { it.name }, chosen?.name),
+                )
+            )
         }
     }
 }
 
+/** The build-time variants an idea offers, and which one this import is reading. */
+internal data class BuildTimeChoice(
+    val available: List<String> = emptyList(),
+    val chosen: String? = null,
+)
+
 /**
  * The rates an imported farm project should record, chosen from the idea's modes.
  *
- * **Interim, and known to be the wrong shape** (Even, 2026-08-16, reversing the same day's earlier
- * call): which mode a farm runs in is a *runtime* choice, not a build-time one. You might run the
- * fortress farm skeletons-only this week and everything-on next, and flattening the choice at
- * import means re-typing rates to switch. The modes belong on the project, with one active —
- * filed separately because it reaches into project_productions, the supply map and the
- * production editor.
+ * ## Flattening is correct for a build-time mode, and wrong for a runtime one
  *
- * Until then the project records one mode's rates flat, which is what `project_productions` has
- * always held. With one mode there is nothing to choose. With several and no explicit choice, the
- * mode producing the most across its items wins: an import that silently picked the slowest would
- * under-promise supply for no reason the user could see.
+ * This was filed as wholly interim (Even, 2026-08-16) on the reading that a mode is always a
+ * *runtime* choice — you might run the fortress farm skeletons-only this week and everything-on
+ * next, and flattening means re-typing rates to switch. MCO-439 finding 1 showed both kinds exist,
+ * and split the issue in two:
+ *
+ *  - **Build-time** (MCO-463): flattening here is right. You pick 4-modules-with-storage once, and
+ *    the project's requirements and rates are both fixed from that one variant. Passing
+ *    [chosenModeName] is how the review screen's choice reaches the project.
+ *  - **Runtime** (MCO-413): still the wrong shape, and still to be fixed. Those modes belong on the
+ *    project with one active, so switching does not re-type anything.
+ *
+ * When [chosenModeName] names a mode, that mode's rates are used **even if it has none**. A
+ * build-time variant nobody timed honestly produces an unmeasured amount; falling back to a
+ * sibling's rate would attribute one variant's throughput to another, which is the drift this
+ * whole issue exists to stop.
+ *
+ * With no choice given, the mode producing the most across its items wins: an import that silently
+ * picked the slowest would under-promise supply for no reason the user could see.
  */
 internal fun ratesForImport(modes: List<IdeaProductionMode>, chosenModeName: String? = null): Map<String, Int> {
     if (modes.isEmpty()) return emptyMap()
@@ -440,9 +548,12 @@ internal fun ratesForImport(modes: List<IdeaProductionMode>, chosenModeName: Str
  * The version range was already checked by [ValidateVersionRangeStep], so reaching here with
  * an id outside the catalog means the idea and the world genuinely disagree.
  */
-internal data class ValidateItemIdsStep(val availableIds: List<Item>) : Step<Pair<BasicIdeaInfo, Map<String, Int>>, AppFailure, IdeaForImport> {
-    override suspend fun process(input: Pair<BasicIdeaInfo, Map<String, Int>>): Result<AppFailure, IdeaForImport> {
-        val (ideaInfo, requirements) = input
+internal data class ValidateItemIdsStep(val availableIds: List<Item>) :
+    Step<Triple<BasicIdeaInfo, Map<String, Int>, BuildTimeChoice>, AppFailure, IdeaForImport> {
+    override suspend fun process(
+        input: Triple<BasicIdeaInfo, Map<String, Int>, BuildTimeChoice>,
+    ): Result<AppFailure, IdeaForImport> {
+        val (ideaInfo, requirements, buildTime) = input
         val mappedProduction = mutableMapOf<Item, Int>()
         val unrecordable = mutableListOf<String>()
         val errors = mutableListOf<ValidationFailure>()
@@ -483,6 +594,8 @@ internal data class ValidateItemIdsStep(val availableIds: List<Item>) : Step<Pai
                     production = mappedProduction,
                     placedCounts = resolved.placedCounts,
                     unrecordableProductions = unrecordable.sorted(),
+                    buildTimeModes = buildTime.available,
+                    chosenBuildTimeMode = buildTime.chosen,
                 )
             )
         } else {

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/pipeline/project/ImportIdeaPipeline.kt
@@ -362,7 +362,12 @@ private val GetIdeaForImportStep = DatabaseSteps.transaction { connection ->
             }
 
             val requirementInfo = DatabaseSteps.query<Int, Map<String, Int>>(
-                sql = SafeSQL.select("SELECT item_id, quantity FROM idea_item_requirements WHERE idea_id = ?"),
+                // Base list only — a build-time mode's own list is chosen at import and read from
+                // the modes (MCO-463, V2_61_0). Without the filter an idea with variants would
+                // import the sum of all of them.
+                sql = SafeSQL.select(
+                    "SELECT item_id, quantity FROM idea_item_requirements WHERE idea_id = ? AND mode_id IS NULL"
+                ),
                 parameterSetter = { statement, ideaId ->
                     statement.setInt(1, ideaId)
                 },

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/dsl/pages/ImportReviewPage.kt
@@ -90,6 +90,14 @@ fun importReviewPage(
     unrecordableProductions: List<String> = emptyList(),
     offerAlreadyBuilt: Boolean = false,
     wizard: ImportWizardStep? = null,
+    /**
+     * The ways this design can be built, when there is more than one (MCO-463). Empty for every
+     * idea with a single material list, and for the schematic door, which has no modes at all.
+     */
+    buildTimeModes: List<String> = emptyList(),
+    chosenBuildTimeMode: String? = null,
+    /** The review URL for another variant — see `reviewHrefFor`. */
+    reviewHref: (String) -> String = { "" },
 ): String = pageShell(
     pageTitle = "Seam — review import",
     user = user,
@@ -147,6 +155,8 @@ fun importReviewPage(
                         required = true
                     }
                 }
+
+                buildTimeChoice(buildTimeModes, chosenBuildTimeMode, reviewHref)
 
                 productionNotice(unrecordableProductions)
 
@@ -493,6 +503,61 @@ private fun FlowContent.warningStrip(warnings: ImportWarnings) {
  * version could have used; a full-weight warning here would outrank the creative-only strip,
  * which is about materials the user is about to go and gather.
  */
+/**
+ * Which way this design is being built (MCO-463), when its author recorded more than one.
+ *
+ * ## Why it is on this screen at all
+ *
+ * A build-time variant changes *what the project costs*: the 4-module cobblestone farm needs about
+ * four times the materials of the single-module one, and they are different `.litematic` files.
+ * That is the same class of decision as unchecking the decorative shell, so it belongs to the
+ * screen whose whole job is showing what the import will cost — made deliberately, not defaulted
+ * silently in a pipeline the user never sees.
+ *
+ * ## Links, not radios
+ *
+ * Choosing re-runs the review GET rather than toggling anything client-side. Everything on this
+ * page is derived from the chosen variant — the material list, MCO-305's warnings, the totals, the
+ * creative-only strip — so re-deriving all of it server-side is the only way they cannot disagree.
+ * A radio that swapped the table alone would leave the warnings describing a different build,
+ * which is exactly the two-answers-to-one-question shape that MCO-458/460/461 were all instances
+ * of. The chosen name also rides the form as a hidden field, so the POST imports what was on
+ * screen.
+ *
+ * Renders nothing at all below two variants, which is every idea that has no build-time axis.
+ */
+private fun FlowContent.buildTimeChoice(
+    available: List<String>,
+    chosen: String?,
+    reviewHref: (String) -> String,
+) {
+    if (available.size < 2) return
+
+    div("import-review__build-time") {
+        p("import-review__build-time-label") { +"This design can be built more than one way" }
+        p("import-review__build-time-hint") {
+            +"Each way costs different materials. The list below is for the one selected."
+        }
+        div("import-review__build-time-options") {
+            available.forEach { mode ->
+                val isChosen = mode == chosen
+                if (isChosen) {
+                    // The current one is not a link: it goes nowhere, and making it clickable
+                    // invites a reload that changes nothing.
+                    span("import-review__build-time-option import-review__build-time-option--chosen") {
+                        +mode
+                    }
+                } else {
+                    a(classes = "import-review__build-time-option") {
+                        href = reviewHref(mode)
+                        +mode
+                    }
+                }
+            }
+        }
+    }
+}
+
 private fun FlowContent.productionNotice(unrecordable: List<String>) {
     if (unrecordable.isEmpty()) return
 

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaMaterialList.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaMaterialList.kt
@@ -1,9 +1,11 @@
 package app.mcorg.presentation.templated.idea
 
+import app.mcorg.domain.model.idea.IdeaProductionMode
 import app.mcorg.pipeline.idea.single.IdeaMaterial
 import kotlinx.html.FlowContent
 import kotlinx.html.div
 import kotlinx.html.h2
+import kotlinx.html.h3
 import kotlinx.html.li
 import kotlinx.html.p
 import kotlinx.html.section
@@ -16,21 +18,77 @@ import kotlinx.html.ul
  * `idea_item_requirements` was written on create and read only by the import pipeline, so the
  * person deciding whether to import a design could not see what it would cost them — the one thing
  * a material list is for.
+ *
+ * ## One list, or one per variant (MCO-463)
+ *
+ * A design with build-time variants has no base list at all: each variant owns a complete list,
+ * from its own `.litematic`, and they *replace* the base rather than adding to it. So [materials]
+ * arrives empty for exactly those designs, and rendering only it would show a farm with fifteen
+ * materials as having none — which is what this page did for the first design ever saved with a
+ * variant.
+ *
+ * Both are shown the same way on purpose. The variants exist because they cost different amounts,
+ * so the reader's question is "how much more is the 4-module one", and stacked lists with their
+ * own totals answer it in one screen.
  */
-fun FlowContent.ideaMaterialList(materials: List<IdeaMaterial>) {
-    if (materials.isEmpty()) return
+fun FlowContent.ideaMaterialList(
+    materials: List<IdeaMaterial>,
+    productionModes: List<IdeaProductionMode> = emptyList(),
+) {
+    if (materials.isNotEmpty()) {
+        section("idea-detail__materials") {
+            materialListBody("Materials", materials)
+        }
+        return
+    }
+
+    val variants = productionModes.filter { it.isBuildTime && it.requirements.isNotEmpty() }
+    if (variants.isEmpty()) return
 
     section("idea-detail__materials") {
         h2("idea-detail__section-title") { +"Materials" }
         p("idea-detail__section-subtitle") {
-            +"${materials.size} ${if (materials.size == 1) "item" else "items"}, ${materials.sumOf { it.quantity.toLong() }.formatWithSeparators()} total"
+            // One variant is not a choice, so it must not be described as one — "can be built 1
+            // ways" was both ungrammatical and untrue. It still gets its own named block, because
+            // the author named it and a second one may follow.
+            +if (variants.size == 1) {
+                "Built one specific way, with its own material list."
+            } else {
+                "This design can be built ${variants.size} ways, each costing something different."
+            }
         }
-        ul("idea-materials") {
-            materials.forEach { material ->
-                li("idea-materials__row") {
-                    span("idea-materials__name") { +material.displayName() }
-                    span("idea-materials__qty") { +material.quantity.toLong().formatWithSeparators() }
-                }
+        variants.forEach { variant ->
+            div("idea-materials__variant") {
+                materialListBody(
+                    variant.name,
+                    variant.requirements.map { (itemId, quantity) -> IdeaMaterial(itemId, null, quantity) }
+                        .sortedByDescending { it.quantity },
+                    headingLevel = 3,
+                )
+            }
+        }
+    }
+}
+
+/** The heading, the count line and the rows — identical whether it is the base list or a variant's. */
+private fun FlowContent.materialListBody(
+    title: String,
+    materials: List<IdeaMaterial>,
+    headingLevel: Int = 2,
+) {
+    if (headingLevel == 2) {
+        h2("idea-detail__section-title") { +title }
+    } else {
+        h3("idea-materials__variant-title") { +title }
+    }
+    p("idea-detail__section-subtitle") {
+        +"${materials.size} ${if (materials.size == 1) "item" else "items"}, ${materials.sumOf { it.quantity.toLong() }.formatWithSeparators()} total"
+    }
+    ul("idea-materials") {
+        materials.forEach { material ->
+            li("idea-materials__row") {
+                span("idea-materials__name") { +material.displayName() }
+                span("idea-materials__qty") { +material.quantity.toLong().formatWithSeparators() }
             }
         }
     }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaPage.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/IdeaPage.kt
@@ -49,7 +49,7 @@ fun ideaPage(
                 ideaDetailHeader(user, idea)
                 ideaDetailFields(idea)
                 ideaProductionModes(productionModes)
-                ideaMaterialList(materials)
+                ideaMaterialList(materials, productionModes)
                 ideaRatingDistribution(idea, comments)
                 ideaCommentsSection(user.id, idea, comments)
             }

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
@@ -270,9 +270,12 @@ private fun FlowContent.productionModeBlock(
             div("production-mode__materials") {
                 p("form-help-text") { +"What building it this way costs — drop this variant's .litematic:" }
                 input(type = InputType.file, classes = "form-control") {
-                    // Not `name`d after the field the base list uses: this input posts on change
-                    // and is never part of the outer form's own submission, so a shared name would
-                    // only risk the two lists colliding on the server.
+                    // Named, and named the same as the base list's input. A control with no `name`
+                    // is not submitted at all, so HTMX posted an empty multipart and the endpoint
+                    // answered 422 — caught in a browser, invisible to a render test asserting the
+                    // hx-post URL. Sharing the name is safe because these are separate requests:
+                    // this input posts only itself, on change, and never rides the outer form.
+                    name = "litematicFile"
                     accept = ".litematic"
                     // Several, for the same reason the base list takes several: a design that
                     // spans dimensions is more than one file (MCO-414), and every one of them is

--- a/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
+++ b/webapp/mc-web/src/main/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFields.kt
@@ -2,11 +2,18 @@ package app.mcorg.presentation.templated.idea.createwizard
 
 import app.mcorg.domain.model.idea.IdeaCategory
 import app.mcorg.domain.model.idea.IdeaDraft
+import app.mcorg.domain.model.idea.IdeaModeKind
 import app.mcorg.domain.model.minecraft.MinecraftVersionRange
 import app.mcorg.pipeline.idea.draft.DraftData
 import app.mcorg.pipeline.idea.draft.DraftProductionMode
+import app.mcorg.presentation.hxPost
+import app.mcorg.presentation.hxSwap
+import app.mcorg.presentation.hxTarget
+import app.mcorg.presentation.hxTrigger
 import kotlinx.html.ButtonType
 import kotlinx.html.FlowContent
+import kotlinx.html.details
+import kotlinx.html.summary
 import kotlinx.html.InputType
 import kotlinx.html.button
 import kotlinx.html.classes
@@ -102,26 +109,46 @@ fun FlowContent.draftProductionFields(draft: IdeaDraft) {
         // Raw <template> because kotlinx.html only offers `template` on PhrasingContent, and this
         // sits in flow content. The rendered fragment carries its own wrapping <div>, which is why
         // the script picks the block out by class rather than taking firstElementChild.
-        unsafe {
-            raw(
-                "<template id=\"production-mode-template\">" +
-                    createHTML().div {
-                        productionModeBlock(
-                            index = MODE_INDEX_TOKEN,
-                            mode = DraftProductionMode(),
-                            showName = true,
-                            versionRange = versionRange,
-                        )
-                    } +
-                    "</template>"
-            )
+        // One template per kind, both server-rendered, because they differ by more than a flag: the
+        // build-time block carries a whole materials upload whose hx-* attributes have to be the
+        // real ones. Building either in JS would mean maintaining the markup twice.
+        IdeaModeKind.entries.forEach { kind ->
+            unsafe {
+                raw(
+                    "<template id=\"production-mode-template-${kind.name}\">" +
+                        createHTML().div {
+                            productionModeBlock(
+                                index = MODE_INDEX_TOKEN,
+                                mode = DraftProductionMode(kind = kind),
+                                showName = true,
+                                versionRange = versionRange,
+                            )
+                        } +
+                        "</template>"
+                )
+            }
         }
 
-        button(classes = "btn btn--ghost btn--sm") {
-            type = ButtonType.button
-            id = "add-production-mode"
-            attributes["onclick"] = "addProductionMode()"
-            +"This farm can be run another way"
+        div("production-mode-actions") {
+            button(classes = "btn btn--ghost btn--sm") {
+                type = ButtonType.button
+                id = "add-production-mode"
+                attributes["onclick"] = "addProductionMode('RUNTIME')"
+                +"This farm can be run another way"
+            }
+            // The second door, and the one MCO-463 exists for. Phrased as a question about the
+            // design rather than about the schema — an author knows whether their farm has a
+            // bigger version; nobody knows what a "build-time mode" is until they are told.
+            button(classes = "btn btn--ghost btn--sm") {
+                type = ButtonType.button
+                id = "add-build-time-mode"
+                attributes["onclick"] = "addProductionMode('BUILD_TIME')"
+                +"…or built another way"
+            }
+        }
+        p("form-help") {
+            +"Built another way means it costs different materials — a 4-module farm against a "
+            +"single one. Each gets its own .litematic, and you pick one when you import it."
         }
 
         script {
@@ -142,14 +169,35 @@ private fun FlowContent.productionModeBlock(
     showName: Boolean,
     versionRange: MinecraftVersionRange,
 ) {
+    val isBuildTime = mode.kind == IdeaModeKind.BUILD_TIME
     div("production-mode") {
         attributes["data-mode-index"] = index
+        attributes["data-mode-kind"] = mode.kind.name
+
+        // Which kind this is, carried explicitly rather than inferred from whether a material list
+        // happens to be present. A build-time variant whose .litematic has not been dropped yet is
+        // still build-time, and inferring would silently demote it on save.
+        hiddenInput {
+            name = "productionMode[$index][kind]"
+            value = mode.kind.name
+        }
+
+        if (isBuildTime) {
+            // Only ever shown on build-time blocks. Runtime is the unmarked default — labelling
+            // both would put mode vocabulary in front of the single-mode author that MCO-204
+            // removed the form's nesting to protect.
+            span("badge badge--neutral production-mode__kind") { +"Built this way" }
+        }
 
         if (showName) {
             input(type = InputType.text, classes = "form-control production-mode__name") {
                 name = "productionMode[$index][name]"
                 value = mode.name
-                placeholder = "How it is run — \"Max speed\", \"Skeletons only\""
+                placeholder = if (isBuildTime) {
+                    "How it is built — \"4 modules\", \"With storage\""
+                } else {
+                    "How it is run — \"Max speed\", \"Skeletons only\""
+                }
             }
         } else {
             // Carries the existing name rather than blanking it. A mode can be named and then
@@ -211,7 +259,83 @@ private fun FlowContent.productionModeBlock(
                     }
                 }
         }
+
+        // A build-time variant costs different materials from its siblings, which is the whole
+        // reason it is a separate mode (MCO-463). Its list comes from its own `.litematic` — the
+        // 4-module farm is its own download — so the upload is per block rather than one batch at
+        // submit: each request stays inside ReceiveSchematicStep's whole-upload file and byte
+        // budget instead of multiplying it by the number of variants, and one unparseable file
+        // costs that variant rather than the whole design.
+        if (isBuildTime) {
+            div("production-mode__materials") {
+                p("form-help-text") { +"What building it this way costs — drop this variant's .litematic:" }
+                input(type = InputType.file, classes = "form-control") {
+                    // Not `name`d after the field the base list uses: this input posts on change
+                    // and is never part of the outer form's own submission, so a shared name would
+                    // only risk the two lists colliding on the server.
+                    accept = ".litematic"
+                    // Several, for the same reason the base list takes several: a design that
+                    // spans dimensions is more than one file (MCO-414), and every one of them is
+                    // part of what *this* variant costs.
+                    multiple = true
+                    hxPost("/ideas/create/litematic?mode=$index")
+                    hxTarget("#mode-materials-$index")
+                    hxSwap("beforeend")
+                    hxTrigger("change")
+                    attributes["hx-encoding"] = "multipart/form-data"
+                }
+
+                // Collapsed by default, and it has to be: four variants of a large farm is four
+                // three-hundred-row lists, and the comparison worth seeing — 400 cobblestone
+                // against 1,600 — is in the summary rather than the rows.
+                details("production-mode__materials-disclosure") {
+                    summary {
+                        span("production-mode__materials-count") {
+                            id = "mode-materials-summary-$index"
+                            +materialsSummary(mode.requirements)
+                        }
+                    }
+                    ul("wizard-item-list production-mode__materials-list") {
+                        id = "mode-materials-$index"
+                        mode.requirements.entries
+                            .sortedByDescending { it.value }
+                            .forEach { (itemId, quantity) ->
+                                li("item-req") {
+                                    id = "item-req-$index-$itemId"
+                                    attributes["data-item-id"] = itemId
+                                    +"$itemId × $quantity"
+                                    hiddenInput {
+                                        name = "modeRequirements[$index][$itemId]"
+                                        value = quantity.toString()
+                                    }
+                                    button(classes = "btn btn--ghost btn--sm") {
+                                        type = ButtonType.button
+                                        attributes["onclick"] = "this.closest('li').remove()"
+                                        +"Remove"
+                                    }
+                                }
+                            }
+                    }
+                }
+            }
+        }
     }
+}
+
+/**
+ * The one line an author reads to tell two variants apart without expanding either.
+ *
+ * Deliberately leads with the total rather than the item count: "1,600 cobblestone" next to
+ * "400 cobblestone" is the check that catches the likely mistake here, which is dropping the same
+ * file into two variants when four downloads have near-identical names.
+ */
+private fun materialsSummary(requirements: Map<String, Int>): String {
+    if (requirements.isEmpty()) return "No materials yet"
+    val largest = requirements.maxByOrNull { it.value }!!
+    val name = largest.key.substringAfter(':').replace('_', ' ')
+    val rest = requirements.size - 1
+    val total = "%,d".format(largest.value)
+    return if (rest == 0) "$total $name" else "$total $name, and $rest more"
 }
 
 /**
@@ -271,7 +395,56 @@ private fun productionScript() = """
         if (event.target && event.target.tagName === 'BUTTON') setTimeout(refreshProductionRecommendation, 0);
     });
 
-    function addProductionMode() {
+    /**
+     * Recomputes a build-time variant's one-line summary from the rows currently in its list.
+     *
+     * Runs after an upload swaps rows in and after a Remove, because the summary is the only part
+     * of a collapsed list anyone reads — a stale one would say 400 cobblestone next to a list
+     * holding 1,600, which is exactly the comparison it exists to support.
+     */
+    function refreshModeMaterials(index) {
+        var list = document.getElementById('mode-materials-' + index);
+        var summary = document.getElementById('mode-materials-summary-' + index);
+        if (!list || !summary) return;
+
+        var rows = list.querySelectorAll('input[type=hidden][name^="modeRequirements["]');
+        if (rows.length === 0) { summary.textContent = 'No materials yet'; return; }
+
+        var largestName = '';
+        var largest = -1;
+        rows.forEach(function (input) {
+            var qty = parseInt(input.value, 10);
+            if (isNaN(qty) || qty <= largest) return;
+            largest = qty;
+            var match = input.name.match(/\[([^\]]+)\]$/);
+            largestName = match ? match[1].split(':').pop().replace(/_/g, ' ') : '';
+        });
+        if (largest < 0) { summary.textContent = 'No materials yet'; return; }
+
+        var total = largest.toLocaleString('en-US');
+        var rest = rows.length - 1;
+        summary.textContent = rest === 0
+            ? total + ' ' + largestName
+            : total + ' ' + largestName + ', and ' + rest + ' more';
+    }
+
+    // An upload swaps rows into one variant's list; htmx tells us which.
+    document.body.addEventListener('htmx:afterSwap', function (event) {
+        var id = event.target && event.target.id;
+        if (id && id.indexOf('mode-materials-') === 0) {
+            refreshModeMaterials(id.substring('mode-materials-'.length));
+        }
+    });
+
+    document.addEventListener('click', function (event) {
+        if (!event.target || event.target.tagName !== 'BUTTON') return;
+        var block = event.target.closest('.production-mode');
+        if (!block) return;
+        // After the row is actually gone, not before.
+        setTimeout(function () { refreshModeMaterials(block.dataset.modeIndex); }, 0);
+    });
+
+    function addProductionMode(kind) {
         var container = document.getElementById('production-modes');
         var section = document.getElementById('draft-productions');
         var index = parseInt(section.dataset.modeCount, 10);
@@ -294,8 +467,10 @@ private fun productionScript() = """
         });
 
         // Cloned from the server-rendered template so the new mode's search combo is identical to
-        // the existing ones — including the hx-vals carrying this draft's version range.
-        var template = document.getElementById('production-mode-template');
+        // the existing ones — including the hx-vals carrying this draft's version range. One
+        // template per kind: the build-time one brings its own materials upload.
+        var template = document.getElementById('production-mode-template-' + (kind || 'RUNTIME'));
+        if (!template) return;
         var markup = template.innerHTML.split('$MODE_INDEX_TOKEN').join(index);
         var holder = document.createElement('div');
         holder.innerHTML = markup;

--- a/webapp/mc-web/src/main/resources/db/migration/V2_61_0__build_time_production_modes.sql
+++ b/webapp/mc-web/src/main/resources/db/migration/V2_61_0__build_time_production_modes.sql
@@ -1,0 +1,97 @@
+-- Modes get a kind, and build-time modes get their own material lists (MCO-463).
+--
+-- V2_57_0 gave an idea production *modes* and modelled the half of them that varies: rates. It
+-- assumed one sentence, which MCO-413 was then built on — "a mode is a runtime option, not a
+-- build-time one". MCO-439 finding 1 found the counterexample while sourcing by hand: a cobblestone
+-- farm published as *single module / 4 modules* × *with / without storage*. All four are chosen
+-- when you build the thing, and 924k/h ÷ 231k/h = 4.0 exactly — the rate spread *is* the module
+-- count, a consequence of a build decision rather than a runtime one.
+--
+-- ## The discriminator is not switchability, it is what the mode changes
+--
+--   runtime mode     changes what the farm supplies
+--   build-time mode  changes what it supplies AND what it costs to build
+--
+-- The first half already has a home (idea_production_rates, per mode). The second does not:
+-- idea_item_requirements is PRIMARY KEY (idea_id, item_id) — one flat list per idea. So the four
+-- modes above were entered against one shared material list, and three of the four are wrong in
+-- the bank right now. A build-time mode is currently unrepresentable, not merely awkward.
+
+-- ---------------------------------------------------------------------------------------------
+-- 1. Modes declare their kind.
+--
+-- TEXT + CHECK rather than a Postgres enum, matching how the rest of this schema spells its closed
+-- sets: an enum needs ALTER TYPE to grow, and this one may well grow (nothing says build-time and
+-- runtime are the only two axes a design can have).
+--
+-- DEFAULT 'RUNTIME' is the honest backfill, not merely the convenient one. Every existing mode was
+-- entered under a form that only ever described ways of *running* a farm, so runtime is what those
+-- authors were answering. Anything else would attribute a choice to them they were never offered.
+ALTER TABLE idea_production_modes
+    ADD COLUMN kind TEXT NOT NULL DEFAULT 'RUNTIME'
+        CHECK (kind IN ('BUILD_TIME', 'RUNTIME'));
+
+-- MCO-413 reads this to decide which modes follow an import to the project: runtime modes reach
+-- project_productions and stay switchable, build-time modes are resolved at import and do not.
+CREATE INDEX idea_production_modes_kind_idx ON idea_production_modes (idea_id, kind);
+
+-- ---------------------------------------------------------------------------------------------
+-- 2. A build-time mode carries its own material list.
+--
+-- ## Whole lists, not deltas
+--
+-- Finding 1 left this open ("gains the mode dimension, or a mode-scoped sibling holds the deltas")
+-- and deltas looked attractive: the storage variant reads like "+N hoppers, +M chests" against a
+-- base. Rejected on how the data actually arrives. A build-time variant is a *different .litematic
+-- file* — the 4-module farm is its own download, parsed by its own upload (MCO-414's multi-file
+-- import already handles exactly this). Whole lists are what the front door produces; a delta would
+-- have to be computed against a base nobody entered, and would then have to be un-computed for
+-- every consumer that wants a material list. Deltas save typing that nobody was going to do
+-- anyway.
+--
+-- ## NULL mode_id is the base list, and it is what every existing row is
+--
+--   mode_id IS NULL      the idea's one list — a non-farm idea, or a farm with no build-time
+--                        variants. The shape this table has always had.
+--   mode_id IS NOT NULL  that build-time mode's own list, *replacing* the base rather than adding
+--                        to it. An idea with build-time modes has no NULL rows.
+--
+-- Replacement, not addition, for the same reason deltas lost: each variant's list is complete as
+-- captured. It also keeps the read trivial — one list per idea, or one per chosen mode, never a
+-- merge at read time.
+--
+-- Nullable rather than requiring every idea to own a mode: an idea with no productions at all (a
+-- build, a storage hall) still has requirements, and inventing a mode row to hang them off would
+-- put a farm concept on ideas that are not farms.
+--
+-- Runtime modes never own requirements — that is the whole distinction — and this is asserted in
+-- application code rather than here. A CHECK cannot see across to idea_production_modes.kind, and
+-- a trigger for one invariant that the two write paths already enforce would cost more to keep
+-- honest than it is worth.
+ALTER TABLE idea_item_requirements
+    ADD COLUMN mode_id INT NULL REFERENCES idea_production_modes (id) ON DELETE CASCADE;
+
+-- The PK cannot survive a nullable member (Postgres will not have NULL in a primary key), so it
+-- becomes two partial unique indexes that together say what it said, per list:
+--   - at most one row per item in the base list
+--   - at most one row per item in each build-time mode's list
+ALTER TABLE idea_item_requirements
+    DROP CONSTRAINT idea_item_requirements_pkey;
+
+CREATE UNIQUE INDEX idea_item_requirements_base_item_idx
+    ON idea_item_requirements (idea_id, item_id)
+    WHERE mode_id IS NULL;
+
+CREATE UNIQUE INDEX idea_item_requirements_mode_item_idx
+    ON idea_item_requirements (mode_id, item_id)
+    WHERE mode_id IS NOT NULL;
+
+-- idx_idea_item_requirements_idea_id (V2_16_2) still serves "everything this idea requires", which
+-- is now the read that has to span both kinds of row, so it is left alone.
+CREATE INDEX idea_item_requirements_mode_id_idx ON idea_item_requirements (mode_id);
+
+-- No backfill. Every existing row keeps mode_id NULL and means exactly what it meant yesterday:
+-- this idea's material list. Build-time modes only become expressible from here on, and the
+-- cobblestone farm that prompted this gets re-entered by hand (MCO-463's last acceptance
+-- criterion) rather than guessed at by a migration that cannot know which of its four variants the
+-- one stored list describes.

--- a/webapp/mc-web/src/main/resources/static/styles/pages/idea-hub.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/idea-hub.css
@@ -783,3 +783,21 @@ a.ideas-pagination__page:hover {
         gap: var(--space-1);
     }
 }
+
+
+/* MCO-463 — a design whose materials live on its build-time variants shows one list per variant.
+   Stacked rather than tabbed, for the same reason as the create form: the variants exist because
+   they cost different amounts, so the lists have to be readable against each other. */
+.idea-materials__variant + .idea-materials__variant {
+    margin-top: var(--space-5);
+    padding-top: var(--space-4);
+    border-top: 1px dashed var(--border);
+}
+
+.idea-materials__variant-title {
+    font-family: var(--font-ui);
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+}

--- a/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/idea-wizard.css
@@ -531,3 +531,47 @@
 .production-recommendation--hidden {
     display: none;
 }
+
+/* MCO-463 — a build-time variant, which costs different materials from its siblings.
+   Marked rather than separated: the whole reason these are stacked instead of tabbed is that the
+   author has to be able to compare 400 cobblestone against 1,600 without navigating. */
+.production-mode[data-mode-kind="BUILD_TIME"] {
+    border-left: 2px solid var(--accent);
+    padding-left: var(--space-3);
+}
+
+.production-mode__kind {
+    align-self: flex-start;
+}
+
+.production-mode__materials {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+}
+
+.production-mode__materials-disclosure > summary {
+    cursor: pointer;
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    padding: var(--space-1) 0;
+}
+
+/* The comparison line, so it reads as data rather than as chrome. */
+.production-mode__materials-count {
+    color: var(--text-primary);
+}
+
+/* Four variants of a large farm is four 300-row lists; bound each one rather than letting the
+   form run to several screens per variant. */
+.production-mode__materials-list {
+    max-height: 18rem;
+    overflow-y: auto;
+}
+
+.production-mode-actions {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+}

--- a/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
+++ b/webapp/mc-web/src/main/resources/static/styles/pages/import-review.css
@@ -411,3 +411,65 @@
         white-space: normal;
     }
 }
+
+
+/* MCO-463 — which way this design is being built, when its author recorded more than one.
+   Sits above the material list because it decides what that list says. */
+.import-review__build-time {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    padding: var(--space-3);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-raised);
+    margin-bottom: var(--space-4);
+}
+
+.import-review__build-time-label {
+    font-family: var(--font-ui);
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0;
+}
+
+.import-review__build-time-hint {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    margin: 0;
+}
+
+.import-review__build-time-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-top: var(--space-2);
+}
+
+/* Segmented control rather than a select: with two to four variants, seeing every option at
+   once is the point — the author named them to be compared. */
+.import-review__build-time-option {
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    text-decoration: none;
+    transition: border-color var(--transition-base), color var(--transition-base);
+}
+
+a.import-review__build-time-option:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.import-review__build-time-option--chosen {
+    border-color: var(--accent);
+    background: var(--accent-muted);
+    font-weight: 600;
+    /* Not a link, so it must not read as one to a pointer either. */
+    cursor: default;
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/commonsteps/IdeaProductionModeMergeTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/commonsteps/IdeaProductionModeMergeTest.kt
@@ -1,8 +1,11 @@
 package app.mcorg.pipeline.idea.commonsteps
 
+import app.mcorg.domain.model.idea.IdeaModeKind
 import app.mcorg.domain.model.idea.IdeaProductionMode
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * MCO-412 — the last line of defence before `UNIQUE (idea_id, name)`.
@@ -91,5 +94,121 @@ class IdeaProductionModeMergeTest {
 
         assertEquals(1, merged.size)
         assertEquals("Max speed", merged.single().name)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // MCO-463 — the two fields a mode gained, and how a name collision resolves them.
+
+    private fun buildTime(name: String, requirements: Map<String, Int>, vararg rates: Pair<String, Int?>) =
+        IdeaProductionModeInput(name, rates.toMap(), IdeaModeKind.BUILD_TIME, requirements)
+
+    @Test
+    fun `a mode is runtime unless it says otherwise`() {
+        // Matches the column default, and what every mode entered before MCO-463 was answering.
+        assertEquals(IdeaModeKind.RUNTIME, mode("Max speed", "minecraft:ice" to 71000).kind)
+    }
+
+    @Test
+    fun `build-time wins a kind collision, because it is the claim with consequences`() {
+        // Demoting to runtime would drop the material list on the floor at the next write.
+        val buildTimeFirst = listOf(
+            buildTime("4 modules", mapOf("minecraft:cobblestone" to 400)),
+            mode("4 modules", "minecraft:cobblestone" to 924000),
+        ).mergeByResolvedName()
+        val runtimeFirst = listOf(
+            mode("4 modules", "minecraft:cobblestone" to 924000),
+            buildTime("4 modules", mapOf("minecraft:cobblestone" to 400)),
+        ).mergeByResolvedName()
+
+        assertEquals(IdeaModeKind.BUILD_TIME, buildTimeFirst.single().kind)
+        assertEquals(IdeaModeKind.BUILD_TIME, runtimeFirst.single().kind)
+    }
+
+    @Test
+    fun `the larger quantity wins when two collide on one material`() {
+        // Same argument as rates: under-stating what a build costs is the expensive way to be wrong.
+        val merged = listOf(
+            buildTime("4 modules", mapOf("minecraft:cobblestone" to 400)),
+            buildTime("4 modules", mapOf("minecraft:cobblestone" to 1600)),
+        ).mergeByResolvedName()
+
+        assertEquals(mapOf("minecraft:cobblestone" to 1600), merged.single().requirements)
+    }
+
+    @Test
+    fun `colliding material lists union rather than replace`() {
+        val merged = listOf(
+            buildTime("With storage", mapOf("minecraft:hopper" to 64)),
+            buildTime("With storage", mapOf("minecraft:chest" to 32)),
+        ).mergeByResolvedName()
+
+        assertEquals(mapOf("minecraft:hopper" to 64, "minecraft:chest" to 32), merged.single().requirements)
+    }
+
+    @Test
+    fun `the four cobblestone variants stay four distinct modes`() {
+        // MCO-439 finding 1, the case that prompted all of this: single/4 modules x with/without
+        // storage. Four names, four material lists, and nothing here collapses them.
+        val merged = listOf(
+            buildTime("1 module", mapOf("minecraft:cobblestone" to 400), "minecraft:cobblestone" to 231000),
+            buildTime("1 module, storage", mapOf("minecraft:cobblestone" to 400, "minecraft:hopper" to 64)),
+            buildTime("4 modules", mapOf("minecraft:cobblestone" to 1600), "minecraft:cobblestone" to 924000),
+            buildTime("4 modules, storage", mapOf("minecraft:cobblestone" to 1600, "minecraft:hopper" to 256)),
+        ).mergeByResolvedName()
+
+        assertEquals(4, merged.size)
+        assertEquals(1600, merged[2].requirements["minecraft:cobblestone"])
+        assertEquals(256, merged[3].requirements["minecraft:hopper"])
+    }
+}
+
+/**
+ * MCO-463 — a runtime mode does not change what the build cost, so it may not own a material list.
+ *
+ * The database cannot say this: a CHECK cannot see across to `idea_production_modes.kind`. So it is
+ * asserted on the way in, at the one type both write paths construct.
+ */
+class IdeaModeRequirementsOwnershipTest {
+
+    private val list = mapOf("minecraft:cobblestone" to 1600)
+
+    @Test
+    fun `a build-time mode stores the list it was given`() {
+        val mode = IdeaProductionModeInput("4 modules", emptyMap(), IdeaModeKind.BUILD_TIME, list)
+
+        assertEquals(list, mode.requirementsToStore)
+    }
+
+    @Test
+    fun `a runtime mode handed a list stores none of it`() {
+        // Dropped rather than rejected: the caller is wrong, but a publish is not worth failing
+        // over a field that carries no meaning for this kind of mode.
+        val mode = IdeaProductionModeInput("Max speed", emptyMap(), IdeaModeKind.RUNTIME, list)
+
+        assertEquals(emptyMap(), mode.requirementsToStore)
+    }
+
+    @Test
+    fun `build-time lists replace the idea's base list`() {
+        val modes = listOf(IdeaProductionModeInput("4 modules", emptyMap(), IdeaModeKind.BUILD_TIME, list))
+
+        assertTrue(modes.replaceBaseRequirements())
+    }
+
+    @Test
+    fun `runtime modes leave the base list alone`() {
+        // The pre-MCO-463 shape, and every idea in the bank: one list, hanging off the idea.
+        val modes = listOf(IdeaProductionModeInput("Max speed", mapOf("minecraft:ice" to 71000)))
+
+        assertFalse(modes.replaceBaseRequirements())
+    }
+
+    @Test
+    fun `a runtime mode carrying a stray list does not displace the base list`() {
+        // replaceBaseRequirements asks what will be *stored*, not what was passed — otherwise a
+        // caller error would silently delete the idea's real material list.
+        val modes = listOf(IdeaProductionModeInput("Max speed", emptyMap(), IdeaModeKind.RUNTIME, list))
+
+        assertFalse(modes.replaceBaseRequirements())
     }
 }

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/draft/BuildTimeModeFormTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/idea/draft/BuildTimeModeFormTest.kt
@@ -1,0 +1,156 @@
+package app.mcorg.pipeline.idea.draft
+
+import app.mcorg.domain.model.idea.IdeaModeKind
+import app.mcorg.presentation.templated.idea.createwizard.DraftWizardStage
+import io.ktor.http.Parameters
+import io.ktor.http.parametersOf
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * MCO-463 — what the create form submits for a build-time variant, and what the draft keeps.
+ *
+ * The four-variant cobblestone farm from MCO-439 finding 1 is the case throughout: *single module /
+ * 4 modules* × *with / without storage*, each with its own `.litematic` and so its own material
+ * list. Before this the form could only hold one list for the whole idea, so three of the four were
+ * wrong.
+ */
+class BuildTimeModeFormTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    private fun productions(vararg pairs: Pair<String, String>): List<DraftProductionMode> {
+        val params: Parameters = parametersOf(*pairs.map { (k, v) -> k to listOf(v) }.toTypedArray())
+        val stageJson = buildStageJson(DraftWizardStage.PRODUCTIONS, params)
+        return json.decodeFromString(DraftData.serializer(), stageJson).productionModes.orEmpty()
+    }
+
+    @Test
+    fun `a mode with no kind submitted is a runtime mode`() {
+        // Every draft saved before this field existed, and every mode the first button adds.
+        val modes = productions(
+            "productionMode[0][name]" to "Max speed",
+            "productionRate[0][minecraft:ice]" to "71000",
+        )
+
+        assertEquals(IdeaModeKind.RUNTIME, modes.single().kind)
+        assertTrue(modes.single().requirements.isEmpty())
+    }
+
+    @Test
+    fun `a build-time variant keeps its own material list`() {
+        val modes = productions(
+            "productionMode[0][name]" to "4 modules",
+            "productionMode[0][kind]" to "BUILD_TIME",
+            "productionRate[0][minecraft:cobblestone]" to "924000",
+            "modeRequirements[0][minecraft:cobblestone]" to "1600",
+            "modeRequirements[0][minecraft:hopper]" to "256",
+        )
+
+        val mode = modes.single()
+        assertEquals(IdeaModeKind.BUILD_TIME, mode.kind)
+        assertEquals(mapOf("minecraft:cobblestone" to 1600, "minecraft:hopper" to 256), mode.requirements)
+    }
+
+    @Test
+    fun `a build-time variant survives on its material list with no rate at all`() {
+        // The rule before MCO-463 was "no rates, no mode". A variant whose output nobody timed is
+        // still a real variant — it says what building it costs, which is the half that matters at
+        // import — so dropping it here would silently discard one of the four.
+        val modes = productions(
+            "productionMode[0][name]" to "1 module, storage",
+            "productionMode[0][kind]" to "BUILD_TIME",
+            "modeRequirements[0][minecraft:cobblestone]" to "400",
+        )
+
+        assertEquals(1, modes.size)
+        assertEquals("1 module, storage", modes.single().name)
+        assertEquals(mapOf("minecraft:cobblestone" to 400), modes.single().requirements)
+    }
+
+    @Test
+    fun `a runtime mode with no rates still says nothing and does not survive`() {
+        // The MCO-412 rule, unchanged for the kind it was written about.
+        val modes = productions("productionMode[0][name]" to "Max speed")
+
+        assertTrue(modes.isEmpty())
+    }
+
+    @Test
+    fun `a runtime mode carrying a stray material list has it dropped`() {
+        // Switching a block back to runtime should not leave materials it no longer claims — they
+        // would reappear on reload and then be dropped again at the write path, silently.
+        val modes = productions(
+            "productionMode[0][name]" to "Max speed",
+            "productionMode[0][kind]" to "RUNTIME",
+            "productionRate[0][minecraft:ice]" to "71000",
+            "modeRequirements[0][minecraft:packed_ice]" to "900",
+        )
+
+        assertTrue(modes.single().requirements.isEmpty())
+    }
+
+    @Test
+    fun `the four cobblestone variants each keep their own list`() {
+        val modes = productions(
+            "productionMode[0][name]" to "1 module",
+            "productionMode[0][kind]" to "BUILD_TIME",
+            "productionRate[0][minecraft:cobblestone]" to "231000",
+            "modeRequirements[0][minecraft:cobblestone]" to "400",
+            "productionMode[1][name]" to "1 module, storage",
+            "productionMode[1][kind]" to "BUILD_TIME",
+            "modeRequirements[1][minecraft:cobblestone]" to "400",
+            "modeRequirements[1][minecraft:hopper]" to "64",
+            "productionMode[2][name]" to "4 modules",
+            "productionMode[2][kind]" to "BUILD_TIME",
+            "productionRate[2][minecraft:cobblestone]" to "924000",
+            "modeRequirements[2][minecraft:cobblestone]" to "1600",
+            "productionMode[3][name]" to "4 modules, storage",
+            "productionMode[3][kind]" to "BUILD_TIME",
+            "modeRequirements[3][minecraft:cobblestone]" to "1600",
+            "modeRequirements[3][minecraft:hopper]" to "256",
+        )
+
+        assertEquals(4, modes.size)
+        assertEquals(
+            listOf("1 module", "1 module, storage", "4 modules", "4 modules, storage"),
+            modes.map { it.name },
+        )
+        // The 4x that made this a build-time axis in the first place, held per variant.
+        assertEquals(400, modes[0].requirements["minecraft:cobblestone"])
+        assertEquals(1600, modes[2].requirements["minecraft:cobblestone"])
+        assertEquals(64, modes[1].requirements["minecraft:hopper"])
+        assertEquals(256, modes[3].requirements["minecraft:hopper"])
+    }
+
+    @Test
+    fun `a material row with no usable quantity is dropped rather than stored as zero`() {
+        // Unlike a rate, where blank means "never measured", a blank quantity says nothing at all —
+        // "some cobblestone" is not a material list.
+        val modes = productions(
+            "productionMode[0][name]" to "4 modules",
+            "productionMode[0][kind]" to "BUILD_TIME",
+            "modeRequirements[0][minecraft:cobblestone]" to "1600",
+            "modeRequirements[0][minecraft:hopper]" to "",
+            "modeRequirements[0][minecraft:chest]" to "nonsense",
+            "modeRequirements[0][minecraft:torch]" to "0",
+        )
+
+        assertEquals(mapOf("minecraft:cobblestone" to 1600), modes.single().requirements)
+    }
+
+    @Test
+    fun `an unrecognised kind falls back to runtime rather than failing the save`() {
+        // The field is a hidden input, so a hand-edited value is the only way here. Losing the
+        // whole draft over it would be worse than treating it as the unmarked default.
+        val modes = productions(
+            "productionMode[0][name]" to "Max speed",
+            "productionMode[0][kind]" to "SOMETHING_ELSE",
+            "productionRate[0][minecraft:ice]" to "71000",
+        )
+
+        assertEquals(IdeaModeKind.RUNTIME, modes.single().kind)
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/BuildTimeImportSelectionTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/pipeline/project/BuildTimeImportSelectionTest.kt
@@ -1,0 +1,109 @@
+package app.mcorg.pipeline.project
+
+import app.mcorg.domain.model.idea.IdeaModeKind
+import app.mcorg.domain.model.idea.IdeaProductionMode
+import app.mcorg.domain.model.idea.buildTimeModes
+import app.mcorg.domain.model.idea.runtimeModes
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * MCO-463 — choosing which way a design is built, at import.
+ *
+ * The case is MCO-439 finding 1's cobblestone farm: *single module / 4 modules* × *with / without
+ * storage*, four variants whose material lists differ by roughly 4×. Which one you import decides
+ * what the project costs, so the choice reaches the project rather than being defaulted out of
+ * sight.
+ */
+class BuildTimeImportSelectionTest {
+
+    private fun variant(name: String, position: Int, cobble: Int, rate: Int?) = IdeaProductionMode(
+        id = position + 1,
+        name = name,
+        position = position,
+        rates = rate?.let { mapOf("minecraft:cobblestone" to it) } ?: emptyMap(),
+        kind = IdeaModeKind.BUILD_TIME,
+        requirements = mapOf("minecraft:cobblestone" to cobble),
+    )
+
+    private val cobbleFarm = listOf(
+        variant("1 module", 0, cobble = 400, rate = 231_000),
+        variant("4 modules", 1, cobble = 1_600, rate = 924_000),
+    )
+
+    private val fortressFarm = listOf(
+        IdeaProductionMode(1, "Skeletons only", 0, mapOf("minecraft:bone" to 900)),
+        IdeaProductionMode(2, "Everything", 1, mapOf("minecraft:bone" to 700, "minecraft:blaze_rod" to 500)),
+    )
+
+    @Test
+    fun `build-time and runtime modes are told apart`() {
+        val mixed = cobbleFarm + fortressFarm
+
+        assertEquals(listOf("1 module", "4 modules"), mixed.buildTimeModes().map { it.name })
+        assertEquals(listOf("Skeletons only", "Everything"), mixed.runtimeModes().map { it.name })
+    }
+
+    @Test
+    fun `a farm with no build-time axis offers no choice at all`() {
+        // Every idea in the bank before MCO-463, and most after it.
+        assertTrue(fortressFarm.buildTimeModes().isEmpty())
+    }
+
+    @Test
+    fun `the named variant's rates are the ones imported`() {
+        assertEquals(mapOf("minecraft:cobblestone" to 231_000), ratesForImport(cobbleFarm, "1 module"))
+        assertEquals(mapOf("minecraft:cobblestone" to 924_000), ratesForImport(cobbleFarm, "4 modules"))
+    }
+
+    @Test
+    fun `an unmeasured variant imports no rate rather than borrowing a sibling's`() {
+        // The drift this whole issue exists to stop: attributing the 4-module farm's 924k/h to the
+        // single-module build because nobody timed that one.
+        val untimed = listOf(
+            variant("1 module", 0, cobble = 400, rate = null),
+            variant("4 modules", 1, cobble = 1_600, rate = 924_000),
+        )
+
+        assertEquals(emptyMap(), ratesForImport(untimed, "1 module"))
+    }
+
+    @Test
+    fun `with no choice given the best producer still wins`() {
+        // Unchanged MCO-412 behaviour for every caller that names no mode.
+        assertEquals(mapOf("minecraft:cobblestone" to 924_000), ratesForImport(cobbleFarm))
+    }
+
+    @Test
+    fun `a name that matches nothing falls back rather than importing an empty design`() {
+        // What happens when the design is edited between the review rendering and the POST: the
+        // variant the form named is gone. Falling back beats failing the import outright.
+        val chosen = cobbleFarm.buildTimeModes().firstOrNull { it.name == "8 modules" }
+            ?: cobbleFarm.buildTimeModes().firstOrNull()
+
+        assertEquals("1 module", chosen?.name)
+    }
+
+    @Test
+    fun `the default is the author's first, not the largest build`() {
+        // `position` is documented as the author's ordering and explicitly not a ranking. Choosing
+        // the biggest producer would silently commit someone to the 4-module build's 4x bill.
+        val default = cobbleFarm.buildTimeModes().firstOrNull()
+
+        assertEquals("1 module", default?.name)
+        assertEquals(mapOf("minecraft:cobblestone" to 400), default?.requirements)
+    }
+
+    @Test
+    fun `each variant carries its own material list, and they differ by the module count`() {
+        val single = cobbleFarm.first { it.name == "1 module" }
+        val four = cobbleFarm.first { it.name == "4 modules" }
+
+        assertEquals(400, single.requirements["minecraft:cobblestone"])
+        assertEquals(1_600, four.requirements["minecraft:cobblestone"])
+        // 924k / 231k = 4.0 exactly — the rate spread *is* the module count, which is what made
+        // this a build-time axis rather than a runtime one.
+        assertEquals(4, four.requirements["minecraft:cobblestone"]!! / single.requirements["minecraft:cobblestone"]!!)
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
@@ -143,19 +143,30 @@ class ImportIdeaReviewIT : WithUser() {
         // MCO-463, from MCO-439 finding 1: a cobblestone farm published as single/4 modules, both
         // chosen when you *build* it and costing roughly 4x apart. Before this the bank could hold
         // one material list for the pair, so one of the two was always wrong.
+        //
+        // It *produces* tuff rather than the cobblestone it is built from, which is a test-harness
+        // constraint and not a fact about the farm. The Testcontainers database is shared across IT
+        // classes, so an idea seeded here is in the idea bank every other suite queries — and
+        // FarmSuggestionIT asserts that a cobblestone plan has *no* design answering it once its
+        // own design is excluded. A second cobblestone producer here made that suite fail
+        // depending on class order, which is exactly the suite-wide collision this file already
+        // warns about for minecraft:sculk_shrieker. Requirements are unconstrained (nothing matches
+        // demand against them), so the 4x cobblestone relationship that makes this a build-time
+        // axis is kept where it matters.
         seedItem("minecraft:cobblestone", "Cobblestone")
         seedItem("minecraft:hopper", "Hopper")
+        seedItem("minecraft:tuff", "Tuff")
         cobbleIdeaId = createIdea("Cobblestone Farm")
         addBuildTimeMode(
             cobbleIdeaId,
             "1 module",
-            rates = listOf("minecraft:cobblestone" to 231_000),
+            rates = listOf("minecraft:tuff" to 231_000),
             requirements = listOf("minecraft:cobblestone" to 400),
         )
         addBuildTimeMode(
             cobbleIdeaId,
             "4 modules",
-            rates = listOf("minecraft:cobblestone" to 924_000),
+            rates = listOf("minecraft:tuff" to 924_000),
             requirements = listOf("minecraft:cobblestone" to 1_600, "minecraft:hopper" to 256),
         )
     }
@@ -775,7 +786,7 @@ class ImportIdeaReviewIT : WithUser() {
         )
         // The 4-module rate, because that is the build being made. Importing the single-module
         // list with the 4-module throughput would be the exact drift MCO-463 exists to stop.
-        assertEquals(listOf("minecraft:cobblestone" to 924_000), readProductions(projectId))
+        assertEquals(listOf("minecraft:tuff" to 924_000), readProductions(projectId))
     }
 
     @Test

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/handler/project/ImportIdeaReviewIT.kt
@@ -63,6 +63,7 @@ class ImportIdeaReviewIT : WithUser() {
     private var multiModeIdeaId: Int = 0
     private var unknownProductionIdeaId: Int = 0
     private var placedIdeaId: Int = 0
+    private var cobbleIdeaId: Int = 0
 
     @BeforeAll
     fun setup() {
@@ -137,6 +138,25 @@ class ImportIdeaReviewIT : WithUser() {
             unknownProductionIdeaId,
             "Default",
             listOf("minecraft:iron_ingot" to 90, "minecraft:sculk_shrieker" to 30),
+        )
+
+        // MCO-463, from MCO-439 finding 1: a cobblestone farm published as single/4 modules, both
+        // chosen when you *build* it and costing roughly 4x apart. Before this the bank could hold
+        // one material list for the pair, so one of the two was always wrong.
+        seedItem("minecraft:cobblestone", "Cobblestone")
+        seedItem("minecraft:hopper", "Hopper")
+        cobbleIdeaId = createIdea("Cobblestone Farm")
+        addBuildTimeMode(
+            cobbleIdeaId,
+            "1 module",
+            rates = listOf("minecraft:cobblestone" to 231_000),
+            requirements = listOf("minecraft:cobblestone" to 400),
+        )
+        addBuildTimeMode(
+            cobbleIdeaId,
+            "4 modules",
+            rates = listOf("minecraft:cobblestone" to 924_000),
+            requirements = listOf("minecraft:cobblestone" to 1_600, "minecraft:hopper" to 256),
         )
     }
 
@@ -677,6 +697,112 @@ class ImportIdeaReviewIT : WithUser() {
 
     // ---- routing — mirrors IdeaHandler --------------------------------------------
 
+    // ---- build-time variants (MCO-463) -------------------------------------------
+
+    @Test
+    fun `a design with two ways of building it offers the choice on the review`() = testApplication {
+        setupRoutes()
+
+        val response = client.get("/ideas/$cobbleIdeaId/import/review?worldId=$worldId") { addAuthCookie(this) }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val body = response.bodyAsText()
+        assertContains(body, "This design can be built more than one way")
+        assertContains(body, "1 module")
+        assertContains(body, "4 modules")
+    }
+
+    @Test
+    fun `the default is the author's first variant, not the largest build`() = testApplication {
+        setupRoutes()
+
+        val body = client.get("/ideas/$cobbleIdeaId/import/review?worldId=$worldId") { addAuthCookie(this) }
+            .bodyAsText()
+
+        // `position` is the author's ordering and explicitly not a ranking; defaulting to the
+        // biggest producer would quietly commit someone to the 4-module build's 4x bill.
+        assertContains(body, "minecraft:cobblestone=400")
+        assertFalse(body.contains("minecraft:cobblestone=1600"), "the 4-module list is not the default")
+        assertFalse(body.contains("minecraft:hopper=256"), "nor are its hoppers")
+    }
+
+    @Test
+    fun `choosing the other variant changes the material list`() = testApplication {
+        setupRoutes()
+
+        val body = client.get("/ideas/$cobbleIdeaId/import/review?worldId=$worldId&buildTimeMode=4+modules") {
+            addAuthCookie(this)
+        }.bodyAsText()
+
+        assertContains(body, "minecraft:cobblestone=1600")
+        assertContains(body, "minecraft:hopper=256")
+        assertFalse(body.contains("minecraft:cobblestone=400"), "the single-module list is gone")
+    }
+
+    @Test
+    fun `the chosen variant rides the form so the POST imports what was on screen`() = testApplication {
+        setupRoutes()
+
+        val body = client.get("/ideas/$cobbleIdeaId/import/review?worldId=$worldId&buildTimeMode=4+modules") {
+            addAuthCookie(this)
+        }.bodyAsText()
+
+        assertContains(body, "name=\"buildTimeMode\"")
+        assertContains(body, "value=\"4 modules\"")
+    }
+
+    @Test
+    fun `importing a variant records its materials and its rate, not a sibling's`() = testApplication {
+        setupRoutes()
+
+        val response = client.post("/ideas/$cobbleIdeaId/import") {
+            addAuthCookie(this)
+            contentType(ContentType.Application.FormUrlEncoded)
+            setBody(
+                "worldId=$worldId&name=Cobble&buildTimeMode=4+modules&" + materials(
+                    "minecraft:cobblestone" to 1600,
+                    "minecraft:hopper" to 256,
+                )
+            )
+        }
+
+        assertEquals(HttpStatusCode.SeeOther, response.status, response.bodyAsText())
+        val projectId = response.headers["Location"]!!.substringAfterLast("/").toInt()
+
+        assertEquals(
+            listOf("minecraft:cobblestone" to 1600, "minecraft:hopper" to 256),
+            readRequirements(projectId).sortedBy { it.first },
+        )
+        // The 4-module rate, because that is the build being made. Importing the single-module
+        // list with the 4-module throughput would be the exact drift MCO-463 exists to stop.
+        assertEquals(listOf("minecraft:cobblestone" to 924_000), readProductions(projectId))
+    }
+
+    @Test
+    fun `a design with one material list offers no choice at all`() = testApplication {
+        setupRoutes()
+
+        val body = client.get("/ideas/$ideaId/import/review?worldId=$worldId") { addAuthCookie(this) }
+            .bodyAsText()
+
+        // Every idea in the bank before MCO-463, and most after it. The screen must look exactly
+        // as it did.
+        assertFalse(body.contains("This design can be built more than one way"))
+        assertFalse(body.contains("name=\"buildTimeMode\""))
+    }
+
+    @Test
+    fun `a variant name that no longer exists falls back rather than importing nothing`() = testApplication {
+        setupRoutes()
+
+        val body = client.get("/ideas/$cobbleIdeaId/import/review?worldId=$worldId&buildTimeMode=8+modules") {
+            addAuthCookie(this)
+        }.bodyAsText()
+
+        // What a stale review URL looks like after the author renamed a variant.
+        assertEquals(true, body.contains("minecraft:cobblestone=400"), "falls back to the author's first")
+    }
+
     private fun ApplicationTestBuilder.setupRoutes() {
         routing {
             install(AuthPlugin)
@@ -846,6 +972,53 @@ class ImportIdeaReviewIT : WithUser() {
                 if (rate == null) stmt.setNull(3, java.sql.Types.INTEGER) else stmt.setInt(3, rate)
             }
         ).process(rates)
+    }
+
+    /**
+     * A build-time variant: its own rates *and* its own material list (MCO-463, V2_61_0).
+     *
+     * The requirement rows carry `mode_id`, which is what makes them this variant's list rather
+     * than the idea's base one. An idea with variants has no base rows at all.
+     */
+    private fun addBuildTimeMode(
+        ideaId: Int,
+        name: String,
+        rates: List<Pair<String, Int?>>,
+        requirements: List<Pair<String, Int>>,
+    ) = runBlocking {
+        val modeId = DatabaseSteps.update<Unit>(
+            SafeSQL.insert(
+                "INSERT INTO idea_production_modes (idea_id, name, position, kind) " +
+                    "VALUES (?, ?, (SELECT COALESCE(MAX(position) + 1, 0) FROM idea_production_modes WHERE idea_id = ?), 'BUILD_TIME') " +
+                    "RETURNING id"
+            ),
+            parameterSetter = { stmt, _ ->
+                stmt.setInt(1, ideaId)
+                stmt.setString(2, name)
+                stmt.setInt(3, ideaId)
+            }
+        ).process(Unit).let { (it as Result.Success).value }
+
+        DatabaseSteps.batchUpdate<Pair<String, Int?>>(
+            SafeSQL.insert("INSERT INTO idea_production_rates (mode_id, item_id, rate_per_hour) VALUES (?, ?, ?)"),
+            parameterSetter = { stmt, (itemId, rate) ->
+                stmt.setInt(1, modeId)
+                stmt.setString(2, itemId)
+                if (rate == null) stmt.setNull(3, java.sql.Types.INTEGER) else stmt.setInt(3, rate)
+            }
+        ).process(rates)
+
+        DatabaseSteps.batchUpdate<Pair<String, Int>>(
+            SafeSQL.insert(
+                "INSERT INTO idea_item_requirements (idea_id, item_id, quantity, mode_id) VALUES (?, ?, ?, ?)"
+            ),
+            parameterSetter = { stmt, (itemId, quantity) ->
+                stmt.setInt(1, ideaId)
+                stmt.setString(2, itemId)
+                stmt.setInt(3, quantity)
+                stmt.setInt(4, modeId)
+            }
+        ).process(requirements)
     }
 
     private fun readProductions(projectId: Int): List<Pair<String, Int>> = runBlocking {

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/IdeaMaterialListVariantsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/IdeaMaterialListVariantsTest.kt
@@ -1,0 +1,100 @@
+package app.mcorg.presentation.templated.idea
+
+import app.mcorg.domain.model.idea.IdeaModeKind
+import app.mcorg.domain.model.idea.IdeaProductionMode
+import app.mcorg.pipeline.idea.single.IdeaMaterial
+import kotlinx.html.div
+import kotlinx.html.stream.createHTML
+import org.junit.jupiter.api.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * MCO-463 — a design whose materials live on its build-time variants still shows them.
+ *
+ * Found in a browser, not here: the first design ever saved with a variant rendered with **no
+ * materials section at all**. Its fifteen materials were real and stored, but they hang off the
+ * variant (`mode_id`), and the page's query had just been narrowed to the base list — correctly, or
+ * a four-variant farm would read as the sum of all four.
+ */
+class IdeaMaterialListVariantsTest {
+
+    private fun render(materials: List<IdeaMaterial>, modes: List<IdeaProductionMode>) =
+        createHTML().div { ideaMaterialList(materials, modes) }
+
+    private fun variant(name: String, position: Int, requirements: Map<String, Int>) = IdeaProductionMode(
+        id = position + 1,
+        name = name,
+        position = position,
+        rates = emptyMap(),
+        kind = IdeaModeKind.BUILD_TIME,
+        requirements = requirements,
+    )
+
+    private val cobbleVariants = listOf(
+        variant("1 module", 0, mapOf("minecraft:cobblestone" to 400)),
+        variant("4 modules", 1, mapOf("minecraft:cobblestone" to 1_600, "minecraft:hopper" to 256)),
+    )
+
+    @Test
+    fun `a design with one list renders exactly as it always did`() {
+        val html = render(listOf(IdeaMaterial("minecraft:cobblestone", "Cobblestone", 400)), emptyList())
+
+        assertContains(html, "Materials")
+        assertContains(html, "Cobblestone")
+        assertFalse(html.contains("idea-materials__variant"), "no variant chrome for a plain design")
+    }
+
+    @Test
+    fun `a design whose materials live on its variants still shows them`() {
+        val html = render(emptyList(), cobbleVariants)
+
+        assertContains(html, "Materials")
+        assertContains(html, "1 module")
+        assertContains(html, "4 modules")
+        assertContains(html, "minecraft:cobblestone".let { "Cobblestone" })
+    }
+
+    @Test
+    fun `each variant carries its own total, which is the comparison worth showing`() {
+        val html = render(emptyList(), cobbleVariants)
+
+        // 400 against 1,856 (1,600 cobblestone + 256 hoppers) — the reason the variants exist.
+        assertContains(html, "1 item, 400 total")
+        assertContains(html, "2 items, 1${DIGIT_GROUP_SEPARATOR}856 total")
+    }
+
+    @Test
+    fun `one variant is not described as a choice`() {
+        // Caught in a browser: this read "This design can be built 1 ways" — ungrammatical, and
+        // claiming a choice that does not exist.
+        val html = render(emptyList(), listOf(cobbleVariants.first()))
+
+        assertContains(html, "1 module")
+        assertFalse(html.contains("1 ways"), "one variant is not a choice between ways")
+    }
+
+    @Test
+    fun `a runtime mode contributes no material list`() {
+        // Only a build-time mode changes what the build costs; a runtime one never owns materials.
+        val runtime = listOf(IdeaProductionMode(1, "Max speed", 0, mapOf("minecraft:ice" to 71_000)))
+
+        assertFalse(render(emptyList(), runtime).contains("Materials"))
+    }
+
+    @Test
+    fun `a design with nothing at all renders nothing`() {
+        assertFalse(render(emptyList(), emptyList()).contains("Materials"))
+    }
+
+    @Test
+    fun `the base list wins when both somehow exist`() {
+        // Should not arise — the write paths make them alternatives — but showing both would double
+        // every quantity, which is the worst of the possible readings.
+        val html = render(listOf(IdeaMaterial("minecraft:stone", "Stone", 12)), cobbleVariants)
+
+        assertContains(html, "Stone")
+        assertFalse(html.contains("4 modules"), "the base list is the whole answer when present")
+    }
+}

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFieldsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFieldsTest.kt
@@ -171,6 +171,18 @@ class DraftProductionFieldsTest {
     }
 
     @Test
+    fun `the variant's file input is named, or nothing is uploaded at all`() {
+        // Found in a browser, not here: the input first shipped with no `name`, and a form control
+        // without one is never submitted — so HTMX posted an empty multipart and the endpoint
+        // answered 422. A render test asserting only the hx-post URL passed the whole time.
+        val html = markup(fourVariants)
+        val uploads = Regex("""<input type="file"[^>]*>""").findAll(html).toList()
+
+        assertEquals(2, uploads.size, "one upload per build-time variant")
+        uploads.forEach { assertContains(it.value, "name=\"litematicFile\"") }
+    }
+
+    @Test
     fun `each variant's materials are submitted under its own index`() {
         val html = markup(fourVariants)
 

--- a/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFieldsTest.kt
+++ b/webapp/mc-web/src/test/kotlin/app/mcorg/presentation/templated/idea/createwizard/DraftProductionFieldsTest.kt
@@ -137,11 +137,91 @@ class DraftProductionFieldsTest {
     fun `a new mode is cloned from a server-rendered template, not built in JS`() {
         // The template carries a real combo — same hx-vals, same version range — so a mode added
         // client-side searches exactly like the ones rendered with the page.
+        //
+        // One template per kind since MCO-463: the build-time block brings a whole materials upload
+        // with its own hx-* attributes, so the two differ by more than a flag.
         val html = render("""{"productionModes":[{"name":"","rates":{}}]}""")
 
-        assertContains(html, "id=\"production-mode-template\"")
+        assertContains(html, "id=\"production-mode-template-RUNTIME\"")
+        assertContains(html, "id=\"production-mode-template-BUILD_TIME\"")
         assertContains(html, "__MODE_INDEX__")
         assertContains(html, "htmx.process(block)")
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // MCO-463 — the build-time variant block.
+
+    private val fourVariants = """{"productionModes":[
+        {"name":"1 module","kind":"BUILD_TIME","rates":{"minecraft:cobblestone":231000},
+         "requirements":{"minecraft:cobblestone":400}},
+        {"name":"4 modules","kind":"BUILD_TIME","rates":{"minecraft:cobblestone":924000},
+         "requirements":{"minecraft:cobblestone":1600,"minecraft:hopper":256}}
+    ]}"""
+
+    @Test
+    fun `a build-time variant gets its own litematic upload, scoped to that mode`() {
+        // Per mode rather than one batch at submit: each request stays inside the whole-upload file
+        // and byte budget instead of multiplying it by the variant count.
+        val html = markup(fourVariants)
+
+        assertContains(html, "/ideas/create/litematic?mode=0")
+        assertContains(html, "/ideas/create/litematic?mode=1")
+        assertContains(html, "#mode-materials-0")
+        assertContains(html, "#mode-materials-1")
+    }
+
+    @Test
+    fun `each variant's materials are submitted under its own index`() {
+        val html = markup(fourVariants)
+
+        assertContains(html, "modeRequirements[0][minecraft:cobblestone]")
+        assertContains(html, "modeRequirements[1][minecraft:cobblestone]")
+        assertContains(html, "modeRequirements[1][minecraft:hopper]")
+    }
+
+    @Test
+    fun `the kind is carried explicitly rather than inferred from having a list`() {
+        // A variant whose .litematic has not been dropped yet is still build-time; inferring from
+        // the list would silently demote it on save.
+        val html = markup("""{"productionModes":[{"name":"4 modules","kind":"BUILD_TIME","rates":{}}]}""")
+
+        assertContains(html, "name=\"productionMode[0][kind]\" value=\"BUILD_TIME\"")
+    }
+
+    @Test
+    fun `both variants stay on screen so their costs can be compared`() {
+        // The reason these are stacked rather than tabbed: 400 against 1,600 is the check that
+        // catches dropping the same file into two variants when four downloads look alike.
+        val html = markup(fourVariants)
+
+        assertContains(html, "1,600 cobblestone")
+        assertContains(html, "400 cobblestone")
+    }
+
+    @Test
+    fun `a variant with no materials yet says so rather than showing an empty disclosure`() {
+        val html = markup("""{"productionModes":[{"name":"4 modules","kind":"BUILD_TIME","rates":{}}]}""")
+
+        assertContains(html, "No materials yet")
+    }
+
+    @Test
+    fun `a runtime mode gets no materials upload and no kind badge`() {
+        // Runtime is the unmarked default — labelling it would put mode vocabulary in front of the
+        // single-mode author that MCO-204 removed the form's nesting to protect.
+        val html = markup("""{"productionModes":[{"name":"","rates":{"minecraft:ice":71000}}]}""")
+
+        assertFalse(html.contains("modeRequirements["), "a runtime mode owns no material list")
+        assertFalse(html.contains("production-mode__kind"), "runtime is the unmarked default")
+        assertFalse(html.contains("litematic?mode="), "only a build-time variant uploads its own")
+    }
+
+    @Test
+    fun `both ways of adding a mode are offered`() {
+        val html = markup("""{"productionModes":[{"name":"","rates":{"minecraft:ice":71000}}]}""")
+
+        assertContains(html, "This farm can be run another way")
+        assertContains(html, "\u2026or built another way")
     }
 
     @Test


### PR DESCRIPTION
Closes MCO-463, the build-time half of the MCO-413 split.

## The case

MCO-412 modelled the half of a production mode that varies with how you *run* a farm — its rates. MCO-439 finding 1 found the other half while sourcing by hand: a cobblestone farm published as *single module / 4 modules* × *with / without storage*, where all four are chosen when you **build** it, and 924k/h ÷ 231k/h = 4.0 exactly — the rate spread *is* the module count.

The discriminator is not switchability but **what the mode changes**:

| | changes | had a home |
|---|---|---|
| runtime mode | what the farm supplies | ✅ `idea_production_rates`, per mode |
| build-time mode | what it supplies **and what it costs to build** | ❌ `idea_item_requirements`, one flat list per idea |

So those four variants were entered against one shared material list, and three of the four are wrong in the bank right now.

## What changed

**Schema (`V2_61_0`).** `idea_production_modes.kind` (default `RUNTIME` — the honest backfill, since every existing mode was answered under a form that only described ways of *running* a farm). `idea_item_requirements.mode_id`, nullable: NULL is the idea's base list, non-null is a variant's own list, **replacing** the base rather than adding to it. Whole lists rather than deltas — a variant arrives as its own `.litematic`, so a complete list is what the front door already produces. The PK can't hold a nullable member, so it becomes two partial unique indexes saying the same thing per list.

**A latent bug the column exposed.** Three readers did `WHERE idea_id = ?` with no mode filter — the detail page, the import, and the revert-to-draft aggregate. Left alone, a four-variant farm would have read as the *sum* of all four.

**Capture.** A second button beside the existing one — "…or built another way" — and the block it adds carries its own `.litematic` upload. Stacked blocks, uploads per mode:

- `MAX_FILES` (12) and `MAX_SCHEMATIC_UPLOAD_BYTES` are budgets for the whole *upload*, not per file. Four variants × three dimensions is already at the cap sharing one budget, and MCO-421 is open on exactly that. Per-mode also means one unparseable file costs that variant, not the design.
- Variants exist *because they cost different amounts*, so they have to be readable against each other. Tabs would hide the comparison that catches the likely mistake here — dropping the same file into two variants when four downloads have near-identical names.

**Import.** The review screen picks the variant, because that choice decides what the project costs. Links rather than radios: everything on that page derives from the chosen variant (list, MCO-305 warnings, totals, creative-only strip), and re-running the GET re-derives all of it together — a radio swapping the table alone would leave the warnings describing a different build, which is the same two-answers-to-one-question shape MCO-458/460/461 all were.

Default is the author's **first** variant, not the fastest or largest: `position` is ordering, not ranking, and defaulting to the biggest producer would quietly commit someone to the 4× bill. (Confirmed by Even — usually the smallest, revisitable later.)

`ratesForImport` now takes the chosen variant's rates **even when it has none**. A variant nobody timed honestly produces an unmeasured amount; borrowing a sibling's rate would attribute one variant's throughput to another, which is the drift this issue exists to stop.

## Three defects the browser caught that the tests did not

All three phases had green unit *and* database tests. Driving the flow found:

1. **The per-variant upload uploaded nothing** — the file input had no `name`, so HTMX posted an empty multipart and the endpoint answered 422. The render test asserted the `hx-post` URL and passed throughout. The regression test for it was checked against the broken version before being kept.
2. **A design's materials vanished from its own detail page** — the base-list filter is correct, but a design *with* variants has no base list, so 15 stored materials rendered as none. Now one list per variant, each with its own total.
3. **"This design can be built 1 ways."**

## Verification

Driven end to end against the worktree's Neon branch. A design saved through the real form stores `kind=BUILD_TIME` with all 15 requirement rows carrying `mode_id` and **no base rows** — the replace-the-base rule holding end to end — the empty runtime mode correctly not surviving, the live summary matching the stored rows, and the review chooser moving redstone from 3,172 to 12,688, exactly 4×. No exceptions or 5xx. Screenshots at 375 and 1440 both read correctly.

**Tests:** unit 1068, database 544, both green. 39 new tests, including 7 ITs driving the real review GET and import POST.

## Notes for review

- **No `preview` label**: reviewed locally instead, on purpose.
- **Design review deferred.** The wording and layout are deliberate-but-unpolished; Even's call is to make it work technically now and redesign later.
- **MCO-463's last acceptance criterion is data entry**, not code — re-entering the real cobblestone farm with its four variants.
- **Unblocks MCO-413** (runtime modes to the project), then MCO-452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xrht7Yb6WPeBvFxvckeBWV
